### PR TITLE
replace failure crate with std

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.3.2"
-failure = "0.1.6"

--- a/proto/src/bmp.rs
+++ b/proto/src/bmp.rs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::error::Error;
 use byteorder::{NetworkEndian, WriteBytesExt};
-use failure::Error;
 use std::convert::From;
 use std::io::{Cursor, Write};
 use std::net::{IpAddr, Ipv4Addr};

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 The RustyBGP Authors.
+// Copyright (C) 2020 The RustyBGP Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod bgp;
-pub mod bmp;
-pub mod error;
-pub mod rtr;
+use std::io;
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidFormat,
+    Std(io::Error),
+}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Error::Std(error)
+    }
+}

--- a/proto/src/rtr.rs
+++ b/proto/src/rtr.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 use super::bgp::IpNet;
+use super::error::Error;
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
-use failure::Error;
 use std::io::Cursor;
 use std::net::IpAddr;
 
@@ -96,7 +96,7 @@ impl Message {
 		let length = c.read_u32::<NetworkEndian>()? as usize;
 
 		if length > buflen {
-			return Err(format_err!("buffer is too short"));
+			return Err(Error::InvalidFormat);
 		}
 
 		match message_type {
@@ -162,7 +162,7 @@ impl Message {
 			}
 			Message::CACHE_RESET => Ok((Message::CacheReset, length)),
 			Message::ERROR_REPORT => Ok((Message::ErrorReport, length)),
-			_ => Err(format_err!("unknown type {}", message_type)),
+			_ => Err(Error::InvalidFormat),
 		}
 	}
 }


### PR DESCRIPTION
The future of failure crate is unclear. The development is sorta
frozen. Let's stick with stdlib.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>