### PR TITLE
Fix go.mod directory in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     open-pull-requests-limit: 50
 
   - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directory: "/tests/integration/functional" # Location of package manifests
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50


### PR DESCRIPTION
Looks like Dependabot had trouble finding the go.mod file and I needed to specify the location in dependabot.yml.

This results in a few pull requests for go modules too. 