### PR TITLE
fix add_path_stream API

### DIFF
--- a/daemon/build.rs
+++ b/daemon/build.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .output()
         .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    println!("cargo:rustc-env=GIT_HASH={git_hash}");
     tonic_build::configure().build_server(true).compile(
         &[
             "../api/gobgp.proto",

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -1210,9 +1210,10 @@ impl GobgpApi for GrpcService {
         let mut stream = request.into_inner();
         while let Some(Ok(request)) = stream.next().await {
             for path in request.paths {
-                let u = self.local_path(path)?;
-                let chan = TABLE[u.0].lock().await.table_event_tx[0].clone();
-                let _ = chan.send(u.1);
+                if let Ok(u) = self.local_path(path) {
+                    let chan = TABLE[u.0].lock().await.table_event_tx[0].clone();
+                    let _ = chan.send(u.1);
+                }
             }
         }
         Ok(tonic::Response::new(()))

--- a/daemon/src/packet/bgp.rs
+++ b/daemon/src/packet/bgp.rs
@@ -496,7 +496,7 @@ impl From<&Capability> for prost_types::Any {
                             |(family, flags, time)| api::LongLivedGracefulRestartCapabilityTuple {
                                 family: Some((*family).into()),
                                 flags: *flags as u32,
-                                time: *time as u32,
+                                time: *time,
                             },
                         )
                         .collect(),
@@ -545,7 +545,7 @@ impl Capability {
             }
             Capability::GracefulRestart(flags, time, v) => {
                 c.put_u8(v.len() as u8 + 2);
-                c.put_u16((*flags as u16) << 12 | *time as u16);
+                c.put_u16((*flags as u16) << 12 | *time);
                 for (family, af_flags) in v {
                     c.put_u16(family.afi());
                     c.put_u8(family.safi());
@@ -1133,7 +1133,7 @@ impl From<&Attribute> for prost_types::Any {
                         Ipv4Addr::from(c.read_u32::<NetworkEndian>().unwrap()),
                     ),
                     8 => (
-                        c.read_u32::<NetworkEndian>().unwrap() as u32,
+                        c.read_u32::<NetworkEndian>().unwrap(),
                         Ipv4Addr::from(c.read_u32::<NetworkEndian>().unwrap()),
                     ),
                     _ => unreachable!("corrupted"),
@@ -1326,7 +1326,7 @@ impl AttrDesc {
         Ok(Attribute {
             code: self.code,
             flags: self.flags,
-            data: AttributeData::Val(c.read_u32::<NetworkEndian>().unwrap() as u32),
+            data: AttributeData::Val(c.read_u32::<NetworkEndian>().unwrap()),
         })
     }
 
@@ -1747,7 +1747,7 @@ impl Codec {
             .write_u16::<NetworkEndian>(mp_len - 4)
             .unwrap();
 
-        Ok(mp_len as u16)
+        Ok(mp_len)
     }
 
     fn mp_unreach_encode(
@@ -1786,7 +1786,7 @@ impl Codec {
         (&mut dst.as_mut()[pos_bin..])
             .write_u16::<NetworkEndian>(mp_len - 4)
             .unwrap();
-        Ok(mp_len as u16)
+        Ok(mp_len)
     }
 
     fn do_encode(
@@ -1833,7 +1833,7 @@ impl Codec {
                 }
 
                 (&mut dst.as_mut()[param_len_pos..])
-                    .write_u8(cap_len as u8)
+                    .write_u8(cap_len)
                     .unwrap();
                 (&mut dst.as_mut()[op_param_len_pos..])
                     .write_u8(cap_len + 2_u8)


### PR DESCRIPTION
add_path_stream() returns an error when it can't parse a path. Fixed it to ignore such path.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>