### PR TITLE
gr,daemon: move restarting-speaker EOR tracking into GrState

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -287,8 +287,6 @@ struct PeerContext {
     /// True if the daemon started with --graceful-restart and this peer has not
     /// yet sent EOR.  Cleared by `clear_restarting` once all tracked peers finish.
     local_restarting: bool,
-    /// Restarting-speaker tracking: families for which we have not yet received EOR from this peer.
-    restarting_pending_eor: Option<FnvHashSet<Family>>,
 }
 
 /// Administrative peer record stored in `Global::peers` under the global
@@ -498,7 +496,6 @@ impl PeerParams {
                 gr_restart_timer: None,
                 gr_deferral_timer: None,
                 local_restarting: false,
-                restarting_pending_eor: None,
             })),
         }
     }
@@ -2941,7 +2938,6 @@ impl Global {
         for peer in self.peers.values_mut() {
             let mut ctx = peer.context.lock().unwrap();
             ctx.local_restarting = false;
-            ctx.restarting_pending_eor = None;
             for cap in &mut peer.config.local_cap {
                 if let packet::Capability::GracefulRestart { flags, .. } = cap {
                     *flags &= !0x8;
@@ -4454,17 +4450,18 @@ impl PeerSession {
                             .map(|g| g.families.clone())
                             .unwrap_or_default();
 
-                        if ctx.local_restarting && !gr_families.is_empty() {
-                            ctx.restarting_pending_eor =
-                                Some(gr_families.iter().cloned().collect::<FnvHashSet<_>>());
-                        }
-
-                        let outputs =
+                        let outputs = if ctx.local_restarting {
+                            ctx.gr_state
+                                .process(crate::gr::GrInput::LocalRestartEstablished {
+                                    gr_families,
+                                })
+                        } else {
                             ctx.gr_state
                                 .process(crate::gr::GrInput::SessionEstablished {
                                     gr_families,
                                     deferral_time,
-                                });
+                                })
+                        };
 
                         let mut drop_source = false;
                         let mut start_deferral = false;
@@ -4499,12 +4496,13 @@ impl PeerSession {
                     }
                 }
                 GlobalEffect::GrEorReceived { family } => {
-                    let source = {
+                    let (source, peer_eor_complete) = {
                         let mut ctx = self.context.lock().unwrap();
                         let outputs = ctx
                             .gr_state
                             .process(crate::gr::GrInput::EorReceived(family));
                         let mut drop_source = false;
+                        let mut peer_eor_complete = false;
                         for output in &outputs {
                             match output {
                                 crate::gr::GrOutput::DeleteStaleRoutes(_) => drop_source = true,
@@ -4513,41 +4511,30 @@ impl PeerSession {
                                         h.abort();
                                     }
                                 }
+                                crate::gr::GrOutput::PeerEorComplete => peer_eor_complete = true,
                                 _ => {}
                             }
                         }
-                        if let Some(pending) = &mut ctx.restarting_pending_eor {
-                            pending.remove(&family);
-                        }
-                        if drop_source {
+                        let source = if drop_source {
                             ctx.gr_source.take()
                         } else {
                             None
-                        }
+                        };
+                        (source, peer_eor_complete)
                     };
                     if let Some(s) = source {
                         gr_drop_source(&self.tables, s).await;
                     }
 
-                    // Check if all tracked peers have finished sending EOR; if so,
-                    // clear restarting-speaker state so future reconnections use R=0.
-                    let mut server = global.write().await;
-                    let any_local_restarting = server
-                        .peers
-                        .values()
-                        .any(|p| p.context.lock().unwrap().local_restarting);
-                    if any_local_restarting {
-                        let any_pending = server.peers.values().any(|p| {
+                    // If this peer completed its EOR (restarting-speaker side), check
+                    // whether all helper peers are done; if so, clear restarting state.
+                    if peer_eor_complete {
+                        let mut server = global.write().await;
+                        let any_still_pending = server.peers.values().any(|p| {
                             let ctx = p.context.lock().unwrap();
-                            ctx.local_restarting
-                                && matches!(&ctx.restarting_pending_eor, Some(s) if !s.is_empty())
+                            ctx.local_restarting && ctx.gr_state.is_local_restarting()
                         });
-                        let any_done = server.peers.values().any(|p| {
-                            let ctx = p.context.lock().unwrap();
-                            ctx.local_restarting
-                                && matches!(&ctx.restarting_pending_eor, Some(s) if s.is_empty())
-                        });
-                        if !any_pending && any_done {
+                        if !any_still_pending {
                             server.clear_restarting();
                         }
                     }

--- a/daemon/src/gr.rs
+++ b/daemon/src/gr.rs
@@ -51,6 +51,10 @@ pub(crate) enum GrInput {
     TimerExpired,
     /// The Selection Deferral Timer fired; delete all remaining stale routes.
     DeferralTimerExpired,
+    /// We are the restarting speaker; this peer reconnected as our helper.
+    /// Track EOR receipt per family (RFC 4724 §4.2).  If `gr_families` is
+    /// empty the machine stays Idle (no tracking needed for this peer).
+    LocalRestartEstablished { gr_families: Vec<Family> },
 }
 
 /// Actions the driver should perform in response to a GR input.
@@ -68,6 +72,10 @@ pub(crate) enum GrOutput {
     StopDeferralTimer,
     /// Delete stale routes for the given families.
     DeleteStaleRoutes(Vec<Family>),
+    /// All expected EOR has been received from this peer (restarting-speaker
+    /// side).  The driver should check whether all local-restarting peers have
+    /// completed and call `clear_restarting` if so.
+    PeerEorComplete,
 }
 
 enum Inner {
@@ -77,6 +85,8 @@ enum Inner {
     Restarting { stale_families: Vec<Family> },
     /// Peer reconnected; Selection Deferral Timer running; waiting for EOR.
     WaitingEor { pending: FnvHashSet<Family> },
+    /// We are the restarting speaker; waiting for EOR from this helper peer.
+    LocalRestarting { pending: FnvHashSet<Family> },
 }
 
 /// GR helper state machine for a single BGP peer.
@@ -91,9 +101,41 @@ impl GrState {
         GrState { state: Inner::Idle }
     }
 
+    /// Returns true while waiting for EOR from a helper peer (restarting-speaker side).
+    pub(crate) fn is_local_restarting(&self) -> bool {
+        matches!(self.state, Inner::LocalRestarting { .. })
+    }
+
     pub(crate) fn process(&mut self, input: GrInput) -> Vec<GrOutput> {
         let state = std::mem::replace(&mut self.state, Inner::Idle);
         let (new_state, outputs) = match (state, input) {
+            // LocalRestarting + SessionDropped: peer dropped before sending all EOR;
+            // give up waiting (no stale routes to mark on our side).
+            (Inner::LocalRestarting { .. }, GrInput::SessionDropped { .. }) => {
+                (Inner::Idle, vec![])
+            }
+
+            // LocalRestartEstablished from Idle: enter LocalRestarting if families
+            // are non-empty, otherwise stay Idle.
+            (Inner::Idle, GrInput::LocalRestartEstablished { gr_families }) => {
+                let pending: FnvHashSet<Family> = gr_families.into_iter().collect();
+                if pending.is_empty() {
+                    (Inner::Idle, vec![])
+                } else {
+                    (Inner::LocalRestarting { pending }, vec![])
+                }
+            }
+
+            // EOR received while we are the restarting speaker.
+            (Inner::LocalRestarting { mut pending }, GrInput::EorReceived(family)) => {
+                pending.remove(&family);
+                if pending.is_empty() {
+                    (Inner::Idle, vec![GrOutput::PeerEorComplete])
+                } else {
+                    (Inner::LocalRestarting { pending }, vec![])
+                }
+            }
+
             // Session drop from any state: mark stale and start restart timer.
             // If dropping from WaitingEor, also stop the deferral timer.
             (
@@ -395,6 +437,86 @@ mod tests {
         assert!(matches!(outputs[0], GrOutput::StopDeferralTimer));
         assert!(matches!(&outputs[1], GrOutput::MarkStale(f) if f == &[ipv4()]));
         assert!(matches!(outputs[2], GrOutput::StartTimer(d) if d == restart_time()));
+        assert!(matches!(gr.state, Inner::Restarting { .. }));
+    }
+
+    // --- restarting-speaker side ---
+
+    #[test]
+    fn local_restart_single_family_eor_emits_peer_eor_complete() {
+        let mut gr = GrState::new();
+        let outputs = gr.process(GrInput::LocalRestartEstablished {
+            gr_families: vec![ipv4()],
+        });
+        assert!(outputs.is_empty());
+        assert!(gr.is_local_restarting());
+
+        let outputs = gr.process(GrInput::EorReceived(ipv4()));
+        assert_eq!(outputs.len(), 1);
+        assert!(matches!(outputs[0], GrOutput::PeerEorComplete));
+        assert!(!gr.is_local_restarting());
+        assert!(matches!(gr.state, Inner::Idle));
+    }
+
+    #[test]
+    fn local_restart_two_families_partial_eor_no_complete() {
+        let mut gr = GrState::new();
+        gr.process(GrInput::LocalRestartEstablished {
+            gr_families: vec![ipv4(), ipv6()],
+        });
+        assert!(gr.is_local_restarting());
+
+        // First EOR: still waiting for IPv6
+        let outputs = gr.process(GrInput::EorReceived(ipv4()));
+        assert!(outputs.is_empty());
+        assert!(gr.is_local_restarting());
+
+        // Second EOR: all done
+        let outputs = gr.process(GrInput::EorReceived(ipv6()));
+        assert_eq!(outputs.len(), 1);
+        assert!(matches!(outputs[0], GrOutput::PeerEorComplete));
+        assert!(!gr.is_local_restarting());
+    }
+
+    #[test]
+    fn local_restart_empty_families_stays_idle() {
+        let mut gr = GrState::new();
+        let outputs = gr.process(GrInput::LocalRestartEstablished {
+            gr_families: vec![],
+        });
+        assert!(outputs.is_empty());
+        assert!(!gr.is_local_restarting());
+        assert!(matches!(gr.state, Inner::Idle));
+    }
+
+    #[test]
+    fn local_restart_session_dropped_goes_idle_without_peer_eor_complete() {
+        let mut gr = GrState::new();
+        gr.process(GrInput::LocalRestartEstablished {
+            gr_families: vec![ipv4()],
+        });
+        assert!(gr.is_local_restarting());
+
+        let outputs = gr.process(GrInput::SessionDropped {
+            families: vec![ipv4()],
+            restart_time: restart_time(),
+        });
+        assert!(outputs.is_empty());
+        assert!(!gr.is_local_restarting());
+        assert!(matches!(gr.state, Inner::Idle));
+    }
+
+    #[test]
+    fn local_restart_established_from_non_idle_is_noop() {
+        // LocalRestartEstablished only works from Idle; from Restarting it is ignored.
+        let mut gr = GrState::new();
+        drop_ipv4(&mut gr);
+        assert!(matches!(gr.state, Inner::Restarting { .. }));
+
+        let outputs = gr.process(GrInput::LocalRestartEstablished {
+            gr_families: vec![ipv4()],
+        });
+        assert!(outputs.is_empty());
         assert!(matches!(gr.state, Inner::Restarting { .. }));
     }
 }


### PR DESCRIPTION
Add GrState::LocalRestarting { pending } to track which families we (as the restarting speaker) are still waiting for EOR from a helper peer.  This replaces PeerContext::restarting_pending_eor and makes the logic unit-testable through GrState::process() directly.

New API:
  GrInput::LocalRestartEstablished { gr_families } -- enter LocalRestarting
  GrOutput::PeerEorComplete                        -- all EOR received
  GrState::is_local_restarting() -> bool

In process_effects, GrSessionEstablished now dispatches to LocalRestartEstablished when local_restarting is set; GrEorReceived acts on PeerEorComplete instead of inspecting restarting_pending_eor. clear_restarting() no longer clears restarting_pending_eor (field removed).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>