### PR TITLE
daemon: remove unnecessary #[allow(dead_code)] annotations

### DIFF
--- a/daemon/src/auth.rs
+++ b/daemon/src/auth.rs
@@ -17,7 +17,6 @@ use std::net::IpAddr;
 use std::os::unix::io::RawFd;
 
 #[repr(C)]
-#[allow(dead_code)]
 struct TcpMd5sig {
     ss_family: u16,
     ss: [u8; 126],
@@ -26,7 +25,6 @@ struct TcpMd5sig {
     _pad1: u32,
     key: [u8; 80],
 }
-#[allow(dead_code)]
 impl TcpMd5sig {
     fn new(addr: &IpAddr, password: String) -> TcpMd5sig {
         let mut ss = [0; 126];

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -221,7 +221,6 @@ struct ActiveConnectCancel(Option<tokio::sync::oneshot::Sender<()>>);
 /// `None` in `PeerConfig::graceful_restart` means GR is disabled for this peer.
 /// Cloned into capability negotiation at each session open.
 #[derive(Clone)]
-#[allow(dead_code)]
 struct GrPeerConfig {
     /// Restart Time advertised in our OPEN (12-bit, max 4095 s).
     restart_time: u16,
@@ -254,7 +253,6 @@ struct PeerConfig {
     /// Per-family prefix limits from config.
     prefix_limits: FnvHashMap<Family, u32>,
     /// GR helper config; None = GR disabled.
-    #[allow(dead_code)]
     graceful_restart: Option<GrPeerConfig>,
 }
 

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -27,7 +27,6 @@ const INITIAL_HOLD_SECS: u64 = 240;
 
 /// BGP session states (RFC 4271 §8.2.2).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum State {
     Idle,
     Connect,
@@ -435,7 +434,6 @@ pub(crate) enum PeerFsmOutput {
 /// BGP peer. Handles collision detection per RFC 4271 §6.8.
 ///
 /// Pure logic — no async, no I/O.
-#[allow(dead_code)]
 pub(crate) struct PeerFsm {
     active: Option<Connection>,
     passive: Option<Connection>,
@@ -447,7 +445,6 @@ pub(crate) struct PeerFsm {
     send_max: FnvHashMap<Family, usize>,
 }
 
-#[allow(dead_code)]
 impl PeerFsm {
     pub(crate) fn new(
         local_router_id: u32,

--- a/daemon/src/gr.rs
+++ b/daemon/src/gr.rs
@@ -28,7 +28,6 @@ use rustybgp_packet::bgp::Family;
 use std::time::Duration;
 
 /// Events fed into the GR state machine.
-#[allow(dead_code)]
 pub(crate) enum GrInput {
     /// The peer session dropped while GR was negotiated for these families.
     /// The caller provides the restart_time from the last OPEN exchange.
@@ -90,12 +89,10 @@ enum Inner {
 }
 
 /// GR helper state machine for a single BGP peer.
-#[allow(dead_code)]
 pub(crate) struct GrState {
     state: Inner,
 }
 
-#[allow(dead_code)]
 impl GrState {
     pub(crate) fn new() -> Self {
         GrState { state: Inner::Idle }


### PR DESCRIPTION
Remove #[allow(dead_code)] from items that are in fact used:
- event.rs: GrPeerConfig struct, PeerConfig::graceful_restart field
- gr.rs: GrInput enum, GrState struct and impl
- fsm.rs: State enum, PeerFsm struct and impl
- auth.rs: TcpMd5sig struct and impl

The remaining four annotations are kept because they suppress genuine dead-code warnings (unused variants/fields that are intentional):
- fsm.rs: Input enum (Disconnected, AdminShutdown variants)
- fsm.rs: SessionDownReason enum (FsmError payload)
- fsm.rs: PeerFsmOutput enum (CloseConnection payload)
- gr.rs: GrOutput enum (MarkStale, StartDeferralTimer, DeleteStaleRoutes payloads)

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>