### PR TITLE
tests: speed up e2e CI with host cargo build and rust-cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
           sudo apt-get install -y protobuf-compiler
           rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
           rustup component add clippy
+      - name: cache
+        uses: Swatinem/rust-cache@v2
       - name: build
         run: |
           cargo clippy -- -D warnings

--- a/.github/workflows/e2e-rfc7911.yml
+++ b/.github/workflows/e2e-rfc7911.yml
@@ -9,9 +9,24 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: checking out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
+      - name: setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler musl-tools
+          rustup target add x86_64-unknown-linux-musl
+      - name: cache
+        uses: Swatinem/rust-cache@v2
+      - name: build rustybgpd
+        run: cargo build --release --target x86_64-unknown-linux-musl
+      - name: prepare prebuilt context
+        run: |
+          mkdir -p /tmp/rustybgp-prebuilt
+          cp target/x86_64-unknown-linux-musl/release/rustybgpd /tmp/rustybgp-prebuilt/
+          cp tests/e2e/shared/Dockerfile.rustybgp-prebuilt /tmp/rustybgp-prebuilt/Dockerfile
       - name: Run RFC 7911 e2e test
         working-directory: tests/e2e/rfc7911
         env:
-          RUST_TARGET: x86_64-unknown-linux-musl
+          RUSTYBGP_BUILD_CONTEXT: /tmp/rustybgp-prebuilt
+          RUSTYBGP_DOCKERFILE: Dockerfile
         run: ./run-test.sh

--- a/.github/workflows/e2e-rfc8950.yml
+++ b/.github/workflows/e2e-rfc8950.yml
@@ -10,8 +10,23 @@ jobs:
     steps:
       - name: checking out
         uses: actions/checkout@v6
+      - name: setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler musl-tools
+          rustup target add x86_64-unknown-linux-musl
+      - name: cache
+        uses: Swatinem/rust-cache@v2
+      - name: build rustybgpd
+        run: cargo build --release --target x86_64-unknown-linux-musl
+      - name: prepare prebuilt context
+        run: |
+          mkdir -p /tmp/rustybgp-prebuilt
+          cp target/x86_64-unknown-linux-musl/release/rustybgpd /tmp/rustybgp-prebuilt/
+          cp tests/e2e/shared/Dockerfile.rustybgp-prebuilt /tmp/rustybgp-prebuilt/Dockerfile
       - name: Run RFC 8950 e2e test
         working-directory: tests/e2e/rfc8950
         env:
-          RUST_TARGET: x86_64-unknown-linux-musl
+          RUSTYBGP_BUILD_CONTEXT: /tmp/rustybgp-prebuilt
+          RUSTYBGP_DOCKERFILE: Dockerfile
         run: ./run-test.sh

--- a/tests/e2e/rfc7911/docker-compose.yml
+++ b/tests/e2e/rfc7911/docker-compose.yml
@@ -41,8 +41,8 @@ services:
   # rustybgp: receives paths from both senders, sends add-path to receiver
   router-rusty:
     build:
-      context: ../../..
-      dockerfile: tests/e2e/shared/Dockerfile.rustybgp
+      context: ${RUSTYBGP_BUILD_CONTEXT:-../../..}
+      dockerfile: ${RUSTYBGP_DOCKERFILE:-tests/e2e/shared/Dockerfile.rustybgp}
       args:
         RUST_TARGET: ${RUST_TARGET:-aarch64-unknown-linux-musl}
     container_name: router-rusty

--- a/tests/e2e/rfc8950/docker-compose.yml
+++ b/tests/e2e/rfc8950/docker-compose.yml
@@ -42,8 +42,8 @@ services:
 
   router-rusty:
     build:
-      context: ../../..
-      dockerfile: tests/e2e/shared/Dockerfile.rustybgp
+      context: ${RUSTYBGP_BUILD_CONTEXT:-../../..}
+      dockerfile: ${RUSTYBGP_DOCKERFILE:-tests/e2e/shared/Dockerfile.rustybgp}
       args:
         RUST_TARGET: ${RUST_TARGET:-aarch64-unknown-linux-musl}
     container_name: router-rusty

--- a/tests/e2e/shared/Dockerfile.rustybgp-prebuilt
+++ b/tests/e2e/shared/Dockerfile.rustybgp-prebuilt
@@ -1,27 +1,10 @@
-# Full build: used for local development (docker compose up --build)
-ARG RUST_TARGET=aarch64-unknown-linux-musl
-FROM ghcr.io/rust-cross/rust-musl-cross:${RUST_TARGET} AS builder
-
-ARG RUST_TARGET=aarch64-unknown-linux-musl
-
-# Install protobuf compiler (required by tonic-build)
-RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /home/rust/src
-COPY . .
-
-RUN cargo build --release --target ${RUST_TARGET}
-
-# Minimal runtime
+# Runtime-only: used in CI with a prebuilt rustybgpd binary
 FROM alpine:3.21
-
-ARG RUST_TARGET=aarch64-unknown-linux-musl
 
 RUN apk add --no-cache iproute2 bash curl
 
-COPY --from=builder \
-    /home/rust/src/target/${RUST_TARGET}/release/rustybgpd \
-    /usr/local/bin/rustybgpd
+# The prebuilt binary is passed via build context
+COPY rustybgpd /usr/local/bin/rustybgpd
 RUN chmod +x /usr/local/bin/rustybgpd
 
 # Install gobgp CLI for route injection via gRPC


### PR DESCRIPTION
Build rustybgpd on the host with Swatinem/rust-cache instead of inside Docker. Dependency compilation is cached across CI runs, making incremental builds much faster. Local development still uses the full Docker build via docker compose up --build.