### PR TITLE
added yaml config file format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The mission is to develop a high-performance and safe BGP implementation; an exp
 
 ![](.github/assets/htop.gif)
 
-RustyBGP supports the gRPC APIs same as GoBGP; your code to manage GoBGP via the APIs should work with RustyBGP. If you need CLI, [GoBGP CLI tool](https://github.com/osrg/gobgp/releases/tag/v3.0.0) allows you to manage RustyBGP. RustyBGP also supports the same configuration file format as GoBGP (only toml for now).
+RustyBGP supports the gRPC APIs same as GoBGP; your code to manage GoBGP via the APIs should work with RustyBGP. If you need CLI, [GoBGP CLI tool](https://github.com/osrg/gobgp/releases/tag/v3.0.0) allows you to manage RustyBGP. RustyBGP also supports the same configuration file format as GoBGP (only toml and yaml for now).
 
 ## Get Started
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -31,6 +31,7 @@ once_cell = "1"
 thiserror = "1"
 libc = "0.2.94"
 serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"
 toml = "0.5.7"
 nix = "0.22"
 uuid = { version = "0.8", features = ["v4"] }

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -18,3 +18,17 @@ pub(crate) mod gen;
 pub(crate) use self::gen::*;
 pub(crate) mod validate;
 pub(crate) use self::validate::*;
+
+use std::error::Error;
+use std::ffi::OsStr;
+use std::path::Path;
+
+pub(crate) fn read_from_file<P: AsRef<Path>>(fname: P) -> Result<BgpConfig, Box<dyn Error>> {
+    let contents = std::fs::read_to_string(fname.as_ref())?;
+    let conf: BgpConfig = match fname.as_ref().extension().and_then(OsStr::to_str) {
+        Some("yaml") | Some("yml") => serde_yaml::from_str(&contents)?,
+        _ => toml::from_str(&contents)?,
+    };
+    conf.validate()?;
+    Ok(conf)
+}

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -64,10 +64,7 @@ fn main() -> Result<(), std::io::Error> {
         .get_matches();
 
     let conf = if let Some(conf) = args.value_of("config") {
-        let conf: config::BgpConfig = toml::from_str(&(std::fs::read_to_string(conf)?))?;
-        if let Err(e) = conf.validate() {
-            panic!("invalid configuraiton {:?}", e);
-        }
+        let conf: config::BgpConfig = config::read_from_file(conf).expect("invalid configuration");
         Some(conf)
     } else {
         let as_number = if let Some(asn) = args.value_of("asn") {


### PR DESCRIPTION
Not 100% interchangeable with gobgp: go's yaml parser is more permissive, rust's is more strict. For example, go allows `as-path: "64321"` where rust requires it to be a number: `as-path: 654321`.