### PR TITLE
feat: add BGP-MUP SAFI support

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -490,6 +490,15 @@ fn read_extcom(c: &mut Cursor<&Vec<u8>>) -> api::ExtendedCommunity {
                 local_admin,
             })
         }
+        mup::EC_TYPE_MUP => {
+            let segment_id2 = c.read_u16::<NetworkEndian>().unwrap() as u32;
+            let segment_id4 = c.read_u32::<NetworkEndian>().unwrap();
+            api::extended_community::Extcom::Mup(api::MupExtended {
+                sub_type: sub_type as u32,
+                segment_id2,
+                segment_id4,
+            })
+        }
         _ => {
             // Copy the full 8-byte chunk so the unknown extcom round-trips.
             let buf = c.get_ref();
@@ -545,6 +554,15 @@ fn write_extcom(c: &mut Cursor<Vec<u8>>, com: api::ExtendedCommunity) -> Result<
             c.write_u32::<NetworkEndian>(t.asn).unwrap();
             c.write_u16::<NetworkEndian>(ensure_u16("local_admin", t.local_admin)?)
                 .unwrap();
+        }
+        api::extended_community::Extcom::Mup(m) => {
+            let mup_ec = mup::MupExtended {
+                sub_type: ensure_u8("sub_type", m.sub_type)?,
+                segment_id2: ensure_u16("segment_id2", m.segment_id2)?,
+                segment_id4: m.segment_id4,
+            };
+            mup_ec.encode(c.get_mut());
+            c.set_position(c.position() + 8);
         }
         api::extended_community::Extcom::Unknown(u) => {
             if u.value.len() != 8 {

--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -18,7 +18,9 @@ use std::io::{Cursor, Write};
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
-use rustybgp_packet::{Family, IpNet, Nlri, bgp::Attribute, bgp::Capability, prefix_sid};
+use rustybgp_packet::{
+    Family, IpNet, Nlri, bgp::Attribute, bgp::Capability, mup, prefix_sid, rd::RouteDistinguisher,
+};
 
 use regex::Regex;
 use uuid::Uuid;
@@ -48,6 +50,130 @@ pub(crate) fn nlri_to_api(f: &Nlri) -> api::Nlri {
                 prefix_len: n.mask as u32,
             })),
         },
+        Nlri::Mup(m) => api::Nlri {
+            nlri: Some(mup_nlri_to_api(m)),
+        },
+    }
+}
+
+fn mup_nlri_to_api(m: &mup::MupNlri) -> api::nlri::Nlri {
+    match m {
+        mup::MupNlri::InterworkSegmentDiscovery(r) => {
+            api::nlri::Nlri::MupInterworkSegmentDiscovery(api::MupInterworkSegmentDiscoveryRoute {
+                rd: Some(rd_to_api(&r.rd)),
+                prefix: format!("{}/{}", r.prefix_addr, r.prefix_len),
+            })
+        }
+        mup::MupNlri::DirectSegmentDiscovery(r) => {
+            api::nlri::Nlri::MupDirectSegmentDiscovery(api::MupDirectSegmentDiscoveryRoute {
+                rd: Some(rd_to_api(&r.rd)),
+                address: r.address.to_string(),
+            })
+        }
+        mup::MupNlri::Type1SessionTransformed(r) => {
+            let ea_len = match r.endpoint_address {
+                std::net::IpAddr::V4(_) => 32,
+                std::net::IpAddr::V6(_) => 128,
+            };
+            let (sa_len, sa_str) = match r.source_address {
+                None => (0u32, String::new()),
+                Some(std::net::IpAddr::V4(a)) => (32, a.to_string()),
+                Some(std::net::IpAddr::V6(a)) => (128, a.to_string()),
+            };
+            #[allow(deprecated)]
+            api::nlri::Nlri::MupType1SessionTransformed(api::MupType1SessionTransformedRoute {
+                rd: Some(rd_to_api(&r.rd)),
+                prefix_length: 0,
+                prefix: format!("{}/{}", r.prefix_addr, r.prefix_len),
+                teid: r.teid,
+                qfi: r.qfi as u32,
+                endpoint_address_length: ea_len,
+                endpoint_address: r.endpoint_address.to_string(),
+                source_address_length: sa_len,
+                source_address: sa_str,
+            })
+        }
+        mup::MupNlri::Type2SessionTransformed(r) => {
+            api::nlri::Nlri::MupType2SessionTransformed(api::MupType2SessionTransformedRoute {
+                rd: Some(rd_to_api(&r.rd)),
+                endpoint_address_length: r.endpoint_address_length as u32,
+                endpoint_address: r.endpoint_address.to_string(),
+                teid: r.teid,
+            })
+        }
+    }
+}
+
+pub(crate) fn rd_to_api(rd: &RouteDistinguisher) -> api::RouteDistinguisher {
+    let v = match *rd {
+        RouteDistinguisher::TwoOctetAs { admin, assigned } => {
+            api::route_distinguisher::Rd::TwoOctetAsn(api::RouteDistinguisherTwoOctetAsn {
+                admin: admin as u32,
+                assigned,
+            })
+        }
+        RouteDistinguisher::Ipv4 { admin, assigned } => {
+            api::route_distinguisher::Rd::IpAddress(api::RouteDistinguisherIpAddress {
+                admin: admin.to_string(),
+                assigned: assigned as u32,
+            })
+        }
+        RouteDistinguisher::FourOctetAs { admin, assigned } => {
+            api::route_distinguisher::Rd::FourOctetAsn(api::RouteDistinguisherFourOctetAsn {
+                admin,
+                assigned: assigned as u32,
+            })
+        }
+    };
+    api::RouteDistinguisher { rd: Some(v) }
+}
+
+pub(crate) fn rd_from_api(rd: &api::RouteDistinguisher) -> Result<RouteDistinguisher, Error> {
+    let inner = rd
+        .rd
+        .as_ref()
+        .ok_or_else(|| Error::InvalidArgument("missing route distinguisher".to_string()))?;
+    match inner {
+        api::route_distinguisher::Rd::TwoOctetAsn(r) => {
+            if r.admin > u16::MAX as u32 {
+                return Err(Error::InvalidArgument(format!(
+                    "two-octet RD admin out of range: {}",
+                    r.admin
+                )));
+            }
+            Ok(RouteDistinguisher::TwoOctetAs {
+                admin: r.admin as u16,
+                assigned: r.assigned,
+            })
+        }
+        api::route_distinguisher::Rd::IpAddress(r) => {
+            let admin = r
+                .admin
+                .parse::<Ipv4Addr>()
+                .map_err(|e| Error::InvalidArgument(format!("invalid RD IPv4 admin: {}", e)))?;
+            if r.assigned > u16::MAX as u32 {
+                return Err(Error::InvalidArgument(format!(
+                    "ipv4 RD assigned out of range: {}",
+                    r.assigned
+                )));
+            }
+            Ok(RouteDistinguisher::Ipv4 {
+                admin,
+                assigned: r.assigned as u16,
+            })
+        }
+        api::route_distinguisher::Rd::FourOctetAsn(r) => {
+            if r.assigned > u16::MAX as u32 {
+                return Err(Error::InvalidArgument(format!(
+                    "four-octet RD assigned out of range: {}",
+                    r.assigned
+                )));
+            }
+            Ok(RouteDistinguisher::FourOctetAs {
+                admin: r.admin,
+                assigned: r.assigned as u16,
+            })
+        }
     }
 }
 
@@ -469,6 +595,8 @@ pub(crate) fn family_from_config(f: &config::generate::AfiSafiType) -> Result<Fa
     match f {
         config::generate::AfiSafiType::Ipv4Unicast => Ok(Family::IPV4),
         config::generate::AfiSafiType::Ipv6Unicast => Ok(Family::IPV6),
+        config::generate::AfiSafiType::Ipv4Mup => Ok(Family::IPV4_MUP),
+        config::generate::AfiSafiType::Ipv6Mup => Ok(Family::IPV6_MUP),
         _ => Err(()),
     }
 }
@@ -479,8 +607,108 @@ pub(crate) fn net_from_api(n: api::Nlri) -> Result<Nlri, Error> {
             Nlri::from_str(&format!("{}/{}", p.prefix, p.prefix_len))
                 .map_err(|e| Error::InvalidArgument(e.to_string()))
         }
+        Some(api::nlri::Nlri::MupInterworkSegmentDiscovery(r)) => {
+            let rd = rd_from_api(
+                r.rd.as_ref()
+                    .ok_or_else(|| Error::InvalidArgument("missing rd".to_string()))?,
+            )?;
+            let (addr, bits) = parse_prefix(&r.prefix)?;
+            Ok(Nlri::Mup(mup::MupNlri::InterworkSegmentDiscovery(
+                mup::MupInterworkSegmentDiscoveryRoute {
+                    rd,
+                    prefix_addr: addr,
+                    prefix_len: bits,
+                },
+            )))
+        }
+        Some(api::nlri::Nlri::MupDirectSegmentDiscovery(r)) => {
+            let rd = rd_from_api(
+                r.rd.as_ref()
+                    .ok_or_else(|| Error::InvalidArgument("missing rd".to_string()))?,
+            )?;
+            let address = r
+                .address
+                .parse::<std::net::IpAddr>()
+                .map_err(|e| Error::InvalidArgument(format!("invalid mup address: {}", e)))?;
+            Ok(Nlri::Mup(mup::MupNlri::DirectSegmentDiscovery(
+                mup::MupDirectSegmentDiscoveryRoute { rd, address },
+            )))
+        }
+        Some(api::nlri::Nlri::MupType1SessionTransformed(r)) => {
+            let rd = rd_from_api(
+                r.rd.as_ref()
+                    .ok_or_else(|| Error::InvalidArgument("missing rd".to_string()))?,
+            )?;
+            let (prefix_addr, prefix_len) = parse_prefix(&r.prefix)?;
+            let endpoint_address = r
+                .endpoint_address
+                .parse::<std::net::IpAddr>()
+                .map_err(|e| Error::InvalidArgument(format!("invalid mup endpoint: {}", e)))?;
+            let source_address =
+                if r.source_address_length == 0 || r.source_address.is_empty() {
+                    None
+                } else {
+                    Some(r.source_address.parse::<std::net::IpAddr>().map_err(|e| {
+                        Error::InvalidArgument(format!("invalid mup source: {}", e))
+                    })?)
+                };
+            if r.qfi > u8::MAX as u32 {
+                return Err(Error::InvalidArgument(format!(
+                    "qfi out of range: {}",
+                    r.qfi
+                )));
+            }
+            Ok(Nlri::Mup(mup::MupNlri::Type1SessionTransformed(
+                mup::MupType1SessionTransformedRoute {
+                    rd,
+                    prefix_addr,
+                    prefix_len,
+                    teid: r.teid,
+                    qfi: r.qfi as u8,
+                    endpoint_address,
+                    source_address,
+                },
+            )))
+        }
+        Some(api::nlri::Nlri::MupType2SessionTransformed(r)) => {
+            let rd = rd_from_api(
+                r.rd.as_ref()
+                    .ok_or_else(|| Error::InvalidArgument("missing rd".to_string()))?,
+            )?;
+            let endpoint_address = r
+                .endpoint_address
+                .parse::<std::net::IpAddr>()
+                .map_err(|e| Error::InvalidArgument(format!("invalid mup endpoint: {}", e)))?;
+            if r.endpoint_address_length > u8::MAX as u32 {
+                return Err(Error::InvalidArgument(format!(
+                    "endpoint_address_length out of range: {}",
+                    r.endpoint_address_length
+                )));
+            }
+            Ok(Nlri::Mup(mup::MupNlri::Type2SessionTransformed(
+                mup::MupType2SessionTransformedRoute {
+                    rd,
+                    endpoint_address_length: r.endpoint_address_length as u8,
+                    endpoint_address,
+                    teid: r.teid,
+                },
+            )))
+        }
         _ => Err(Error::InvalidArgument("invalid NLRI".to_string())),
     }
+}
+
+fn parse_prefix(s: &str) -> Result<(std::net::IpAddr, u8), Error> {
+    let (addr_str, len_str) = s
+        .rsplit_once('/')
+        .ok_or_else(|| Error::InvalidArgument(format!("missing prefix length: {}", s)))?;
+    let addr = addr_str
+        .parse::<std::net::IpAddr>()
+        .map_err(|e| Error::InvalidArgument(format!("invalid prefix: {}", e)))?;
+    let len: u8 = len_str
+        .parse()
+        .map_err(|e| Error::InvalidArgument(format!("invalid prefix length: {}", e)))?;
+    Ok((addr, len))
 }
 
 pub(crate) fn attr_from_api(a: api::Attribute) -> Result<Attribute, Error> {

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -606,10 +606,7 @@ impl TryFrom<&config::Neighbor> for Peer {
             .filter(|x| {
                 let name = x.config.as_ref().and_then(|c| c.afi_safi_name.as_ref());
                 let Some(f) = name else { return false };
-                if (f == &config::generate::AfiSafiType::Ipv4Unicast
-                    || f == &config::generate::AfiSafiType::Ipv6Unicast)
-                    && let Ok(family) = convert::family_from_config(f)
-                {
+                if let Ok(family) = convert::family_from_config(f) {
                     families.push(family);
                 }
                 true

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -3367,6 +3367,8 @@ fn send_kernel_route(change: &table::Change) {
     let (dst, prefix_len) = match change.net {
         packet::Nlri::V4(net) => (IpAddr::from(net.addr), net.mask),
         packet::Nlri::V6(net) => (IpAddr::from(net.addr), net.mask),
+        // MUP NLRI do not map to kernel routes; skip them here.
+        packet::Nlri::Mup(_) => return,
     };
     if change.attr.is_empty() {
         let _ = tx.send(KernelRouteEvent::Withdraw { dst, prefix_len });

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -176,6 +176,7 @@ impl fmt::Display for IpNet {
 pub enum Nlri {
     V4(Ipv4Net),
     V6(Ipv6Net),
+    Mup(crate::mup::MupNlri),
     // add more Family here
 }
 
@@ -184,6 +185,7 @@ impl Nlri {
         match self {
             Nlri::V4(net) => net.encode(dst),
             Nlri::V6(net) => net.encode(dst),
+            Nlri::Mup(m) => Ok(m.encode(dst)),
         }
     }
 
@@ -192,6 +194,9 @@ impl Nlri {
         match family {
             Family::IPV4 => Ipv4Net::decode(c, len).map(Nlri::V4),
             Family::IPV6 => Ipv6Net::decode(c, len).map(Nlri::V6),
+            Family::IPV4_MUP | Family::IPV6_MUP => {
+                crate::mup::MupNlri::decode(family, c, len).map(Nlri::Mup)
+            }
             _ => Err(BgpError::UpdateMalformedAttributeList.into()),
         }
     }
@@ -216,6 +221,7 @@ impl fmt::Display for Nlri {
         match self {
             Nlri::V4(net) => net.fmt(f),
             Nlri::V6(net) => net.fmt(f),
+            Nlri::Mup(m) => m.fmt(f),
         }
     }
 }

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -33,10 +33,13 @@ impl Family {
     pub const AFI_IP6: u16 = 2;
 
     const SAFI_UNICAST: u8 = 1;
+    const SAFI_MUP: u8 = 85;
 
     pub const EMPTY: Family = Family(0);
     pub const IPV4: Family = Family((Family::AFI_IP as u32) << 16 | Family::SAFI_UNICAST as u32);
     pub const IPV6: Family = Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_UNICAST as u32);
+    pub const IPV4_MUP: Family = Family((Family::AFI_IP as u32) << 16 | Family::SAFI_MUP as u32);
+    pub const IPV6_MUP: Family = Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_MUP as u32);
 
     pub fn new(v: u32) -> Self {
         Family(v)

--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -24,6 +24,7 @@ pub mod bmp;
 pub mod error;
 pub mod frame;
 pub mod mrt;
+pub mod mup;
 pub mod prefix_sid;
 pub mod rd;
 pub mod rpki;

--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -25,4 +25,5 @@ pub mod error;
 pub mod frame;
 pub mod mrt;
 pub mod prefix_sid;
+pub mod rd;
 pub mod rpki;

--- a/packet/src/mup.rs
+++ b/packet/src/mup.rs
@@ -1,0 +1,705 @@
+// Copyright (C) 2019-2026 The RustyBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! BGP-MUP SAFI (SAFI=85) route encoding per draft-ietf-bess-mup-safi-00.
+//! Implements Architecture Type 1 (3GPP-5G) and route types 1..4.
+
+use crate::bgp::Family;
+use crate::error::{BgpError, Error};
+use crate::rd::RouteDistinguisher;
+use byteorder::{ByteOrder, NetworkEndian};
+use bytes::BufMut;
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+pub const ARCH_TYPE_3GPP_5G: u8 = 1;
+
+pub const ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY: u16 = 1;
+pub const ROUTE_TYPE_DIRECT_SEGMENT_DISCOVERY: u16 = 2;
+pub const ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED: u16 = 3;
+pub const ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED: u16 = 4;
+
+/// BGP-MUP Extended Community type (`0x0c`, transitive).
+pub const EC_TYPE_MUP: u8 = 0x0c;
+/// Sub-type for the Direct-Type Segment Identifier Extended Community.
+pub const EC_SUBTYPE_MUP_DIRECT_SEG: u8 = 0x00;
+
+fn malformed() -> Error {
+    BgpError::UpdateMalformedAttributeList.into()
+}
+
+fn addr_bit_len(family: Family) -> Result<u8, Error> {
+    match family.afi() {
+        Family::AFI_IP => Ok(32),
+        Family::AFI_IP6 => Ok(128),
+        _ => Err(malformed()),
+    }
+}
+
+fn decode_ip(family: Family, bytes: &[u8]) -> Result<IpAddr, Error> {
+    match (family.afi(), bytes.len()) {
+        (Family::AFI_IP, 4) => Ok(IpAddr::V4(Ipv4Addr::new(
+            bytes[0], bytes[1], bytes[2], bytes[3],
+        ))),
+        (Family::AFI_IP6, 16) => {
+            let mut arr = [0u8; 16];
+            arr.copy_from_slice(bytes);
+            Ok(IpAddr::V6(Ipv6Addr::from(arr)))
+        }
+        _ => Err(malformed()),
+    }
+}
+
+fn decode_prefix(family: Family, bit_len: u8, bytes: &[u8]) -> Result<IpAddr, Error> {
+    let max_bits = addr_bit_len(family)?;
+    if bit_len > max_bits {
+        return Err(malformed());
+    }
+    let byte_len = bit_len.div_ceil(8) as usize;
+    if bytes.len() < byte_len {
+        return Err(malformed());
+    }
+    match family.afi() {
+        Family::AFI_IP => {
+            let mut arr = [0u8; 4];
+            arr[..byte_len].copy_from_slice(&bytes[..byte_len]);
+            Ok(IpAddr::V4(Ipv4Addr::from(arr)))
+        }
+        Family::AFI_IP6 => {
+            let mut arr = [0u8; 16];
+            arr[..byte_len].copy_from_slice(&bytes[..byte_len]);
+            Ok(IpAddr::V6(Ipv6Addr::from(arr)))
+        }
+        _ => Err(malformed()),
+    }
+}
+
+fn encode_prefix<B: BufMut>(dst: &mut B, addr: IpAddr, bit_len: u8) {
+    let byte_len = bit_len.div_ceil(8) as usize;
+    match addr {
+        IpAddr::V4(a) => dst.put_slice(&a.octets()[..byte_len.min(4)]),
+        IpAddr::V6(a) => dst.put_slice(&a.octets()[..byte_len.min(16)]),
+    }
+}
+
+fn ip_octets(addr: IpAddr) -> Vec<u8> {
+    match addr {
+        IpAddr::V4(a) => a.octets().to_vec(),
+        IpAddr::V6(a) => a.octets().to_vec(),
+    }
+}
+
+/// A single BGP-MUP NLRI, parameterised by address family (IPv4-MUP or IPv6-MUP).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MupNlri {
+    InterworkSegmentDiscovery(MupInterworkSegmentDiscoveryRoute),
+    DirectSegmentDiscovery(MupDirectSegmentDiscoveryRoute),
+    Type1SessionTransformed(MupType1SessionTransformedRoute),
+    Type2SessionTransformed(MupType2SessionTransformedRoute),
+}
+
+/// Route Type 1: Interwork Segment Discovery Route.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MupInterworkSegmentDiscoveryRoute {
+    pub rd: RouteDistinguisher,
+    pub prefix_addr: IpAddr,
+    pub prefix_len: u8,
+}
+
+/// Route Type 2: Direct Segment Discovery Route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MupDirectSegmentDiscoveryRoute {
+    pub rd: RouteDistinguisher,
+    pub address: IpAddr,
+}
+
+/// Route Type 3: Type 1 Session Transformed Route (3GPP-5G).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MupType1SessionTransformedRoute {
+    pub rd: RouteDistinguisher,
+    pub prefix_addr: IpAddr,
+    pub prefix_len: u8,
+    pub teid: u32,
+    pub qfi: u8,
+    pub endpoint_address: IpAddr,
+    pub source_address: Option<IpAddr>,
+}
+
+/// Route Type 4: Type 2 Session Transformed Route (3GPP-5G).
+/// `endpoint_address_length` is the total bit length of the endpoint IP
+/// and the trailing (possibly truncated) TEID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MupType2SessionTransformedRoute {
+    pub rd: RouteDistinguisher,
+    pub endpoint_address_length: u8,
+    pub endpoint_address: IpAddr,
+    pub teid: u32,
+}
+
+impl MupNlri {
+    /// Decode a single MUP NLRI starting at the current position of `data`.
+    /// Returns the NLRI and the number of bytes consumed.
+    pub fn decode(family: Family, data: &[u8]) -> Result<(Self, usize), Error> {
+        if data.len() < 4 {
+            return Err(malformed());
+        }
+        let arch_type = data[0];
+        if arch_type != ARCH_TYPE_3GPP_5G {
+            return Err(malformed());
+        }
+        let route_type = NetworkEndian::read_u16(&data[1..3]);
+        let length = data[3] as usize;
+        let total = 4 + length;
+        if data.len() < total {
+            return Err(malformed());
+        }
+        let body = &data[4..total];
+        let nlri = match route_type {
+            ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY => MupNlri::InterworkSegmentDiscovery(
+                MupInterworkSegmentDiscoveryRoute::decode(family, body)?,
+            ),
+            ROUTE_TYPE_DIRECT_SEGMENT_DISCOVERY => MupNlri::DirectSegmentDiscovery(
+                MupDirectSegmentDiscoveryRoute::decode(family, body)?,
+            ),
+            ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED => MupNlri::Type1SessionTransformed(
+                MupType1SessionTransformedRoute::decode(family, body)?,
+            ),
+            ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED => MupNlri::Type2SessionTransformed(
+                MupType2SessionTransformedRoute::decode(family, body)?,
+            ),
+            _ => return Err(malformed()),
+        };
+        Ok((nlri, total))
+    }
+
+    pub fn encode<B: BufMut>(&self, dst: &mut B) {
+        let (route_type, body) = match self {
+            MupNlri::InterworkSegmentDiscovery(r) => {
+                (ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY, r.serialize())
+            }
+            MupNlri::DirectSegmentDiscovery(r) => {
+                (ROUTE_TYPE_DIRECT_SEGMENT_DISCOVERY, r.serialize())
+            }
+            MupNlri::Type1SessionTransformed(r) => {
+                (ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED, r.serialize())
+            }
+            MupNlri::Type2SessionTransformed(r) => {
+                (ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED, r.serialize())
+            }
+        };
+        dst.put_u8(ARCH_TYPE_3GPP_5G);
+        dst.put_u16(route_type);
+        dst.put_u8(body.len() as u8);
+        dst.put_slice(&body);
+    }
+
+    pub fn route_type(&self) -> u16 {
+        match self {
+            MupNlri::InterworkSegmentDiscovery(_) => ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY,
+            MupNlri::DirectSegmentDiscovery(_) => ROUTE_TYPE_DIRECT_SEGMENT_DISCOVERY,
+            MupNlri::Type1SessionTransformed(_) => ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED,
+            MupNlri::Type2SessionTransformed(_) => ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED,
+        }
+    }
+}
+
+impl fmt::Display for MupNlri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MupNlri::InterworkSegmentDiscovery(r) => {
+                write!(
+                    f,
+                    "[type:isd][rd:{}][prefix:{}/{}]",
+                    r.rd, r.prefix_addr, r.prefix_len
+                )
+            }
+            MupNlri::DirectSegmentDiscovery(r) => {
+                write!(f, "[type:dsd][rd:{}][address:{}]", r.rd, r.address)
+            }
+            MupNlri::Type1SessionTransformed(r) => {
+                write!(
+                    f,
+                    "[type:t1st][rd:{}][prefix:{}/{}][teid:{}][qfi:{}][endpoint:{}]",
+                    r.rd, r.prefix_addr, r.prefix_len, r.teid, r.qfi, r.endpoint_address
+                )?;
+                if let Some(src) = r.source_address {
+                    write!(f, "[source:{}]", src)?;
+                }
+                Ok(())
+            }
+            MupNlri::Type2SessionTransformed(r) => write!(
+                f,
+                "[type:t2st][rd:{}][endpoint-length:{}][endpoint:{}][teid:{}]",
+                r.rd, r.endpoint_address_length, r.endpoint_address, r.teid
+            ),
+        }
+    }
+}
+
+impl MupInterworkSegmentDiscoveryRoute {
+    fn decode(family: Family, data: &[u8]) -> Result<Self, Error> {
+        if data.len() < RouteDistinguisher::LEN + 1 {
+            return Err(malformed());
+        }
+        let rd = RouteDistinguisher::decode(&data[..RouteDistinguisher::LEN])?;
+        let prefix_len = data[RouteDistinguisher::LEN];
+        let byte_len = prefix_len.div_ceil(8) as usize;
+        let rest = &data[RouteDistinguisher::LEN + 1..];
+        if rest.len() < byte_len {
+            return Err(malformed());
+        }
+        let prefix_addr = decode_prefix(family, prefix_len, rest)?;
+        Ok(Self {
+            rd,
+            prefix_addr,
+            prefix_len,
+        })
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.rd.encode(&mut buf);
+        buf.put_u8(self.prefix_len);
+        encode_prefix(&mut buf, self.prefix_addr, self.prefix_len);
+        buf
+    }
+}
+
+impl MupDirectSegmentDiscoveryRoute {
+    fn decode(family: Family, data: &[u8]) -> Result<Self, Error> {
+        if data.len() < RouteDistinguisher::LEN {
+            return Err(malformed());
+        }
+        let rd = RouteDistinguisher::decode(&data[..RouteDistinguisher::LEN])?;
+        let rest = &data[RouteDistinguisher::LEN..];
+        let address = decode_ip(family, rest)?;
+        Ok(Self { rd, address })
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.rd.encode(&mut buf);
+        buf.extend_from_slice(&ip_octets(self.address));
+        buf
+    }
+}
+
+impl MupType1SessionTransformedRoute {
+    fn decode(family: Family, data: &[u8]) -> Result<Self, Error> {
+        let rd_end = RouteDistinguisher::LEN;
+        if data.len() < rd_end + 1 {
+            return Err(malformed());
+        }
+        let rd = RouteDistinguisher::decode(&data[..rd_end])?;
+        let prefix_len = data[rd_end];
+        let prefix_bytes = prefix_len.div_ceil(8) as usize;
+        let after_prefix = rd_end + 1 + prefix_bytes;
+        if data.len() < after_prefix + 4 + 1 + 1 {
+            return Err(malformed());
+        }
+        let prefix_addr = decode_prefix(family, prefix_len, &data[rd_end + 1..])?;
+        let teid = NetworkEndian::read_u32(&data[after_prefix..after_prefix + 4]);
+        let qfi = data[after_prefix + 4];
+        let ea_len = data[after_prefix + 5];
+        let max_bits = addr_bit_len(family)?;
+        if ea_len != max_bits {
+            return Err(malformed());
+        }
+        let ea_bytes = (ea_len / 8) as usize;
+        let ea_start = after_prefix + 6;
+        if data.len() < ea_start + ea_bytes + 1 {
+            return Err(malformed());
+        }
+        let endpoint_address = decode_ip(family, &data[ea_start..ea_start + ea_bytes])?;
+        let sa_len_pos = ea_start + ea_bytes;
+        let sa_len = data[sa_len_pos];
+        let source_address = if sa_len == 0 {
+            None
+        } else {
+            if sa_len != max_bits {
+                return Err(malformed());
+            }
+            let sa_bytes = (sa_len / 8) as usize;
+            let sa_start = sa_len_pos + 1;
+            if data.len() < sa_start + sa_bytes {
+                return Err(malformed());
+            }
+            Some(decode_ip(family, &data[sa_start..sa_start + sa_bytes])?)
+        };
+        Ok(Self {
+            rd,
+            prefix_addr,
+            prefix_len,
+            teid,
+            qfi,
+            endpoint_address,
+            source_address,
+        })
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.rd.encode(&mut buf);
+        buf.put_u8(self.prefix_len);
+        encode_prefix(&mut buf, self.prefix_addr, self.prefix_len);
+        buf.put_u32(self.teid);
+        buf.put_u8(self.qfi);
+        let ea_bits = match self.endpoint_address {
+            IpAddr::V4(_) => 32,
+            IpAddr::V6(_) => 128,
+        };
+        buf.put_u8(ea_bits);
+        buf.extend_from_slice(&ip_octets(self.endpoint_address));
+        match self.source_address {
+            None => buf.put_u8(0),
+            Some(sa) => {
+                let bits = match sa {
+                    IpAddr::V4(_) => 32,
+                    IpAddr::V6(_) => 128,
+                };
+                buf.put_u8(bits);
+                buf.extend_from_slice(&ip_octets(sa));
+            }
+        }
+        buf
+    }
+}
+
+impl MupType2SessionTransformedRoute {
+    fn decode(family: Family, data: &[u8]) -> Result<Self, Error> {
+        let rd_end = RouteDistinguisher::LEN;
+        if data.len() < rd_end + 1 {
+            return Err(malformed());
+        }
+        let rd = RouteDistinguisher::decode(&data[..rd_end])?;
+        let ea_len = data[rd_end];
+        let ip_bits = addr_bit_len(family)?;
+        if ea_len < ip_bits || ea_len > ip_bits + 32 {
+            return Err(malformed());
+        }
+        let ip_bytes = (ip_bits / 8) as usize;
+        let ip_start = rd_end + 1;
+        if data.len() < ip_start + ip_bytes {
+            return Err(malformed());
+        }
+        let endpoint_address = decode_ip(family, &data[ip_start..ip_start + ip_bytes])?;
+        let teid_bits = ea_len - ip_bits;
+        let teid_bytes = teid_bits.div_ceil(8) as usize;
+        let teid_start = ip_start + ip_bytes;
+        if data.len() < teid_start + teid_bytes {
+            return Err(malformed());
+        }
+        let mut teid_buf = [0u8; 4];
+        teid_buf[..teid_bytes].copy_from_slice(&data[teid_start..teid_start + teid_bytes]);
+        let teid = NetworkEndian::read_u32(&teid_buf);
+        Ok(Self {
+            rd,
+            endpoint_address_length: ea_len,
+            endpoint_address,
+            teid,
+        })
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.rd.encode(&mut buf);
+        buf.put_u8(self.endpoint_address_length);
+        buf.extend_from_slice(&ip_octets(self.endpoint_address));
+        let ip_bits = match self.endpoint_address {
+            IpAddr::V4(_) => 32,
+            IpAddr::V6(_) => 128,
+        };
+        let teid_bits = self.endpoint_address_length.saturating_sub(ip_bits);
+        let teid_bytes = teid_bits.div_ceil(8) as usize;
+        let teid_be = self.teid.to_be_bytes();
+        buf.extend_from_slice(&teid_be[..teid_bytes]);
+        buf
+    }
+}
+
+/// BGP-MUP Extended Community (draft-ietf-bess-mup-safi §3.2). 8 octets on
+/// the wire: `[type=0x0c][sub_type][segment_id2:2][segment_id4:4]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MupExtended {
+    pub sub_type: u8,
+    pub segment_id2: u16,
+    pub segment_id4: u32,
+}
+
+impl MupExtended {
+    pub const LEN: usize = 8;
+
+    pub fn decode(data: &[u8]) -> Result<Self, Error> {
+        if data.len() != Self::LEN {
+            return Err(malformed());
+        }
+        if data[0] != EC_TYPE_MUP {
+            return Err(malformed());
+        }
+        Ok(Self {
+            sub_type: data[1],
+            segment_id2: NetworkEndian::read_u16(&data[2..4]),
+            segment_id4: NetworkEndian::read_u32(&data[4..8]),
+        })
+    }
+
+    pub fn encode<B: BufMut>(&self, dst: &mut B) {
+        dst.put_u8(EC_TYPE_MUP);
+        dst.put_u8(self.sub_type);
+        dst.put_u16(self.segment_id2);
+        dst.put_u32(self.segment_id4);
+    }
+}
+
+impl fmt::Display for MupExtended {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.segment_id2, self.segment_id4)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rd() -> RouteDistinguisher {
+        RouteDistinguisher::TwoOctetAs {
+            admin: 100,
+            assigned: 200,
+        }
+    }
+
+    fn roundtrip(family: Family, nlri: MupNlri) {
+        let mut buf = Vec::new();
+        nlri.encode(&mut buf);
+        let (decoded, consumed) = MupNlri::decode(family, &buf).unwrap();
+        assert_eq!(consumed, buf.len());
+        assert_eq!(decoded, nlri);
+    }
+
+    #[test]
+    fn isd_ipv4_roundtrip() {
+        roundtrip(
+            Family::IPV4_MUP,
+            MupNlri::InterworkSegmentDiscovery(MupInterworkSegmentDiscoveryRoute {
+                rd: rd(),
+                prefix_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)),
+                prefix_len: 24,
+            }),
+        );
+    }
+
+    #[test]
+    fn isd_ipv6_roundtrip() {
+        roundtrip(
+            Family::IPV6_MUP,
+            MupNlri::InterworkSegmentDiscovery(MupInterworkSegmentDiscoveryRoute {
+                rd: rd(),
+                prefix_addr: IpAddr::V6("2001:db8::".parse().unwrap()),
+                prefix_len: 32,
+            }),
+        );
+    }
+
+    #[test]
+    fn dsd_ipv4_roundtrip() {
+        roundtrip(
+            Family::IPV4_MUP,
+            MupNlri::DirectSegmentDiscovery(MupDirectSegmentDiscoveryRoute {
+                rd: rd(),
+                address: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            }),
+        );
+    }
+
+    #[test]
+    fn dsd_ipv6_roundtrip() {
+        roundtrip(
+            Family::IPV6_MUP,
+            MupNlri::DirectSegmentDiscovery(MupDirectSegmentDiscoveryRoute {
+                rd: rd(),
+                address: IpAddr::V6("2001:db8::1".parse().unwrap()),
+            }),
+        );
+    }
+
+    #[test]
+    fn t1st_ipv4_with_source() {
+        roundtrip(
+            Family::IPV4_MUP,
+            MupNlri::Type1SessionTransformed(MupType1SessionTransformedRoute {
+                rd: rd(),
+                prefix_addr: IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+                prefix_len: 32,
+                teid: 12345,
+                qfi: 9,
+                endpoint_address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                source_address: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))),
+            }),
+        );
+    }
+
+    #[test]
+    fn t1st_ipv4_without_source() {
+        roundtrip(
+            Family::IPV4_MUP,
+            MupNlri::Type1SessionTransformed(MupType1SessionTransformedRoute {
+                rd: rd(),
+                prefix_addr: IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+                prefix_len: 32,
+                teid: 12345,
+                qfi: 9,
+                endpoint_address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                source_address: None,
+            }),
+        );
+    }
+
+    #[test]
+    fn t1st_ipv6_with_source() {
+        roundtrip(
+            Family::IPV6_MUP,
+            MupNlri::Type1SessionTransformed(MupType1SessionTransformedRoute {
+                rd: rd(),
+                prefix_addr: IpAddr::V6("2001:db8::1".parse().unwrap()),
+                prefix_len: 128,
+                teid: 42,
+                qfi: 5,
+                endpoint_address: IpAddr::V6("2001:db8::2".parse().unwrap()),
+                source_address: Some(IpAddr::V6("2001:db8::3".parse().unwrap())),
+            }),
+        );
+    }
+
+    #[test]
+    fn t2st_ipv4_full_teid() {
+        // endpoint length = 32 (IP) + 32 (TEID) = 64 bits
+        roundtrip(
+            Family::IPV4_MUP,
+            MupNlri::Type2SessionTransformed(MupType2SessionTransformedRoute {
+                rd: rd(),
+                endpoint_address_length: 64,
+                endpoint_address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                teid: 0xDEADBEEF,
+            }),
+        );
+    }
+
+    #[test]
+    fn t2st_ipv4_truncated_teid() {
+        // endpoint length = 32 (IP) + 16 (TEID upper bits) = 48 bits
+        // teid = 0xAABB0000 encoded as [0xaa, 0xbb]
+        roundtrip(
+            Family::IPV4_MUP,
+            MupNlri::Type2SessionTransformed(MupType2SessionTransformedRoute {
+                rd: rd(),
+                endpoint_address_length: 48,
+                endpoint_address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                teid: 0xAABB_0000,
+            }),
+        );
+    }
+
+    #[test]
+    fn t2st_ipv4_no_teid() {
+        roundtrip(
+            Family::IPV4_MUP,
+            MupNlri::Type2SessionTransformed(MupType2SessionTransformedRoute {
+                rd: rd(),
+                endpoint_address_length: 32,
+                endpoint_address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                teid: 0,
+            }),
+        );
+    }
+
+    #[test]
+    fn t2st_ipv6_full_teid() {
+        roundtrip(
+            Family::IPV6_MUP,
+            MupNlri::Type2SessionTransformed(MupType2SessionTransformedRoute {
+                rd: rd(),
+                endpoint_address_length: 160,
+                endpoint_address: IpAddr::V6("2001:db8::1".parse().unwrap()),
+                teid: 0x01020304,
+            }),
+        );
+    }
+
+    #[test]
+    fn decode_rejects_wrong_arch_type() {
+        let data = [0x02u8, 0x00, 0x01, 0x00];
+        assert!(MupNlri::decode(Family::IPV4_MUP, &data).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_unknown_route_type() {
+        let data = [0x01u8, 0x00, 0x05, 0x00];
+        assert!(MupNlri::decode(Family::IPV4_MUP, &data).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_truncated() {
+        // header claims length=10 but body is empty
+        let data = [0x01u8, 0x00, 0x01, 0x0a];
+        assert!(MupNlri::decode(Family::IPV4_MUP, &data).is_err());
+    }
+
+    #[test]
+    fn mup_extended_roundtrip() {
+        let ec = MupExtended {
+            sub_type: EC_SUBTYPE_MUP_DIRECT_SEG,
+            segment_id2: 10,
+            segment_id4: 20,
+        };
+        let mut buf = Vec::new();
+        ec.encode(&mut buf);
+        assert_eq!(buf.len(), MupExtended::LEN);
+        assert_eq!(buf, vec![0x0c, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x14]);
+        assert_eq!(MupExtended::decode(&buf).unwrap(), ec);
+    }
+
+    #[test]
+    fn mup_extended_rejects_wrong_type() {
+        let bad = [0x06u8, 0x00, 0, 0, 0, 0, 0, 0];
+        assert!(MupExtended::decode(&bad).is_err());
+    }
+
+    #[test]
+    fn isd_ipv4_wire_format() {
+        // Arch=1, RT=1, Len=13 => RD(8)+PLen(1)+Prefix(3 bytes for /24)
+        let nlri = MupNlri::InterworkSegmentDiscovery(MupInterworkSegmentDiscoveryRoute {
+            rd: RouteDistinguisher::TwoOctetAs {
+                admin: 100,
+                assigned: 200,
+            },
+            prefix_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)),
+            prefix_len: 24,
+        });
+        let mut buf = Vec::new();
+        nlri.encode(&mut buf);
+        // header(4) + RD(8) + PLen(1) + prefix(3) = 16
+        assert_eq!(buf.len(), 16);
+        assert_eq!(buf[0], 0x01); // arch 3gpp-5g
+        assert_eq!(&buf[1..3], &[0x00, 0x01]); // route type 1
+        assert_eq!(buf[3], 12); // body length
+        // RD TwoOctetAs 100:200
+        assert_eq!(
+            &buf[4..12],
+            &[0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0xc8]
+        );
+        assert_eq!(buf[12], 24); // prefix len bits
+        assert_eq!(&buf[13..16], &[10, 0, 0]);
+    }
+}

--- a/packet/src/mup.rs
+++ b/packet/src/mup.rs
@@ -22,6 +22,7 @@ use crate::rd::RouteDistinguisher;
 use byteorder::{ByteOrder, NetworkEndian};
 use bytes::BufMut;
 use std::fmt;
+use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 pub const ARCH_TYPE_3GPP_5G: u8 = 1;
@@ -102,7 +103,7 @@ fn ip_octets(addr: IpAddr) -> Vec<u8> {
 }
 
 /// A single BGP-MUP NLRI, parameterised by address family (IPv4-MUP or IPv6-MUP).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MupNlri {
     InterworkSegmentDiscovery(MupInterworkSegmentDiscoveryRoute),
     DirectSegmentDiscovery(MupDirectSegmentDiscoveryRoute),
@@ -111,7 +112,7 @@ pub enum MupNlri {
 }
 
 /// Route Type 1: Interwork Segment Discovery Route.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MupInterworkSegmentDiscoveryRoute {
     pub rd: RouteDistinguisher,
     pub prefix_addr: IpAddr,
@@ -126,7 +127,7 @@ pub struct MupDirectSegmentDiscoveryRoute {
 }
 
 /// Route Type 3: Type 1 Session Transformed Route (3GPP-5G).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MupType1SessionTransformedRoute {
     pub rd: RouteDistinguisher,
     pub prefix_addr: IpAddr,
@@ -149,42 +150,46 @@ pub struct MupType2SessionTransformedRoute {
 }
 
 impl MupNlri {
-    /// Decode a single MUP NLRI starting at the current position of `data`.
-    /// Returns the NLRI and the number of bytes consumed.
-    pub fn decode(family: Family, data: &[u8]) -> Result<(Self, usize), Error> {
-        if data.len() < 4 {
+    /// Decode a single MUP NLRI from `c`, consuming `4 + body_length` bytes.
+    /// `len` is the upper bound of bytes remaining in the enclosing buffer.
+    pub fn decode<T: io::Read>(family: Family, c: &mut T, len: usize) -> Result<Self, Error> {
+        if len < 4 {
             return Err(malformed());
         }
-        let arch_type = data[0];
+        let mut header = [0u8; 4];
+        c.read_exact(&mut header).map_err(|_| malformed())?;
+        let arch_type = header[0];
         if arch_type != ARCH_TYPE_3GPP_5G {
             return Err(malformed());
         }
-        let route_type = NetworkEndian::read_u16(&data[1..3]);
-        let length = data[3] as usize;
-        let total = 4 + length;
-        if data.len() < total {
+        let route_type = NetworkEndian::read_u16(&header[1..3]);
+        let body_len = header[3] as usize;
+        if len < 4 + body_len {
             return Err(malformed());
         }
-        let body = &data[4..total];
-        let nlri = match route_type {
-            ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY => MupNlri::InterworkSegmentDiscovery(
-                MupInterworkSegmentDiscoveryRoute::decode(family, body)?,
-            ),
-            ROUTE_TYPE_DIRECT_SEGMENT_DISCOVERY => MupNlri::DirectSegmentDiscovery(
-                MupDirectSegmentDiscoveryRoute::decode(family, body)?,
-            ),
-            ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED => MupNlri::Type1SessionTransformed(
-                MupType1SessionTransformedRoute::decode(family, body)?,
-            ),
-            ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED => MupNlri::Type2SessionTransformed(
-                MupType2SessionTransformedRoute::decode(family, body)?,
-            ),
-            _ => return Err(malformed()),
-        };
-        Ok((nlri, total))
+        let mut body = vec![0u8; body_len];
+        if body_len > 0 {
+            c.read_exact(&mut body).map_err(|_| malformed())?;
+        }
+        match route_type {
+            ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY => Ok(MupNlri::InterworkSegmentDiscovery(
+                MupInterworkSegmentDiscoveryRoute::decode(family, &body)?,
+            )),
+            ROUTE_TYPE_DIRECT_SEGMENT_DISCOVERY => Ok(MupNlri::DirectSegmentDiscovery(
+                MupDirectSegmentDiscoveryRoute::decode(family, &body)?,
+            )),
+            ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED => Ok(MupNlri::Type1SessionTransformed(
+                MupType1SessionTransformedRoute::decode(family, &body)?,
+            )),
+            ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED => Ok(MupNlri::Type2SessionTransformed(
+                MupType2SessionTransformedRoute::decode(family, &body)?,
+            )),
+            _ => Err(malformed()),
+        }
     }
 
-    pub fn encode<B: BufMut>(&self, dst: &mut B) {
+    /// Encode the NLRI (header + body) into `dst` and return the number of bytes written.
+    pub fn encode<B: BufMut>(&self, dst: &mut B) -> u16 {
         let (route_type, body) = match self {
             MupNlri::InterworkSegmentDiscovery(r) => {
                 (ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY, r.serialize())
@@ -203,6 +208,7 @@ impl MupNlri {
         dst.put_u16(route_type);
         dst.put_u8(body.len() as u8);
         dst.put_slice(&body);
+        (4 + body.len()) as u16
     }
 
     pub fn route_type(&self) -> u16 {
@@ -472,6 +478,7 @@ impl fmt::Display for MupExtended {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
 
     fn rd() -> RouteDistinguisher {
         RouteDistinguisher::TwoOctetAs {
@@ -483,9 +490,11 @@ mod tests {
     fn roundtrip(family: Family, nlri: MupNlri) {
         let mut buf = Vec::new();
         nlri.encode(&mut buf);
-        let (decoded, consumed) = MupNlri::decode(family, &buf).unwrap();
-        assert_eq!(consumed, buf.len());
+        let len = buf.len();
+        let mut c = Cursor::new(buf);
+        let decoded = MupNlri::decode(family, &mut c, len).unwrap();
         assert_eq!(decoded, nlri);
+        assert_eq!(c.position(), len as u64);
     }
 
     #[test]
@@ -637,23 +646,26 @@ mod tests {
         );
     }
 
+    fn decode_slice(family: Family, data: &[u8]) -> Result<MupNlri, Error> {
+        let len = data.len();
+        let mut c = Cursor::new(data);
+        MupNlri::decode(family, &mut c, len)
+    }
+
     #[test]
     fn decode_rejects_wrong_arch_type() {
-        let data = [0x02u8, 0x00, 0x01, 0x00];
-        assert!(MupNlri::decode(Family::IPV4_MUP, &data).is_err());
+        assert!(decode_slice(Family::IPV4_MUP, &[0x02u8, 0x00, 0x01, 0x00]).is_err());
     }
 
     #[test]
     fn decode_rejects_unknown_route_type() {
-        let data = [0x01u8, 0x00, 0x05, 0x00];
-        assert!(MupNlri::decode(Family::IPV4_MUP, &data).is_err());
+        assert!(decode_slice(Family::IPV4_MUP, &[0x01u8, 0x00, 0x05, 0x00]).is_err());
     }
 
     #[test]
     fn decode_rejects_truncated() {
         // header claims length=10 but body is empty
-        let data = [0x01u8, 0x00, 0x01, 0x0a];
-        assert!(MupNlri::decode(Family::IPV4_MUP, &data).is_err());
+        assert!(decode_slice(Family::IPV4_MUP, &[0x01u8, 0x00, 0x01, 0x0a]).is_err());
     }
 
     #[test]

--- a/packet/src/rd.rs
+++ b/packet/src/rd.rs
@@ -1,0 +1,255 @@
+// Copyright (C) 2019-2026 The RustyBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::{BgpError, Error};
+use byteorder::{ByteOrder, NetworkEndian};
+use bytes::BufMut;
+use std::fmt;
+use std::net::Ipv4Addr;
+use std::str::FromStr;
+
+/// Route Distinguisher (RFC 4364 §4.2). Eight-octet identifier that
+/// qualifies a VPN address so overlapping customer prefixes stay unique.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RouteDistinguisher {
+    /// Type 0: 2-octet AS : 4-octet assigned number.
+    TwoOctetAs { admin: u16, assigned: u32 },
+    /// Type 1: 4-octet IPv4 address : 2-octet assigned number.
+    Ipv4 { admin: Ipv4Addr, assigned: u16 },
+    /// Type 2: 4-octet AS : 2-octet assigned number.
+    FourOctetAs { admin: u32, assigned: u16 },
+}
+
+impl RouteDistinguisher {
+    pub const LEN: usize = 8;
+
+    const TYPE_TWO_OCTET_AS: u16 = 0;
+    const TYPE_IPV4: u16 = 1;
+    const TYPE_FOUR_OCTET_AS: u16 = 2;
+
+    pub fn decode(data: &[u8]) -> Result<Self, Error> {
+        let malformed: Error = BgpError::UpdateMalformedAttributeList.into();
+        if data.len() != Self::LEN {
+            return Err(malformed);
+        }
+        let rd_type = NetworkEndian::read_u16(&data[0..2]);
+        match rd_type {
+            Self::TYPE_TWO_OCTET_AS => Ok(RouteDistinguisher::TwoOctetAs {
+                admin: NetworkEndian::read_u16(&data[2..4]),
+                assigned: NetworkEndian::read_u32(&data[4..8]),
+            }),
+            Self::TYPE_IPV4 => Ok(RouteDistinguisher::Ipv4 {
+                admin: Ipv4Addr::new(data[2], data[3], data[4], data[5]),
+                assigned: NetworkEndian::read_u16(&data[6..8]),
+            }),
+            Self::TYPE_FOUR_OCTET_AS => Ok(RouteDistinguisher::FourOctetAs {
+                admin: NetworkEndian::read_u32(&data[2..6]),
+                assigned: NetworkEndian::read_u16(&data[6..8]),
+            }),
+            _ => Err(malformed),
+        }
+    }
+
+    pub fn encode<B: BufMut>(&self, dst: &mut B) {
+        match *self {
+            RouteDistinguisher::TwoOctetAs { admin, assigned } => {
+                dst.put_u16(Self::TYPE_TWO_OCTET_AS);
+                dst.put_u16(admin);
+                dst.put_u32(assigned);
+            }
+            RouteDistinguisher::Ipv4 { admin, assigned } => {
+                dst.put_u16(Self::TYPE_IPV4);
+                dst.put_slice(&admin.octets());
+                dst.put_u16(assigned);
+            }
+            RouteDistinguisher::FourOctetAs { admin, assigned } => {
+                dst.put_u16(Self::TYPE_FOUR_OCTET_AS);
+                dst.put_u32(admin);
+                dst.put_u16(assigned);
+            }
+        }
+    }
+}
+
+impl fmt::Display for RouteDistinguisher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RouteDistinguisher::TwoOctetAs { admin, assigned } => {
+                write!(f, "{}:{}", admin, assigned)
+            }
+            RouteDistinguisher::Ipv4 { admin, assigned } => write!(f, "{}:{}", admin, assigned),
+            RouteDistinguisher::FourOctetAs { admin, assigned } => {
+                write!(f, "{}:{}", admin, assigned)
+            }
+        }
+    }
+}
+
+impl FromStr for RouteDistinguisher {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        let malformed = || -> Error { BgpError::UpdateMalformedAttributeList.into() };
+        let (admin_str, assigned_str) = s.rsplit_once(':').ok_or_else(malformed)?;
+        if let Ok(addr) = admin_str.parse::<Ipv4Addr>() {
+            let assigned: u16 = assigned_str.parse().map_err(|_| malformed())?;
+            return Ok(RouteDistinguisher::Ipv4 {
+                admin: addr,
+                assigned,
+            });
+        }
+        let admin: u32 = admin_str.parse().map_err(|_| malformed())?;
+        if admin <= u16::MAX as u32 {
+            let assigned: u32 = assigned_str.parse().map_err(|_| malformed())?;
+            Ok(RouteDistinguisher::TwoOctetAs {
+                admin: admin as u16,
+                assigned,
+            })
+        } else {
+            let assigned: u16 = assigned_str.parse().map_err(|_| malformed())?;
+            Ok(RouteDistinguisher::FourOctetAs { admin, assigned })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(rd: RouteDistinguisher) {
+        let mut buf = Vec::with_capacity(RouteDistinguisher::LEN);
+        rd.encode(&mut buf);
+        assert_eq!(buf.len(), RouteDistinguisher::LEN);
+        let decoded = RouteDistinguisher::decode(&buf).unwrap();
+        assert_eq!(rd, decoded);
+    }
+
+    #[test]
+    fn rd_two_octet_as_roundtrip() {
+        roundtrip(RouteDistinguisher::TwoOctetAs {
+            admin: 65000,
+            assigned: 12345,
+        });
+    }
+
+    #[test]
+    fn rd_ipv4_roundtrip() {
+        roundtrip(RouteDistinguisher::Ipv4 {
+            admin: Ipv4Addr::new(192, 0, 2, 1),
+            assigned: 100,
+        });
+    }
+
+    #[test]
+    fn rd_four_octet_as_roundtrip() {
+        roundtrip(RouteDistinguisher::FourOctetAs {
+            admin: 4_200_000_000,
+            assigned: 7,
+        });
+    }
+
+    #[test]
+    fn rd_two_octet_as_wire_format() {
+        let rd = RouteDistinguisher::TwoOctetAs {
+            admin: 0x00fd,
+            assigned: 0x1234_5678,
+        };
+        let mut buf = Vec::new();
+        rd.encode(&mut buf);
+        assert_eq!(buf, vec![0x00, 0x00, 0x00, 0xfd, 0x12, 0x34, 0x56, 0x78]);
+    }
+
+    #[test]
+    fn rd_ipv4_wire_format() {
+        let rd = RouteDistinguisher::Ipv4 {
+            admin: Ipv4Addr::new(192, 0, 2, 1),
+            assigned: 0x00c8,
+        };
+        let mut buf = Vec::new();
+        rd.encode(&mut buf);
+        assert_eq!(buf, vec![0x00, 0x01, 192, 0, 2, 1, 0x00, 0xc8]);
+    }
+
+    #[test]
+    fn rd_four_octet_as_wire_format() {
+        let rd = RouteDistinguisher::FourOctetAs {
+            admin: 0x1234_5678,
+            assigned: 0x00c8,
+        };
+        let mut buf = Vec::new();
+        rd.encode(&mut buf);
+        assert_eq!(buf, vec![0x00, 0x02, 0x12, 0x34, 0x56, 0x78, 0x00, 0xc8]);
+    }
+
+    #[test]
+    fn rd_decode_rejects_unknown_type() {
+        assert!(RouteDistinguisher::decode(&[0x00, 0x03, 0, 0, 0, 0, 0, 0]).is_err());
+    }
+
+    #[test]
+    fn rd_decode_rejects_bad_length() {
+        assert!(RouteDistinguisher::decode(&[0x00, 0x00, 0, 0, 0, 0, 0]).is_err());
+        assert!(RouteDistinguisher::decode(&[0x00, 0x00, 0, 0, 0, 0, 0, 0, 0]).is_err());
+    }
+
+    #[test]
+    fn rd_from_str_two_octet_as() {
+        assert_eq!(
+            "100:200".parse::<RouteDistinguisher>().unwrap(),
+            RouteDistinguisher::TwoOctetAs {
+                admin: 100,
+                assigned: 200,
+            }
+        );
+    }
+
+    #[test]
+    fn rd_from_str_ipv4() {
+        assert_eq!(
+            "192.0.2.1:100".parse::<RouteDistinguisher>().unwrap(),
+            RouteDistinguisher::Ipv4 {
+                admin: Ipv4Addr::new(192, 0, 2, 1),
+                assigned: 100,
+            }
+        );
+    }
+
+    #[test]
+    fn rd_from_str_four_octet_as() {
+        assert_eq!(
+            "4200000000:7".parse::<RouteDistinguisher>().unwrap(),
+            RouteDistinguisher::FourOctetAs {
+                admin: 4_200_000_000,
+                assigned: 7,
+            }
+        );
+    }
+
+    #[test]
+    fn rd_from_str_display_roundtrip() {
+        for input in ["100:200", "192.0.2.1:100", "4200000000:7"] {
+            let rd: RouteDistinguisher = input.parse().unwrap();
+            assert_eq!(rd.to_string(), input);
+        }
+    }
+
+    #[test]
+    fn rd_from_str_rejects_garbage() {
+        assert!("".parse::<RouteDistinguisher>().is_err());
+        assert!("100".parse::<RouteDistinguisher>().is_err());
+        assert!("abc:def".parse::<RouteDistinguisher>().is_err());
+        assert!("100:99999999999".parse::<RouteDistinguisher>().is_err());
+    }
+}

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -16,7 +16,9 @@
 use rustybgp_packet::bgp::{
     Attribute, Ipv4Net, Ipv6Net, Message, Nexthop, NlriSet, PeerCodec, PeerCodecBuilder, Update,
 };
+use rustybgp_packet::mup;
 use rustybgp_packet::prefix_sid;
+use rustybgp_packet::rd::RouteDistinguisher;
 use rustybgp_packet::{BgpFramer, Family, Nlri, PathNlri};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
@@ -601,6 +603,211 @@ fn update_passes_through_unknown_prefix_sid_tlv() {
                 .find(|a| a.code() == Attribute::PREFIX_SID)
                 .expect("PREFIX_SID must be present");
             assert_eq!(a.binary().unwrap(), &sid_bytes);
+        }
+        _ => panic!("expected Update"),
+    }
+}
+
+// ─── MUP SAFI announce / withdraw ────────────────────────────────────────────
+
+fn ipv4_mup_codec() -> PeerCodec {
+    PeerCodecBuilder::new()
+        .local_asn(65001)
+        .keep_aspath(true)
+        .keep_nexthop(true)
+        .families(vec![Family::IPV4_MUP])
+        .build()
+}
+
+fn ipv6_mup_codec() -> PeerCodec {
+    PeerCodecBuilder::new()
+        .local_asn(65001)
+        .keep_aspath(true)
+        .keep_nexthop(true)
+        .families(vec![Family::IPV6_MUP])
+        .build()
+}
+
+fn mup_rd() -> RouteDistinguisher {
+    RouteDistinguisher::TwoOctetAs {
+        admin: 65000,
+        assigned: 100,
+    }
+}
+
+#[test]
+fn update_ipv4_mup_announce() {
+    let nlri = PathNlri::new(Nlri::Mup(mup::MupNlri::InterworkSegmentDiscovery(
+        mup::MupInterworkSegmentDiscoveryRoute {
+            rd: mup_rd(),
+            prefix_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)),
+            prefix_len: 24,
+        },
+    )));
+    let nexthop: Ipv4Addr = "10.0.0.1".parse().unwrap();
+    let msg = Message::Update(Update {
+        reach: None,
+        mp_reach: Some(NlriSet {
+            family: Family::IPV4_MUP,
+            entries: vec![nlri],
+        }),
+        attr: Arc::new(vec![
+            Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
+            Attribute::new_with_bin(
+                Attribute::AS_PATH,
+                vec![Attribute::AS_PATH_TYPE_SEQ, 1, 0x00, 0x00, 0xFD, 0xEA],
+            )
+            .unwrap(),
+            Attribute::new_with_bin(Attribute::NEXTHOP, nexthop.octets().to_vec()).unwrap(),
+        ]),
+        unreach: None,
+        mp_unreach: None,
+        nexthop: None,
+    });
+
+    match round_trip(&msg, ipv4_mup_codec()) {
+        Message::Update(Update {
+            mp_reach,
+            mp_unreach,
+            ..
+        }) => {
+            assert!(mp_unreach.is_none());
+            let s = mp_reach.unwrap();
+            assert_eq!(s.family, Family::IPV4_MUP);
+            assert_eq!(s.entries, vec![nlri]);
+        }
+        _ => panic!("expected Update"),
+    }
+}
+
+#[test]
+fn update_ipv6_mup_announce() {
+    let nlri = PathNlri::new(Nlri::Mup(mup::MupNlri::DirectSegmentDiscovery(
+        mup::MupDirectSegmentDiscoveryRoute {
+            rd: mup_rd(),
+            address: IpAddr::V6("2001:db8::1".parse().unwrap()),
+        },
+    )));
+    let nexthop_bytes: Vec<u8> = "2001:db8::1".parse::<Ipv6Addr>().unwrap().octets().to_vec();
+    let msg = Message::Update(Update {
+        reach: None,
+        mp_reach: Some(NlriSet {
+            family: Family::IPV6_MUP,
+            entries: vec![nlri],
+        }),
+        attr: Arc::new(vec![
+            Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
+            Attribute::new_with_bin(
+                Attribute::AS_PATH,
+                vec![Attribute::AS_PATH_TYPE_SEQ, 1, 0x00, 0x00, 0xFD, 0xEA],
+            )
+            .unwrap(),
+            Attribute::new_with_bin(Attribute::NEXTHOP, nexthop_bytes).unwrap(),
+        ]),
+        unreach: None,
+        mp_unreach: None,
+        nexthop: None,
+    });
+
+    match round_trip(&msg, ipv6_mup_codec()) {
+        Message::Update(Update {
+            mp_reach,
+            mp_unreach,
+            ..
+        }) => {
+            assert!(mp_unreach.is_none());
+            let s = mp_reach.unwrap();
+            assert_eq!(s.family, Family::IPV6_MUP);
+            assert_eq!(s.entries, vec![nlri]);
+        }
+        _ => panic!("expected Update"),
+    }
+}
+
+#[test]
+fn update_mup_withdraw() {
+    let nlri = PathNlri::new(Nlri::Mup(mup::MupNlri::Type2SessionTransformed(
+        mup::MupType2SessionTransformedRoute {
+            rd: mup_rd(),
+            endpoint_address_length: 64,
+            endpoint_address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            teid: 0xdead_beef,
+        },
+    )));
+    let msg = Message::Update(Update {
+        reach: None,
+        mp_reach: None,
+        attr: Arc::new(Vec::new()),
+        unreach: None,
+        mp_unreach: Some(NlriSet {
+            family: Family::IPV4_MUP,
+            entries: vec![nlri],
+        }),
+        nexthop: None,
+    });
+
+    match round_trip(&msg, ipv4_mup_codec()) {
+        Message::Update(Update {
+            mp_reach,
+            mp_unreach,
+            ..
+        }) => {
+            assert!(mp_reach.is_none());
+            let s = mp_unreach.unwrap();
+            assert_eq!(s.family, Family::IPV4_MUP);
+            assert_eq!(s.entries, vec![nlri]);
+        }
+        _ => panic!("expected Update"),
+    }
+}
+
+#[test]
+fn update_mup_with_ext_community() {
+    let nlri = PathNlri::new(Nlri::Mup(mup::MupNlri::DirectSegmentDiscovery(
+        mup::MupDirectSegmentDiscoveryRoute {
+            rd: mup_rd(),
+            address: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+        },
+    )));
+    // Build EXTENDED_COMMUNITY bytes containing a MUP ext community.
+    let mut ec_bytes = Vec::new();
+    mup::MupExtended {
+        sub_type: mup::EC_SUBTYPE_MUP_DIRECT_SEG,
+        segment_id2: 10,
+        segment_id4: 20,
+    }
+    .encode(&mut ec_bytes);
+    let nexthop: Ipv4Addr = "10.0.0.1".parse().unwrap();
+    let msg = Message::Update(Update {
+        reach: None,
+        mp_reach: Some(NlriSet {
+            family: Family::IPV4_MUP,
+            entries: vec![nlri],
+        }),
+        attr: Arc::new(vec![
+            Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
+            Attribute::new_with_bin(
+                Attribute::AS_PATH,
+                vec![Attribute::AS_PATH_TYPE_SEQ, 1, 0x00, 0x00, 0xFD, 0xEA],
+            )
+            .unwrap(),
+            Attribute::new_with_bin(Attribute::NEXTHOP, nexthop.octets().to_vec()).unwrap(),
+            Attribute::new_with_bin(Attribute::EXTENDED_COMMUNITY, ec_bytes.clone()).unwrap(),
+        ]),
+        unreach: None,
+        mp_unreach: None,
+        nexthop: None,
+    });
+
+    match round_trip(&msg, ipv4_mup_codec()) {
+        Message::Update(Update { mp_reach, attr, .. }) => {
+            let s = mp_reach.unwrap();
+            assert_eq!(s.entries, vec![nlri]);
+            let ec = attr
+                .iter()
+                .find(|a| a.code() == Attribute::EXTENDED_COMMUNITY)
+                .expect("EXTENDED_COMMUNITY missing");
+            assert_eq!(ec.binary().unwrap(), ec_bytes.as_slice());
         }
         _ => panic!("expected Update"),
     }

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -1354,6 +1354,7 @@ impl Condition {
                         return !(*opt == MatchOption::Any);
                     }
                     packet::Nlri::V6(_) => {}
+                    packet::Nlri::Mup(_) => {}
                 };
             }
             Condition::AsPath(_name, opt, set) => {
@@ -2053,6 +2054,7 @@ impl RpkiTable {
                 let (mut addr, mask) = match net {
                     packet::Nlri::V4(net) => (net.addr.octets().to_vec(), net.mask),
                     packet::Nlri::V6(net) => (net.addr.octets().to_vec(), net.mask),
+                    packet::Nlri::Mup(_) => return None,
                 };
                 addr.drain((mask.div_ceil(8)) as usize..);
                 for (ipnet, entry) in m.iter_prefix(&addr) {


### PR DESCRIPTION
Add support for the BGP-MUP SAFI (draft-ietf-bess-mup-safi-00,
SAFI 85) for Architecture Type 1 (3GPP-5G).

- packet: a `RouteDistinguisher` type covering RD types 0/1/2
  (RFC 4364) and the four MUP route types — Interwork Segment
  Discovery, Direct Segment Discovery, Type 1 Session
  Transformed, Type 2 Session Transformed. A `Nlri::Mup` variant
  hooks into the per-family decode/encode dispatch, and the MUP
  Extended Community (transitive type 0x0c, sub-type 0x00
  segment identifier) is decoded into the existing `MUPExtended`
  proto.
- config / daemon: `AfiSafiType::Ipv4Mup` / `Ipv6Mup` map onto
  `Family::IPV4_MUP` / `Family::IPV6_MUP` so `ipv4-mup` /
  `ipv6-mup` can be requested from neighbor configuration and
  negotiated via the Multiprotocol capability. gRPC
  `nlri_to_api` and `net_from_api` round-trip the four route
  types together with their RDs.

Verified against gobgp 4.4.0 for both `ipv4-mup` and `ipv6-mup`:
capability negotiation, ISD / DSD / T1ST / T2ST origination and
reception (ISD/DSD with Prefix SID carrying the SRv6 L3 Service
TLV), MP_UNREACH withdraw, and session re-convergence after
reset.

## Reproducing

rustybgp config (YAML):

```yaml
global:
  config:
    as: 65001
    router-id: "172.40.0.1"
neighbors:
  - config:
      neighbor-address: "172.40.0.2"
      peer-as: 65002
    afi-safis:
      - config:
          afi-safi-name: ipv4-mup
      - config:
          afi-safi-name: ipv6-mup
```

gobgp config (TOML):

```toml
[global.config]
  as = 65002
  router-id = "172.40.0.2"

[[neighbors]]
  [neighbors.config]
    neighbor-address = "172.40.0.1"
    peer-as = 65001
  [[neighbors.afi-safis]]
    [neighbors.afi-safis.config]
      afi-safi-name = "ipv4-mup"
  [[neighbors.afi-safis]]
    [neighbors.afi-safis.config]
      afi-safi-name = "ipv6-mup"
```

The same `gobgp` CLI talks to both daemons over gRPC, so route
injection is symmetric — pointing it at gobgpd exercises the
gobgp -> rustybgp direction, and pointing it at rustybgpd
exercises the rustybgp -> gobgp direction. Examples:

```sh
# Type 1 Session Transformed
gobgp global rib add -a mup-ipv4 t1st 192.168.1.1/32 \
  rd 100:100 rt 10:10 teid 12345 qfi 9 endpoint 10.0.0.1
# Type 2 Session Transformed
gobgp global rib add -a mup-ipv4 t2st 10.0.0.1 \
  rd 100:100 rt 10:10 endpoint-address-length 64 teid 12345 mup 10:10
# Interwork Segment Discovery (with Prefix SID)
gobgp global rib add -a mup-ipv4 isd 10.10.0.0/24 \
  rd 100:100 prefix 2001:db8:1::1/128 \
  locator-node-length 24 function-length 16 behavior ENDM_GTP4E \
  rt 10:10 nexthop 2001:db8::2
# Direct Segment Discovery (with Prefix SID and segment identifier)
gobgp global rib add -a mup-ipv4 dsd 10.30.0.1 \
  rd 100:100 prefix 2001:db8:3::1/128 \
  locator-node-length 24 function-length 16 behavior ENDM_GTP4E \
  rt 10:10 mup 10:10 nexthop 2001:db8::2
```

`gobgp -u <rustybgpd-host>` (or running the CLI inside the
rustybgpd container) targets rustybgpd's gRPC; the same commands
with different RD / prefix values then originate the MUP route
from the rustybgp side.