### PR TITLE
daemon: make SessionDownReason::FsmError a unit variant

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -4481,9 +4481,7 @@ impl PeerSession {
                         crate::fsm::SessionDownReason::RemoteNotification(msg) => {
                             bmp::PeerDownReason::RemoteNotification(msg)
                         }
-                        crate::fsm::SessionDownReason::FsmError(_) => {
-                            bmp::PeerDownReason::LocalFsm(0)
-                        }
+                        crate::fsm::SessionDownReason::FsmError => bmp::PeerDownReason::LocalFsm(0),
                         crate::fsm::SessionDownReason::AdminShutdown => {
                             bmp::PeerDownReason::LocalFsm(0)
                         }

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -114,11 +114,10 @@ pub(crate) enum Output {
 
 /// Reason the session is going down.
 #[derive(Clone)]
-#[allow(dead_code)]
 pub(crate) enum SessionDownReason {
     HoldTimerExpired,
     RemoteNotification(bgp::Message),
-    FsmError(State),
+    FsmError,
     AdminShutdown,
     IoError,
 }
@@ -240,7 +239,7 @@ impl Connection {
                         state: u8::from(self.state),
                     },
                 )),
-                Output::SessionDown(SessionDownReason::FsmError(self.state)),
+                Output::SessionDown(SessionDownReason::FsmError),
             ];
         }
 
@@ -317,7 +316,7 @@ impl Connection {
                         state: u8::from(self.state),
                     },
                 )),
-                Output::SessionDown(SessionDownReason::FsmError(self.state)),
+                Output::SessionDown(SessionDownReason::FsmError),
             ],
         }
     }
@@ -330,7 +329,7 @@ impl Connection {
                         state: u8::from(self.state),
                     },
                 )),
-                Output::SessionDown(SessionDownReason::FsmError(self.state)),
+                Output::SessionDown(SessionDownReason::FsmError),
             ];
         }
         vec![Output::SetHoldTimer(self.negotiated_holdtime)]
@@ -350,7 +349,7 @@ impl Connection {
                         state: u8::from(self.state),
                     },
                 )),
-                Output::SessionDown(SessionDownReason::FsmError(self.state)),
+                Output::SessionDown(SessionDownReason::FsmError),
             ];
         }
         vec![Output::RouteRefresh(family)]
@@ -750,7 +749,7 @@ mod tests {
         )));
         assert!(has_output(&out, |o| matches!(
             o,
-            Output::SessionDown(SessionDownReason::FsmError(_))
+            Output::SessionDown(SessionDownReason::FsmError)
         )));
     }
 
@@ -952,7 +951,7 @@ mod tests {
         )));
         assert!(has_output(&out, |o| matches!(
             o,
-            Output::SessionDown(SessionDownReason::FsmError(_))
+            Output::SessionDown(SessionDownReason::FsmError)
         )));
     }
 
@@ -992,7 +991,7 @@ mod tests {
         )));
         assert!(has_output(&out, |o| matches!(
             o,
-            Output::SessionDown(SessionDownReason::FsmError(_))
+            Output::SessionDown(SessionDownReason::FsmError)
         )));
     }
 


### PR DESCRIPTION
The State payload was never read — all match arms used FsmError(_). FsmError occurs mostly before Established (OPEN exchange errors) so BMP PeerDown is not sent anyway; in the rare post-Established case the state value adds no actionable information.

Remove the payload and the now-unnecessary #[allow(dead_code)] on SessionDownReason.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>