### PR TITLE
packet: encode IPv6 link-local nexthop in MP_REACH_NLRI

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -35,5 +35,5 @@ socket2 = { version = "0.6", features = ["all"] }
 byteorder = "1"
 thiserror = "2"
 libc = "0.2"
-nix = { version = "0.31", features = ["socket"] }
+nix = { version = "0.31", features = ["socket", "net"] }
 uuid = { version = "1", features = ["v4"] }

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -24,7 +24,7 @@ use std::collections::HashSet;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::convert::{From, TryFrom};
 use std::hash::{Hash, Hasher};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::ops::Deref;
 use std::os::fd::AsFd;
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -3436,6 +3436,40 @@ pub(crate) async fn main(bgp: Option<config::BgpConfig>, any_peer: bool) {
     Global::serve(bgp, any_peer, active_tx, active_rx).await;
 }
 
+/// For an IPv6 socket, find the link-local address of the same interface.
+/// Returns `None` for IPv4 sockets or if no link-local address is found.
+/// For a directly-connected IPv6 peer, find the link-local address of the
+/// local interface. Only looks up link-local when scope_id is non-zero
+/// (indicating a directly-connected peer). Multihop peers have no
+/// reachable link-local, so they get `None`.
+fn find_link_local(local: &SocketAddr) -> Option<Ipv6Addr> {
+    let scope_id = match local {
+        SocketAddr::V6(v6) if v6.scope_id() != 0 => v6.scope_id(),
+        _ => return None,
+    };
+    // If local address is itself link-local, use it directly.
+    if let IpAddr::V6(v6) = local.ip()
+        && v6.is_unicast_link_local()
+    {
+        return Some(v6);
+    }
+    // Look up the interface's link-local address.
+    let name = nix::net::if_::if_indextoname(scope_id)
+        .ok()
+        .and_then(|c| c.into_string().ok())?;
+    nix::ifaddrs::getifaddrs().ok()?.find_map(|ifa| {
+        if ifa.interface_name != name {
+            return None;
+        }
+        let addr = ifa.address?.as_sockaddr_in6()?.ip();
+        if (addr.segments()[0] & 0xffc0) == 0xfe80 {
+            Some(addr)
+        } else {
+            None
+        }
+    })
+}
+
 fn peer_loop(
     mut h: Handler,
     mgmt_rx: mpsc::UnboundedReceiver<PeerMgmtMsg>,
@@ -3459,6 +3493,8 @@ fn peer_loop(
 struct Handler {
     remote_addr: IpAddr,
     local_addr: IpAddr,
+    /// IPv6 link-local address of the local interface (for 32-byte MP_REACH nexthop).
+    link_addr: Option<Ipv6Addr>,
 
     local_asn: u32,
 
@@ -3503,9 +3539,12 @@ impl Handler {
         prefix_limits: FnvHashMap<Family, u32>,
     ) -> Option<Self> {
         let local_sockaddr = stream.local_addr().ok()?;
+        let local_addr = local_sockaddr.ip();
+        let link_addr = find_link_local(&local_sockaddr);
         Some(Handler {
             remote_addr,
-            local_addr: local_sockaddr.ip(),
+            local_addr,
+            link_addr,
             local_router_id,
             local_asn,
             state,
@@ -4003,19 +4042,17 @@ impl Handler {
             txbuf_size = std::cmp::min(txbuf_size, r / 2);
         }
 
-        let mut framer = BgpFramer::new(if self.rs_client {
-            bgp::PeerCodecBuilder::new()
-                .local_asn(self.local_asn)
-                .local_addr(self.local_addr)
-                .keep_aspath(true)
-                .keep_nexthop(true)
-                .build()
-        } else {
-            bgp::PeerCodecBuilder::new()
-                .local_asn(self.local_asn)
-                .local_addr(self.local_addr)
-                .build()
-        });
+        let mut builder = bgp::PeerCodecBuilder::new();
+        builder
+            .local_asn(self.local_asn)
+            .local_addr(self.local_addr);
+        if let Some(ll) = self.link_addr {
+            builder.link_addr(ll);
+        }
+        if self.rs_client {
+            builder.keep_aspath(true).keep_nexthop(true);
+        }
+        let mut framer = BgpFramer::new(builder.build());
 
         let mut peer_event_rx = Vec::new();
         for _ in 0..*NUM_TABLES {

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -1267,6 +1267,7 @@ pub struct PeerCodecBuilder {
     local_asn: u32,
     remote_asn: u32,
     local_addr: IpAddr,
+    link_addr: Option<Ipv6Addr>,
     extended_length: bool,
     keep_aspath: bool,
     keep_nexthop: bool,
@@ -1285,6 +1286,7 @@ impl PeerCodecBuilder {
             local_asn: 0,
             remote_asn: 0,
             local_addr: IpAddr::V4(Ipv4Addr::from(0)),
+            link_addr: None,
             extended_length: false,
             keep_aspath: false,
             keep_nexthop: false,
@@ -1302,6 +1304,7 @@ impl PeerCodecBuilder {
             local_asn: self.local_asn,
             remote_asn: self.remote_asn,
             local_addr: self.local_addr,
+            link_addr: self.link_addr,
             extended_length: self.extended_length,
             keep_aspath: self.keep_aspath,
             keep_nexthop: self.keep_nexthop,
@@ -1316,6 +1319,11 @@ impl PeerCodecBuilder {
 
     pub fn local_addr(&mut self, local_addr: IpAddr) -> &mut Self {
         self.local_addr = local_addr;
+        self
+    }
+
+    pub fn link_addr(&mut self, addr: Ipv6Addr) -> &mut Self {
+        self.link_addr = Some(addr);
         self
     }
 
@@ -1340,6 +1348,7 @@ pub struct PeerCodec {
     local_asn: u32,
     remote_asn: u32,
     local_addr: IpAddr,
+    link_addr: Option<Ipv6Addr>,
     keep_aspath: bool,
     keep_nexthop: bool,
     pub channel: FnvHashMap<Family, Channel>,
@@ -1401,15 +1410,20 @@ impl PeerCodec {
             dst.put_slice(&padded);
         } else {
             match self.local_addr {
-                IpAddr::V6(addr) => {
-                    let addr = addr.octets();
-                    dst.put_u8(addr.len() as u8);
-                    dst.put_slice(&addr);
+                IpAddr::V6(global) => {
+                    if let Some(ll) = self.link_addr {
+                        // 32-byte nexthop: global + link-local (RFC 2545)
+                        dst.put_u8(32);
+                        dst.put_slice(&global.octets());
+                        dst.put_slice(&ll.octets());
+                    } else {
+                        dst.put_u8(16);
+                        dst.put_slice(&global.octets());
+                    }
                 }
                 IpAddr::V4(addr) => {
-                    let addr = addr.octets();
-                    dst.put_u8(addr.len() as u8);
-                    dst.put_slice(&addr);
+                    dst.put_u8(4);
+                    dst.put_slice(&addr.octets());
                 }
             };
         }


### PR DESCRIPTION
For directly-connected IPv6 peers, include the interface's link-local address in the 32-byte MP_REACH nexthop (RFC 2545) so that the receiving peer can use it as the forwarding gateway.