### PR TITLE
feat(packet): add BGP Prefix SID attribute support

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -18,7 +18,7 @@ use std::io::Cursor;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
-use rustybgp_packet::{Family, IpNet, Nlri, bgp::Attribute, bgp::Capability};
+use rustybgp_packet::{Family, IpNet, Nlri, bgp::Attribute, bgp::Capability, prefix_sid};
 
 use regex::Regex;
 use uuid::Uuid;
@@ -286,6 +286,18 @@ pub(crate) fn attr_to_api(a: &Attribute) -> api::Attribute {
                 )),
             }
         }
+        Attribute::PREFIX_SID => match prefix_sid::PrefixSid::decode(a.binary().unwrap()) {
+            Ok(sid) => api::Attribute {
+                attr: Some(api::attribute::Attr::PrefixSid(prefix_sid_to_api(&sid))),
+            },
+            Err(_) => api::Attribute {
+                attr: Some(api::attribute::Attr::Unknown(api::UnknownAttribute {
+                    flags: a.flags() as u32,
+                    r#type: a.code() as u32,
+                    value: a.binary().unwrap().to_owned(),
+                })),
+            },
+        },
         _ => api::Attribute {
             attr: Some(api::attribute::Attr::Unknown(api::UnknownAttribute {
                 flags: a.flags() as u32,
@@ -404,10 +416,211 @@ pub(crate) fn attr_from_api(a: api::Attribute) -> Result<Attribute, Error> {
             Attribute::new_with_bin(Attribute::LARGE_COMMUNITY, c.into_inner())
                 .ok_or(Error::InvalidArgument("unsupported attribute".to_string()))
         }
+        api::attribute::Attr::PrefixSid(p) => {
+            let sid = prefix_sid_from_api(p)?;
+            Attribute::new_with_bin(Attribute::PREFIX_SID, sid.to_vec())
+                .ok_or(Error::InvalidArgument("unsupported attribute".to_string()))
+        }
         _ => Err(Error::InvalidArgument(
             "attribute conversion not implemented".to_string(),
         )),
     }
+}
+
+pub(crate) fn prefix_sid_to_api(sid: &prefix_sid::PrefixSid) -> api::PrefixSid {
+    let tlvs = sid
+        .tlvs
+        .iter()
+        .filter_map(|tlv| match tlv {
+            prefix_sid::PrefixSidTlv::Srv6L3Service(t) => Some(api::prefix_sid::Tlv {
+                tlv: Some(api::prefix_sid::tlv::Tlv::L3Service(
+                    api::SRv6L3ServiceTlv {
+                        sub_tlvs: srv6_service_sub_tlvs_to_api(&t.sub_tlvs),
+                    },
+                )),
+            }),
+            prefix_sid::PrefixSidTlv::Srv6L2Service(t) => Some(api::prefix_sid::Tlv {
+                tlv: Some(api::prefix_sid::tlv::Tlv::L2Service(
+                    api::SRv6L2ServiceTlv {
+                        sub_tlvs: srv6_service_sub_tlvs_to_api(&t.sub_tlvs),
+                    },
+                )),
+            }),
+            // Unknown TLVs are not represented in the proto; drop them for
+            // the typed gRPC view. They still round-trip on the wire because
+            // the daemon keeps the original attribute bytes.
+            prefix_sid::PrefixSidTlv::Unknown { .. } => None,
+        })
+        .collect();
+    api::PrefixSid { tlvs }
+}
+
+fn srv6_service_sub_tlvs_to_api(
+    subs: &[prefix_sid::Srv6ServiceSubTlv],
+) -> std::collections::HashMap<u32, api::SRv6SubTlVs> {
+    let mut map = std::collections::HashMap::new();
+    for sub in subs {
+        if let prefix_sid::Srv6ServiceSubTlv::Information(info) = sub {
+            let entry = map
+                .entry(prefix_sid::Srv6ServiceSubTlv::SUBTLV_SRV6_INFORMATION as u32)
+                .or_insert(api::SRv6SubTlVs { tlvs: Vec::new() });
+            entry.tlvs.push(api::SRv6SubTlv {
+                tlv: Some(api::s_rv6_sub_tlv::Tlv::Information(
+                    api::SRv6InformationSubTlv {
+                        sid: info.sid.octets().to_vec(),
+                        flags: Some(api::SRv6SidFlags { flag_1: false }),
+                        endpoint_behavior: info.endpoint_behavior as u32,
+                        sub_sub_tlvs: srv6_service_sub_sub_tlvs_to_api(&info.sub_sub_tlvs),
+                    },
+                )),
+            });
+        }
+    }
+    map
+}
+
+fn srv6_service_sub_sub_tlvs_to_api(
+    subs: &[prefix_sid::Srv6ServiceDataSubSubTlv],
+) -> std::collections::HashMap<u32, api::SRv6SubSubTlVs> {
+    let mut map = std::collections::HashMap::new();
+    for sub in subs {
+        if let prefix_sid::Srv6ServiceDataSubSubTlv::Structure(s) = sub {
+            let entry = map
+                .entry(prefix_sid::Srv6ServiceDataSubSubTlv::SUBSUBTLV_SRV6_SID_STRUCTURE as u32)
+                .or_insert(api::SRv6SubSubTlVs { tlvs: Vec::new() });
+            entry.tlvs.push(api::SRv6SubSubTlv {
+                tlv: Some(api::s_rv6_sub_sub_tlv::Tlv::Structure(
+                    api::SRv6StructureSubSubTlv {
+                        locator_block_length: s.locator_block_length as u32,
+                        locator_node_length: s.locator_node_length as u32,
+                        function_length: s.function_length as u32,
+                        argument_length: s.argument_length as u32,
+                        transposition_length: s.transposition_length as u32,
+                        transposition_offset: s.transposition_offset as u32,
+                    },
+                )),
+            });
+        }
+    }
+    map
+}
+
+pub(crate) fn prefix_sid_from_api(p: api::PrefixSid) -> Result<prefix_sid::PrefixSid, Error> {
+    let mut tlvs = Vec::with_capacity(p.tlvs.len());
+    for tlv in p.tlvs {
+        let inner = tlv
+            .tlv
+            .ok_or_else(|| Error::InvalidArgument("empty prefix_sid tlv oneof".to_string()))?;
+        match inner {
+            api::prefix_sid::tlv::Tlv::L3Service(t) => {
+                tlvs.push(prefix_sid::PrefixSidTlv::Srv6L3Service(
+                    prefix_sid::Srv6ServiceTlv {
+                        reserved: 0,
+                        sub_tlvs: srv6_service_sub_tlvs_from_api(t.sub_tlvs)?,
+                    },
+                ));
+            }
+            api::prefix_sid::tlv::Tlv::L2Service(t) => {
+                tlvs.push(prefix_sid::PrefixSidTlv::Srv6L2Service(
+                    prefix_sid::Srv6ServiceTlv {
+                        reserved: 0,
+                        sub_tlvs: srv6_service_sub_tlvs_from_api(t.sub_tlvs)?,
+                    },
+                ));
+            }
+        }
+    }
+    Ok(prefix_sid::PrefixSid { tlvs })
+}
+
+fn srv6_service_sub_tlvs_from_api(
+    map: std::collections::HashMap<u32, api::SRv6SubTlVs>,
+) -> Result<Vec<prefix_sid::Srv6ServiceSubTlv>, Error> {
+    let mut out = Vec::new();
+    for (_key, sub_tlvs) in map {
+        for sub in sub_tlvs.tlvs {
+            let inner = sub
+                .tlv
+                .ok_or_else(|| Error::InvalidArgument("empty srv6 sub_tlv".to_string()))?;
+            match inner {
+                api::s_rv6_sub_tlv::Tlv::Information(info) => {
+                    if info.sid.len() != 16 {
+                        return Err(Error::InvalidArgument(format!(
+                            "SRv6 SID must be 16 bytes, got {}",
+                            info.sid.len()
+                        )));
+                    }
+                    let mut sid_bytes = [0u8; 16];
+                    sid_bytes.copy_from_slice(&info.sid);
+                    if info.endpoint_behavior > u16::MAX as u32 {
+                        return Err(Error::InvalidArgument(format!(
+                            "endpoint_behavior out of range: {}",
+                            info.endpoint_behavior
+                        )));
+                    }
+                    out.push(prefix_sid::Srv6ServiceSubTlv::Information(
+                        prefix_sid::Srv6InformationSubTlv {
+                            sid: sid_bytes.into(),
+                            flags: 0,
+                            endpoint_behavior: info.endpoint_behavior as u16,
+                            sub_sub_tlvs: srv6_service_sub_sub_tlvs_from_api(info.sub_sub_tlvs)?,
+                        },
+                    ));
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn srv6_service_sub_sub_tlvs_from_api(
+    map: std::collections::HashMap<u32, api::SRv6SubSubTlVs>,
+) -> Result<Vec<prefix_sid::Srv6ServiceDataSubSubTlv>, Error> {
+    let mut out = Vec::new();
+    for (_key, sub_sub_tlvs) in map {
+        for sub in sub_sub_tlvs.tlvs {
+            let inner = sub
+                .tlv
+                .ok_or_else(|| Error::InvalidArgument("empty srv6 sub_sub_tlv".to_string()))?;
+            match inner {
+                api::s_rv6_sub_sub_tlv::Tlv::Structure(s) => {
+                    let ensure_u8 = |name: &str, v: u32| -> Result<u8, Error> {
+                        if v > u8::MAX as u32 {
+                            Err(Error::InvalidArgument(format!(
+                                "{} out of range: {}",
+                                name, v
+                            )))
+                        } else {
+                            Ok(v as u8)
+                        }
+                    };
+                    out.push(prefix_sid::Srv6ServiceDataSubSubTlv::Structure(
+                        prefix_sid::Srv6SidStructureSubSubTlv {
+                            locator_block_length: ensure_u8(
+                                "locator_block_length",
+                                s.locator_block_length,
+                            )?,
+                            locator_node_length: ensure_u8(
+                                "locator_node_length",
+                                s.locator_node_length,
+                            )?,
+                            function_length: ensure_u8("function_length", s.function_length)?,
+                            argument_length: ensure_u8("argument_length", s.argument_length)?,
+                            transposition_length: ensure_u8(
+                                "transposition_length",
+                                s.transposition_length,
+                            )?,
+                            transposition_offset: ensure_u8(
+                                "transposition_offset",
+                                s.transposition_offset,
+                            )?,
+                        },
+                    ));
+                }
+            }
+        }
+    }
+    Ok(out)
 }
 
 pub(crate) fn statement_to_api(my: &rustybgp_table::Statement) -> api::Statement {

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -785,6 +785,7 @@ impl Attribute {
     pub const AS4_AGGREGATOR: u8 = 18;
     pub const AIGP: u8 = 26;
     pub const LARGE_COMMUNITY: u8 = 32;
+    pub const PREFIX_SID: u8 = 40;
 
     pub const AS_PATH_TYPE_SET: u8 = 1;
     pub const AS_PATH_TYPE_SEQ: u8 = 2;
@@ -859,6 +860,7 @@ impl Attribute {
             Self::AS4_AGGREGATOR => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
             Self::AIGP => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
             Self::LARGE_COMMUNITY => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
+            Self::PREFIX_SID => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
             _ => None,
         }
     }

--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -24,4 +24,5 @@ pub mod bmp;
 pub mod error;
 pub mod frame;
 pub mod mrt;
+pub mod prefix_sid;
 pub mod rpki;

--- a/packet/src/prefix_sid.rs
+++ b/packet/src/prefix_sid.rs
@@ -1,0 +1,467 @@
+// Copyright (C) 2019-2026 The RustyBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! BGP Prefix SID Attribute (RFC 8669, path attribute type 40).
+//!
+//! Known TLVs, sub-TLVs, and sub-sub-TLVs are parsed into typed
+//! variants; everything else is preserved as `Unknown { type, value }`
+//! so the attribute round-trips byte-for-byte regardless of the
+//! specific TLV mix an originator chose.
+
+use crate::error::{BgpError, Error};
+use byteorder::{NetworkEndian, ReadBytesExt};
+use bytes::BufMut;
+use std::io::{self, Cursor, Read};
+use std::net::Ipv6Addr;
+
+fn malformed() -> Error {
+    BgpError::UpdateMalformedAttributeList.into()
+}
+
+/// Read a `[type: 1][length: 2 BE]` header plus `length` bytes of value.
+/// Returns the type byte and the (owned) value bytes, and advances `c`.
+fn read_tlv_header<T: io::Read>(c: &mut T) -> Result<(u8, Vec<u8>), Error> {
+    let type_id = c.read_u8().map_err(|_| malformed())?;
+    let len = c.read_u16::<NetworkEndian>().map_err(|_| malformed())? as usize;
+    let mut value = vec![0u8; len];
+    c.read_exact(&mut value).map_err(|_| malformed())?;
+    Ok((type_id, value))
+}
+
+fn write_tlv<B: BufMut>(dst: &mut B, type_id: u8, value: &[u8]) {
+    dst.put_u8(type_id);
+    dst.put_u16(value.len() as u16);
+    dst.put_slice(value);
+}
+
+/// The decoded Prefix SID attribute value (everything after the path
+/// attribute header).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PrefixSid {
+    pub tlvs: Vec<PrefixSidTlv>,
+}
+
+/// Top-level Prefix SID TLV. Unknown TLV types are preserved verbatim.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PrefixSidTlv {
+    Srv6L3Service(Srv6ServiceTlv),
+    Srv6L2Service(Srv6ServiceTlv),
+    Unknown { type_id: u8, value: Vec<u8> },
+}
+
+/// Payload shared by SRv6 L3/L2 Service TLVs: a reserved byte followed
+/// by zero or more service sub-TLVs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct Srv6ServiceTlv {
+    pub reserved: u8,
+    pub sub_tlvs: Vec<Srv6ServiceSubTlv>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Srv6ServiceSubTlv {
+    Information(Srv6InformationSubTlv),
+    Unknown { type_id: u8, value: Vec<u8> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Srv6InformationSubTlv {
+    pub sid: Ipv6Addr,
+    pub flags: u8,
+    pub endpoint_behavior: u16,
+    pub sub_sub_tlvs: Vec<Srv6ServiceDataSubSubTlv>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Srv6ServiceDataSubSubTlv {
+    Structure(Srv6SidStructureSubSubTlv),
+    Unknown { type_id: u8, value: Vec<u8> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Srv6SidStructureSubSubTlv {
+    pub locator_block_length: u8,
+    pub locator_node_length: u8,
+    pub function_length: u8,
+    pub argument_length: u8,
+    pub transposition_length: u8,
+    pub transposition_offset: u8,
+}
+
+impl PrefixSid {
+    pub fn decode(data: &[u8]) -> Result<Self, Error> {
+        let mut c = Cursor::new(data);
+        let total = data.len() as u64;
+        let mut tlvs = Vec::new();
+        while c.position() < total {
+            let (type_id, value) = read_tlv_header(&mut c)?;
+            tlvs.push(PrefixSidTlv::decode(type_id, &value)?);
+        }
+        Ok(PrefixSid { tlvs })
+    }
+
+    pub fn encode<B: BufMut>(&self, dst: &mut B) {
+        for tlv in &self.tlvs {
+            tlv.encode(dst);
+        }
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut v = Vec::new();
+        self.encode(&mut v);
+        v
+    }
+}
+
+impl PrefixSidTlv {
+    /// TLV type for SRv6 L3 Service (RFC 9252 §2).
+    pub const TLV_SRV6_L3_SERVICE: u8 = 5;
+    /// TLV type for SRv6 L2 Service.
+    pub const TLV_SRV6_L2_SERVICE: u8 = 6;
+
+    fn decode(type_id: u8, value: &[u8]) -> Result<Self, Error> {
+        match type_id {
+            Self::TLV_SRV6_L3_SERVICE => {
+                Ok(PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv::decode(value)?))
+            }
+            Self::TLV_SRV6_L2_SERVICE => {
+                Ok(PrefixSidTlv::Srv6L2Service(Srv6ServiceTlv::decode(value)?))
+            }
+            _ => Ok(PrefixSidTlv::Unknown {
+                type_id,
+                value: value.to_vec(),
+            }),
+        }
+    }
+
+    fn encode<B: BufMut>(&self, dst: &mut B) {
+        match self {
+            PrefixSidTlv::Srv6L3Service(t) => {
+                write_tlv(dst, Self::TLV_SRV6_L3_SERVICE, &t.to_vec())
+            }
+            PrefixSidTlv::Srv6L2Service(t) => {
+                write_tlv(dst, Self::TLV_SRV6_L2_SERVICE, &t.to_vec())
+            }
+            PrefixSidTlv::Unknown { type_id, value } => write_tlv(dst, *type_id, value),
+        }
+    }
+}
+
+impl Srv6ServiceTlv {
+    fn decode(data: &[u8]) -> Result<Self, Error> {
+        if data.is_empty() {
+            return Err(malformed());
+        }
+        let mut c = Cursor::new(data);
+        let total = data.len() as u64;
+        let reserved = c.read_u8().map_err(|_| malformed())?;
+        let mut sub_tlvs = Vec::new();
+        while c.position() < total {
+            let (type_id, value) = read_tlv_header(&mut c)?;
+            sub_tlvs.push(Srv6ServiceSubTlv::decode(type_id, &value)?);
+        }
+        Ok(Srv6ServiceTlv { reserved, sub_tlvs })
+    }
+
+    fn to_vec(&self) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.put_u8(self.reserved);
+        for sub in &self.sub_tlvs {
+            sub.encode(&mut v);
+        }
+        v
+    }
+}
+
+impl Srv6ServiceSubTlv {
+    /// Sub-TLV type for SRv6 SID Information (RFC 9252 §3.1).
+    pub const SUBTLV_SRV6_INFORMATION: u8 = 1;
+
+    fn decode(type_id: u8, value: &[u8]) -> Result<Self, Error> {
+        match type_id {
+            Self::SUBTLV_SRV6_INFORMATION => Ok(Srv6ServiceSubTlv::Information(
+                Srv6InformationSubTlv::decode(value)?,
+            )),
+            _ => Ok(Srv6ServiceSubTlv::Unknown {
+                type_id,
+                value: value.to_vec(),
+            }),
+        }
+    }
+
+    fn encode<B: BufMut>(&self, dst: &mut B) {
+        match self {
+            Srv6ServiceSubTlv::Information(info) => {
+                write_tlv(dst, Self::SUBTLV_SRV6_INFORMATION, &info.to_vec())
+            }
+            Srv6ServiceSubTlv::Unknown { type_id, value } => write_tlv(dst, *type_id, value),
+        }
+    }
+}
+
+impl Srv6InformationSubTlv {
+    /// Fixed prefix length before any sub-sub-TLVs:
+    /// Reserved(1) + SID(16) + Flags(1) + Endpoint Behavior(2) + Reserved(1) = 21 bytes.
+    const FIXED_LEN: usize = 21;
+
+    fn decode(data: &[u8]) -> Result<Self, Error> {
+        if data.len() < Self::FIXED_LEN {
+            return Err(malformed());
+        }
+        let mut c = Cursor::new(data);
+        let total = data.len() as u64;
+        let _reserved = c.read_u8().map_err(|_| malformed())?;
+        let mut sid_bytes = [0u8; 16];
+        c.read_exact(&mut sid_bytes).map_err(|_| malformed())?;
+        let sid = Ipv6Addr::from(sid_bytes);
+        let flags = c.read_u8().map_err(|_| malformed())?;
+        let endpoint_behavior = c.read_u16::<NetworkEndian>().map_err(|_| malformed())?;
+        let _reserved = c.read_u8().map_err(|_| malformed())?;
+        let mut sub_sub_tlvs = Vec::new();
+        while c.position() < total {
+            let (type_id, value) = read_tlv_header(&mut c)?;
+            sub_sub_tlvs.push(Srv6ServiceDataSubSubTlv::decode(type_id, &value)?);
+        }
+        Ok(Srv6InformationSubTlv {
+            sid,
+            flags,
+            endpoint_behavior,
+            sub_sub_tlvs,
+        })
+    }
+
+    fn to_vec(&self) -> Vec<u8> {
+        let mut v = Vec::with_capacity(Self::FIXED_LEN);
+        v.put_u8(0); // Reserved
+        v.extend_from_slice(&self.sid.octets());
+        v.put_u8(self.flags);
+        v.put_u16(self.endpoint_behavior);
+        v.put_u8(0); // Reserved
+        for sub in &self.sub_sub_tlvs {
+            sub.encode(&mut v);
+        }
+        v
+    }
+}
+
+impl Srv6ServiceDataSubSubTlv {
+    /// Sub-Sub-TLV type for SRv6 SID Structure (RFC 9252 §3.2.1).
+    pub const SUBSUBTLV_SRV6_SID_STRUCTURE: u8 = 1;
+
+    fn decode(type_id: u8, value: &[u8]) -> Result<Self, Error> {
+        match type_id {
+            Self::SUBSUBTLV_SRV6_SID_STRUCTURE => Ok(Srv6ServiceDataSubSubTlv::Structure(
+                Srv6SidStructureSubSubTlv::decode(value)?,
+            )),
+            _ => Ok(Srv6ServiceDataSubSubTlv::Unknown {
+                type_id,
+                value: value.to_vec(),
+            }),
+        }
+    }
+
+    fn encode<B: BufMut>(&self, dst: &mut B) {
+        match self {
+            Srv6ServiceDataSubSubTlv::Structure(s) => {
+                write_tlv(dst, Self::SUBSUBTLV_SRV6_SID_STRUCTURE, &(*s).to_vec())
+            }
+            Srv6ServiceDataSubSubTlv::Unknown { type_id, value } => write_tlv(dst, *type_id, value),
+        }
+    }
+}
+
+impl Srv6SidStructureSubSubTlv {
+    /// Fixed 6-octet value (RFC 9252 §3.2.1).
+    pub const LEN: usize = 6;
+
+    fn decode(data: &[u8]) -> Result<Self, Error> {
+        if data.len() < Self::LEN {
+            return Err(malformed());
+        }
+        let mut c = Cursor::new(data);
+        Ok(Srv6SidStructureSubSubTlv {
+            locator_block_length: c.read_u8().map_err(|_| malformed())?,
+            locator_node_length: c.read_u8().map_err(|_| malformed())?,
+            function_length: c.read_u8().map_err(|_| malformed())?,
+            argument_length: c.read_u8().map_err(|_| malformed())?,
+            transposition_length: c.read_u8().map_err(|_| malformed())?,
+            transposition_offset: c.read_u8().map_err(|_| malformed())?,
+        })
+    }
+
+    fn to_vec(self) -> Vec<u8> {
+        vec![
+            self.locator_block_length,
+            self.locator_node_length,
+            self.function_length,
+            self.argument_length,
+            self.transposition_length,
+            self.transposition_offset,
+        ]
+    }
+}
+
+#[test]
+fn empty_attribute_roundtrip() {
+    let sid = PrefixSid { tlvs: Vec::new() };
+    let bytes = sid.to_vec();
+    assert!(bytes.is_empty());
+    assert_eq!(PrefixSid::decode(&bytes).unwrap(), sid);
+}
+
+#[test]
+fn unknown_tlv_passthrough() {
+    let sid = PrefixSid {
+        tlvs: vec![PrefixSidTlv::Unknown {
+            type_id: 99,
+            value: vec![0x01, 0x02, 0x03],
+        }],
+    };
+    let bytes = sid.to_vec();
+    assert_eq!(bytes, vec![99, 0x00, 0x03, 0x01, 0x02, 0x03]);
+    assert_eq!(PrefixSid::decode(&bytes).unwrap(), sid);
+}
+
+#[test]
+fn srv6_l3_service_roundtrip() {
+    let sid = PrefixSid {
+        tlvs: vec![PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
+            reserved: 0,
+            sub_tlvs: vec![Srv6ServiceSubTlv::Information(Srv6InformationSubTlv {
+                sid: "2001:0:5:3::".parse().unwrap(),
+                flags: 0,
+                endpoint_behavior: 19, // End.DT4
+                sub_sub_tlvs: vec![Srv6ServiceDataSubSubTlv::Structure(
+                    Srv6SidStructureSubSubTlv {
+                        locator_block_length: 40,
+                        locator_node_length: 24,
+                        function_length: 16,
+                        argument_length: 0,
+                        transposition_length: 16,
+                        transposition_offset: 64,
+                    },
+                )],
+            })],
+        })],
+    };
+    let bytes = sid.to_vec();
+    assert_eq!(PrefixSid::decode(&bytes).unwrap(), sid);
+}
+
+#[test]
+fn srv6_l3_service_wire_format() {
+    // Known-good byte sequence from RFC 9252 examples / gobgp
+    // prefix_sid_test.go: SRv6 L3 Service TLV with Information sub-TLV
+    // (SID 2001:0:5:3::, End.DT4, SID Structure 40/24/16/0/16/64).
+    // Attribute value only; path-attribute header is omitted.
+    let expected: Vec<u8> = vec![
+        // TLV: type=5, length=34
+        0x05, 0x00, 0x22, // SRv6 L3 Service TLV value
+        0x00, // Reserved
+        // Sub-TLV: type=1, length=30
+        0x01, 0x00, 0x1e, // SRv6 Information sub-TLV value
+        0x00, // Reserved
+        0x20, 0x01, 0x00, 0x00, 0x00, 0x05, 0x00, 0x03, // SID bytes 0..8
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // SID bytes 8..16
+        0x00, // Flags
+        0x00, 0x13, // Endpoint Behavior 19
+        0x00, // Reserved
+        // Sub-Sub-TLV: type=1, length=6
+        0x01, 0x00, 0x06, // SRv6 SID Structure
+        0x28, 0x18, 0x10, 0x00, 0x10, 0x40,
+    ];
+    let decoded = PrefixSid::decode(&expected).unwrap();
+    assert_eq!(decoded.to_vec(), expected);
+    match &decoded.tlvs[0] {
+        PrefixSidTlv::Srv6L3Service(t) => match &t.sub_tlvs[0] {
+            Srv6ServiceSubTlv::Information(i) => {
+                assert_eq!(i.sid, "2001:0:5:3::".parse::<Ipv6Addr>().unwrap());
+                assert_eq!(i.endpoint_behavior, 19);
+                match &i.sub_sub_tlvs[0] {
+                    Srv6ServiceDataSubSubTlv::Structure(s) => {
+                        assert_eq!(s.locator_block_length, 40);
+                        assert_eq!(s.locator_node_length, 24);
+                        assert_eq!(s.function_length, 16);
+                        assert_eq!(s.argument_length, 0);
+                        assert_eq!(s.transposition_length, 16);
+                        assert_eq!(s.transposition_offset, 64);
+                    }
+                    _ => panic!("expected Structure sub-sub-tlv"),
+                }
+            }
+            _ => panic!("expected Information sub-tlv"),
+        },
+        _ => panic!("expected Srv6L3Service"),
+    }
+}
+
+#[test]
+fn unknown_sub_tlv_skipped_as_unknown() {
+    // L3 Service with Reserved + unknown sub-TLV type 0xff (length 3).
+    let bytes: Vec<u8> = vec![
+        0x05, 0x00, 0x07, // TLV type=5, length=7
+        0x00, // Reserved
+        0xff, 0x00, 0x03, 0x01, 0x02, 0x03,
+    ];
+    let decoded = PrefixSid::decode(&bytes).unwrap();
+    assert_eq!(decoded.to_vec(), bytes);
+    match &decoded.tlvs[0] {
+        PrefixSidTlv::Srv6L3Service(t) => match &t.sub_tlvs[0] {
+            Srv6ServiceSubTlv::Unknown { type_id, value } => {
+                assert_eq!(*type_id, 0xff);
+                assert_eq!(value, &vec![0x01, 0x02, 0x03]);
+            }
+            _ => panic!("expected Unknown sub-tlv"),
+        },
+        _ => panic!("expected L3 Service"),
+    }
+}
+
+#[test]
+fn decode_rejects_truncated_tlv_header() {
+    assert!(PrefixSid::decode(&[0x05, 0x00]).is_err());
+}
+
+#[test]
+fn decode_rejects_truncated_tlv_value() {
+    // type=5, length=10, but only 2 bytes of value follow
+    assert!(PrefixSid::decode(&[0x05, 0x00, 0x0a, 0x00, 0x00]).is_err());
+}
+
+#[test]
+fn decode_rejects_information_sub_tlv_too_short() {
+    // L3 Service with an Information sub-TLV whose value is shorter than FIXED_LEN.
+    let bytes: Vec<u8> = vec![
+        0x05, 0x00, 0x07, 0x00, // TLV type=5, length=7, reserved
+        0x01, 0x00, 0x03, 0x00, 0x00, 0x00, // Information sub-TLV with 3-byte value
+    ];
+    assert!(PrefixSid::decode(&bytes).is_err());
+}
+
+#[test]
+fn decode_rejects_sid_structure_too_short() {
+    // Information sub-TLV with a Sub-Sub-TLV type=1 whose length is 3 instead of 6.
+    let bytes: Vec<u8> = vec![
+        0x05, 0x00, 0x1f, // TLV type=5, length=31
+        0x00, // Reserved
+        0x01, 0x00, 0x1b, // Sub-TLV type=1, length=27
+        0x00, // Reserved
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,    // SID
+        0x00, // Flags
+        0x00, 0x00, // Endpoint
+        0x00, // Reserved
+        0x01, 0x00, 0x03, 0x01, 0x02, 0x03, // Bogus SID Structure len=3
+    ];
+    assert!(PrefixSid::decode(&bytes).is_err());
+}

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -16,6 +16,7 @@
 use rustybgp_packet::bgp::{
     Attribute, Ipv4Net, Ipv6Net, Message, Nexthop, NlriSet, PeerCodec, PeerCodecBuilder, Update,
 };
+use rustybgp_packet::prefix_sid;
 use rustybgp_packet::{BgpFramer, Family, Nlri, PathNlri};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
@@ -476,6 +477,130 @@ fn update_attr_community() {
             assert_eq!(bytes.len(), 4);
             let parsed = u32::from_be_bytes(bytes[..4].try_into().unwrap());
             assert_eq!(parsed, community);
+        }
+        _ => panic!("expected Update"),
+    }
+}
+
+// ─── Prefix SID attribute (RFC 8669) ─────────────────────────────────────────
+
+#[test]
+fn update_ipv4_with_prefix_sid() {
+    let prefix = ipv4_prefix("10.0.0.0", 24);
+    // Build a Prefix SID attribute with SRv6 L3 Service TLV containing one
+    // Information sub-TLV and one SID Structure sub-sub-TLV.
+    let sid = prefix_sid::PrefixSid {
+        tlvs: vec![prefix_sid::PrefixSidTlv::Srv6L3Service(
+            prefix_sid::Srv6ServiceTlv {
+                reserved: 0,
+                sub_tlvs: vec![prefix_sid::Srv6ServiceSubTlv::Information(
+                    prefix_sid::Srv6InformationSubTlv {
+                        sid: "2001:0:5:3::".parse().unwrap(),
+                        flags: 0,
+                        endpoint_behavior: 19, // End.DT4
+                        sub_sub_tlvs: vec![prefix_sid::Srv6ServiceDataSubSubTlv::Structure(
+                            prefix_sid::Srv6SidStructureSubSubTlv {
+                                locator_block_length: 40,
+                                locator_node_length: 24,
+                                function_length: 16,
+                                argument_length: 0,
+                                transposition_length: 16,
+                                transposition_offset: 64,
+                            },
+                        )],
+                    },
+                )],
+            },
+        )],
+    };
+    let sid_bytes = sid.to_vec();
+
+    let msg = Message::Update(Update {
+        reach: Some(NlriSet {
+            family: Family::IPV4,
+            entries: vec![prefix],
+        }),
+        mp_reach: None,
+        attr: Arc::new(vec![
+            Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
+            Attribute::new_with_bin(
+                Attribute::AS_PATH,
+                vec![Attribute::AS_PATH_TYPE_SEQ, 1, 0x00, 0x00, 0xFD, 0xEA],
+            )
+            .unwrap(),
+            Attribute::new_with_bin(
+                Attribute::NEXTHOP,
+                Ipv4Addr::new(192, 0, 2, 254).octets().to_vec(),
+            )
+            .unwrap(),
+            Attribute::new_with_bin(Attribute::PREFIX_SID, sid_bytes.clone()).unwrap(),
+        ]),
+        unreach: None,
+        mp_unreach: None,
+        nexthop: None,
+    });
+
+    match round_trip(&msg, ipv4_codec()) {
+        Message::Update(Update { reach, attr, .. }) => {
+            assert_eq!(reach.unwrap().entries, vec![prefix]);
+            let a = attr
+                .iter()
+                .find(|a| a.code() == Attribute::PREFIX_SID)
+                .expect("PREFIX_SID must be present");
+            assert_eq!(a.binary().unwrap(), &sid_bytes);
+            // Decoded structure equals the input.
+            let decoded = prefix_sid::PrefixSid::decode(a.binary().unwrap()).unwrap();
+            assert_eq!(decoded, sid);
+        }
+        _ => panic!("expected Update"),
+    }
+}
+
+#[test]
+fn update_passes_through_unknown_prefix_sid_tlv() {
+    // Receivers must re-advertise TLV types they do not understand.
+    let prefix = ipv4_prefix("10.0.0.0", 24);
+    let sid = prefix_sid::PrefixSid {
+        tlvs: vec![prefix_sid::PrefixSidTlv::Unknown {
+            type_id: 0x55,
+            value: vec![0xAA, 0xBB, 0xCC],
+        }],
+    };
+    let sid_bytes = sid.to_vec();
+    assert_eq!(sid_bytes, vec![0x55, 0x00, 0x03, 0xAA, 0xBB, 0xCC]);
+
+    let msg = Message::Update(Update {
+        reach: Some(NlriSet {
+            family: Family::IPV4,
+            entries: vec![prefix],
+        }),
+        mp_reach: None,
+        attr: Arc::new(vec![
+            Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
+            Attribute::new_with_bin(
+                Attribute::AS_PATH,
+                vec![Attribute::AS_PATH_TYPE_SEQ, 1, 0x00, 0x00, 0xFD, 0xEA],
+            )
+            .unwrap(),
+            Attribute::new_with_bin(
+                Attribute::NEXTHOP,
+                Ipv4Addr::new(192, 0, 2, 254).octets().to_vec(),
+            )
+            .unwrap(),
+            Attribute::new_with_bin(Attribute::PREFIX_SID, sid_bytes.clone()).unwrap(),
+        ]),
+        unreach: None,
+        mp_unreach: None,
+        nexthop: None,
+    });
+
+    match round_trip(&msg, ipv4_codec()) {
+        Message::Update(Update { attr, .. }) => {
+            let a = attr
+                .iter()
+                .find(|a| a.code() == Attribute::PREFIX_SID)
+                .expect("PREFIX_SID must be present");
+            assert_eq!(a.binary().unwrap(), &sid_bytes);
         }
         _ => panic!("expected Update"),
     }


### PR DESCRIPTION
Add support for the BGP Prefix SID path attribute (RFC 8669, type 40).

- packet: new `prefix_sid` module with typed SRv6 L3/L2 Service TLV
  (RFC 9252), SRv6 SID Information sub-TLV, and SRv6 SID Structure
  sub-sub-TLV. Unknown TLV, sub-TLV, and sub-sub-TLV types are
  preserved as opaque bytes so the attribute round-trips losslessly
  regardless of the mix an originator chose.
- daemon: gRPC conversion in `convert.rs` wires the existing
  `PrefixSid` proto message to the new typed representation so
  clients can inspect or set SRv6 service TLVs.
- tests: PeerCodec round-trip covering a typed SRv6 L3 Service TLV
  and an unknown top-level TLV pass-through.