### PR TITLE
daemon: replace SessionState enum with fsm::State

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -122,39 +122,16 @@ impl MessageCounter {
     }
 }
 
-#[derive(PartialEq, Clone, Copy)]
-#[allow(dead_code)]
-enum SessionState {
-    Idle,
-    Connect,
-    Active,
-    OpenSent,
-    OpenConfirm,
-    Established,
-}
+use crate::fsm::State as SessionState;
 
-fn session_state_to_api(v: u8) -> api::peer_state::SessionState {
+fn session_state_to_api(v: SessionState) -> api::peer_state::SessionState {
     match v {
-        0 => api::peer_state::SessionState::Idle,
-        1 => api::peer_state::SessionState::Connect,
-        2 => api::peer_state::SessionState::Active,
-        3 => api::peer_state::SessionState::Opensent,
-        4 => api::peer_state::SessionState::Openconfirm,
-        5 => api::peer_state::SessionState::Established,
-        _ => panic!("unexpected session state {}", v),
-    }
-}
-
-impl From<SessionState> for u8 {
-    fn from(s: SessionState) -> Self {
-        match s {
-            SessionState::Idle => 0,
-            SessionState::Connect => 1,
-            SessionState::Active => 2,
-            SessionState::OpenSent => 3,
-            SessionState::OpenConfirm => 4,
-            SessionState::Established => 5,
-        }
+        SessionState::Idle => api::peer_state::SessionState::Idle,
+        SessionState::Connect => api::peer_state::SessionState::Connect,
+        SessionState::Active => api::peer_state::SessionState::Active,
+        SessionState::OpenSent => api::peer_state::SessionState::Opensent,
+        SessionState::OpenConfirm => api::peer_state::SessionState::Openconfirm,
+        SessionState::Established => api::peer_state::SessionState::Established,
     }
 }
 
@@ -471,7 +448,8 @@ impl PeerBuilder {
 
 impl From<&Peer> for api::Peer {
     fn from(p: &Peer) -> Self {
-        let session_state = p.state.fsm.load(Ordering::Acquire);
+        let session_state = SessionState::try_from(p.state.fsm.load(Ordering::Acquire))
+            .unwrap_or(SessionState::Idle);
         let remote_cap = {
             let mut v = Vec::new();
             loop {

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -47,6 +47,21 @@ impl From<State> for u8 {
     }
 }
 
+impl TryFrom<u8> for State {
+    type Error = u8;
+    fn try_from(v: u8) -> Result<Self, u8> {
+        match v {
+            0 => Ok(State::Idle),
+            1 => Ok(State::Connect),
+            2 => Ok(State::Active),
+            3 => Ok(State::OpenSent),
+            4 => Ok(State::OpenConfirm),
+            5 => Ok(State::Established),
+            _ => Err(v),
+        }
+    }
+}
+
 /// Events fed into the session FSM.
 #[allow(dead_code)]
 pub(crate) enum Input {


### PR DESCRIPTION
Remove the duplicate state enum from event.rs. session_state_to_api now takes fsm::State directly instead of a raw u8, with TryFrom<u8> for conversion from the atomic storage.