### PR TITLE
fix(daemon): send non-IPv4-unicast families through MP_REACH_NLRI

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -3790,11 +3790,16 @@ impl Handler {
         // 2. Drain pending updates (withdrawals, reach, EOR) via peer_tx.
         txbuf = bytes::BytesMut::with_capacity(txbuf_size);
         for (family, p) in pending.iter_mut() {
-            let use_mp = framer
-                .inner()
-                .channel
-                .get(family)
-                .is_some_and(|c| c.extended_nexthop());
+            // IPv4-unicast can carry reachability either in the UPDATE's
+            // traditional NLRI section or via MP_REACH_NLRI (when RFC 8950
+            // Extended Nexthop is negotiated). Every other family must use
+            // MP_REACH_NLRI.
+            let use_mp = *family != packet::Family::IPV4
+                || framer
+                    .inner()
+                    .channel
+                    .get(family)
+                    .is_some_and(|c| c.extended_nexthop());
             for msg in p.drain_messages(*family, use_mp) {
                 let _ = framer.encode_to(&msg, &mut txbuf);
                 self.counter_tx.sync(&msg);


### PR DESCRIPTION
`drain_messages` only used MP_REACH_NLRI when the RFC 8950
Extended Nexthop capability was negotiated. That gate is only
meaningful for IPv4-unicast; every other family must always use
MP_REACH_NLRI to carry both nexthop and NLRI.

Without this, an IPv6-unicast UPDATE originated by the daemon
ends up with the NLRI in the IPv4 NLRI section of the message,
which the peer rejects as "Invalid Network Field" (RFC 4271
§6.3, notification code 3 / subcode 10).

Observed against a neighbor that negotiated only the MP
capability for ipv6-unicast: the daemon sent a broken UPDATE and
the peer closed the session immediately after issuing the
NOTIFICATION.