### PR TITLE
daemon: mark snapshot routes as sent in export_map at on_established

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -3792,7 +3792,9 @@ impl Connection {
                     }) {
                         continue;
                     }
+                    let (family, net) = (c.family, c.net);
                     pending.get_mut(f).unwrap().insert_change(c);
+                    self.export_map.mark_sent(family, net);
                 }
             }
 


### PR DESCRIPTION
Routes inserted into pending during the initial snapshot were not tracked in export_map, causing valid withdrawals for those routes to be suppressed by handle_advertise (was_sent returned false). This could result in stale routes being sent to the peer.


Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>