### PR TITLE
Draft: Trying to implement bgp-actions.set_next_hop

### DIFF
--- a/daemon/src/config/validate.rs
+++ b/daemon/src/config/validate.rs
@@ -379,7 +379,32 @@ impl TryFrom<&Statement> for api::Statement {
             med: None,
             as_prepend: None,
             ext_community: None,
-            nexthop: None,
+            nexthop: match a.bgp_actions.as_ref() {
+                Some(a) => {
+                    if let Some(s) = a.set_next_hop.as_ref() {
+                        match s.as_str() {
+                            "self" => Some(api::NexthopAction {
+                                self_: true,
+                                unchanged: false,
+                                address: String::new(),
+                            }),
+                            "unchanged" => Some(api::NexthopAction {
+                                self_: false,
+                                unchanged: true,
+                                address: String::new(),
+                            }),
+                            _ => Some(api::NexthopAction {
+                                self_: false,
+                                unchanged: false,
+                                address: s.to_string(),
+                            }),
+                        }
+                    } else {
+                        None
+                    }
+                }
+                None => None,
+            },
             local_pref: None,
             large_community: None,
         });

--- a/daemon/src/packet/bgp.rs
+++ b/daemon/src/packet/bgp.rs
@@ -23,7 +23,6 @@ use std::convert::{Into, TryFrom};
 use std::io::Cursor;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
-use std::sync::Arc;
 use std::{fmt, io};
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -1475,7 +1474,7 @@ pub(crate) enum Message {
     Update {
         reach: Option<(Family, Vec<(Net, u32)>)>,
         unreach: Option<(Family, Vec<(Net, u32)>)>,
-        attr: Arc<Vec<Attribute>>,
+        attr: Vec<Attribute>,
     },
     Notification {
         code: u8,
@@ -1504,13 +1503,13 @@ impl Message {
         if family == Family::IPV4 {
             Message::Update {
                 reach: Some((Family::IPV4, Vec::new())),
-                attr: Arc::new(Vec::new()),
+                attr: Vec::new(),
                 unreach: None,
             }
         } else {
             Message::Update {
                 reach: None,
-                attr: Arc::new(Vec::new()),
+                attr: Vec::new(),
                 unreach: Some((family, Vec::new())),
             }
         }
@@ -1685,7 +1684,7 @@ impl Codec {
     fn mp_reach_encode(
         &self,
         buf_head: usize,
-        attrs: Arc<Vec<Attribute>>,
+        attrs: Vec<Attribute>,
         dst: &mut BytesMut,
         reach: &(Family, Vec<(Net, u32)>),
         reach_idx: &mut usize,
@@ -1753,7 +1752,7 @@ impl Codec {
     fn mp_unreach_encode(
         &self,
         buf_head: usize,
-        _: Arc<Vec<Attribute>>,
+        _: Vec<Attribute>,
         dst: &mut BytesMut,
         unreach: &(Family, Vec<(Net, u32)>),
         unreach_idx: &mut usize,
@@ -2263,7 +2262,7 @@ impl Decoder for Codec {
                     return Ok(Some(Message::Update {
                         reach: Some((Family::IPV4, Vec::new())),
                         unreach: None,
-                        attr: Arc::new(Vec::new()),
+                        attr: Vec::new(),
                     }));
                 }
 
@@ -2424,7 +2423,7 @@ impl Decoder for Codec {
                     } else {
                         Some((reach_family, reach))
                     },
-                    attr: Arc::new(attr),
+                    attr: attr,
                     unreach: if unreach.is_empty() {
                         None
                     } else {
@@ -2552,11 +2551,11 @@ fn build_many_v4_route() {
     let reach: Vec<(Net, u32)> = net.iter().cloned().map(|n| (n, 0)).collect();
     let mut msg = Message::Update {
         reach: Some((Family::IPV4, reach)),
-        attr: Arc::new(vec![
+        attr: vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
             Attribute::new_with_bin(Attribute::AS_PATH, vec![2, 1, 1, 0, 0, 0]).unwrap(),
             Attribute::new_with_bin(Attribute::NEXTHOP, vec![0, 0, 0, 0]).unwrap(),
-        ]),
+        ],
         unreach: None,
     };
     let mut set = fnv::FnvHashSet::default();
@@ -2596,7 +2595,7 @@ fn build_many_v4_route() {
     let unreach = net.iter().cloned().map(|n| (n, 0)).collect();
     msg = Message::Update {
         reach: None,
-        attr: Arc::new(Vec::new()),
+        attr: Vec::new(),
         unreach: Some((Family::IPV4, unreach)),
     };
 
@@ -2647,11 +2646,11 @@ fn many_mp_reach() {
 
     let msg = Message::Update {
         reach: Some((Family::IPV6, reach)),
-        attr: Arc::new(vec![
+        attr: vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
             Attribute::new_with_bin(Attribute::AS_PATH, vec![2, 1, 1, 0, 0, 0]).unwrap(),
             Attribute::new_with_bin(Attribute::NEXTHOP, (0..31).collect::<Vec<u8>>()).unwrap(),
-        ]),
+        ],
         unreach: None,
     };
 
@@ -2701,7 +2700,7 @@ fn many_mp_unreach() {
 
     let msg = Message::Update {
         reach: None,
-        attr: Arc::new(Vec::new()),
+        attr: Vec::new(),
         unreach: Some((Family::IPV6, unreach)),
     };
 


### PR DESCRIPTION
*This is more like a request for comment then PR.*

Greetings, thanks for the great works on this project. I am trying to use this project to ingest mrt dumps and modify next hop information. Being a beginner in both rust and bgp, this is quite a challenge for me, so please bear with my ignorance and correct me if wrong.

I have noticed that the current way of storing route attributes with `Arc<Vec<_>>` does not provide ability to modify them when applying policies like set_next_hop. At first I tried to use `RwLock` inside `Arc` to provide mutability of the attributes. But that didn't go well with 4 times longer full table mrt injection time than stock.

The second way, being this patch, tried to remove the `Arc` on attibutes all along, since `TABLE`s have their own global mutex lock. Could you please help me understand why attributes are being `Arc`ed instead of being copied around? My guess is to save memory when having multiple `TABLE`s.

Would please take a look at this PR and give me some direction in implementing this ability? Thank you.

p.s. I only modified the minimum possible code to make this action work.