### PR TITLE
update CI workflows to use Ubuntu 22.04 instead of Ubuntu 18.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ on: [pull_request]
 jobs:
   build:
     name: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checking out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: setup
         run: |
           rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Upload container image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Upload
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master
       - name: setup


### PR DESCRIPTION
The Ubuntu 18.04 GitHub Actions runner image has been deprecated on 2022-08-08 and will be removed on 2023-04-01. For more information see <https://github.com/actions/runner-images/issues/6002>.

Therefore, this pull request switches to the newer runner image.