### PR TITLE
Update futures and futures-core

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -18,8 +18,8 @@ tokio = { version = "=1.27", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec","time"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 clap = "2.33"
-futures = "=0.3.16"
-futures-core = "=0.3.16"
+futures = "0.3.31"
+futures-core = "0.3.31"
 patricia_tree = "0.3"
 regex = "1"
 hostname = "0.3"


### PR DESCRIPTION
It was locked by https://github.com/osrg/rustybgp/commit/29d09b5b93ca1fdcf30c865aafeaff394361acbb

Since the commit does not state why, and that Rust is unsatisfied. I upgraded the lib and it builds.

```
    Updating crates.io index
error: failed to select a version for `futures-core`.
    ... required by package `futures-util v0.3.31`
    ... which satisfies dependency `futures-util = "^0.3.16"` of package `futures v0.3.16`
    ... which satisfies dependency `futures = "=0.3.16"` of package `rustybgpd v0.2.0 (/mnt/Dev/@williamdes/@forked-repos/rustybgp/daemon)`
versions that meet the requirements `^0.3.31` are: 0.3.31

all possible versions conflict with previously selected packages.

  previously selected package `futures-core v0.3.16`
    ... which satisfies dependency `futures-core = "=0.3.16"` of package `rustybgpd v0.2.0 (/mnt/Dev/@williamdes/@forked-repos/rustybgp/daemon)`

failed to select a version for `futures-core` which could resolve this conflict
```