### PR TITLE
not sort attributes on rx path

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -3847,9 +3847,8 @@ async fn handle_bgp_session(
                             delay
                                 .reset(Instant::now() + Duration::from_secs(keepalive_interval as u64));
                         }
-                        bgp::Message::Update(mut update) => {
+                        bgp::Message::Update(update) => {
                             if !update.attrs.is_empty() {
-                                update.attrs.sort_by_key(|a| a.attr());
                                 let pa = Arc::new(PathAttr {
                                     entry: update.attrs,
                                 });


### PR DESCRIPTION
we sort attributes on tx path.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>