### PR TITLE
replace yanked treebitmap crate

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -35,7 +35,7 @@ serde_yaml = "0.8"
 toml = "0.5.7"
 nix = "0.22"
 uuid = { version = "0.8", features = ["v4"] }
-treebitmap = "0.4"
+ip_network_table-deps-treebitmap = "0.5.0"
 
 [build-dependencies]
 tonic-build = "0.5.2"

--- a/daemon/src/table.rs
+++ b/daemon/src/table.rs
@@ -15,6 +15,7 @@
 
 use crate::proto::ToApi;
 use fnv::FnvHashMap;
+use ip_network_table_deps_treebitmap::IpLookupTable;
 use once_cell::sync::Lazy;
 use patricia_tree::PatriciaMap;
 use regex::Regex;
@@ -27,7 +28,6 @@ use std::ops::AddAssign;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::SystemTime;
-use treebitmap::IpLookupTable;
 
 use crate::api;
 use crate::error::Error;


### PR DESCRIPTION
The original treebitmap crate was yanked:

https://crates.io/crates/treebitmap

use the forked one:

https://crates.io/crates/ip_network_table-deps-treebitmap

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>