### PR TITLE
table,daemon: add tests for Selection Deferral (RFC 4724 section 4.1)

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -6197,4 +6197,148 @@ mod tests {
         let arb = ctx.conn_arbiter.lock().unwrap();
         assert!(arb.fsm.connection(crate::fsm::Role::Passive).is_none());
     }
+
+    // ---- Selection Deferral (Restarting Speaker, RFC 4724 section 4.1) ----
+
+    fn make_selection_deferral(peers: &[(IpAddr, Vec<Family>)]) -> crate::gr::RestartingDeferral {
+        let map: fnv::FnvHashMap<IpAddr, Vec<Family>> = peers.iter().cloned().collect();
+        let (deferral, _) = crate::gr::RestartingDeferral::new(map, Duration::from_secs(360));
+        deferral
+    }
+
+    #[tokio::test]
+    async fn selection_deferral_peer_established_starts_timer() {
+        let global = make_global();
+        let tables = make_tables();
+        let remote_addr: IpAddr = "10.0.0.1".parse().unwrap();
+        let context = make_context(false);
+
+        // Install a selection_deferral with this peer as the sole GR peer.
+        global.write().await.selection_deferral = Some(make_selection_deferral(&[(
+            remote_addr,
+            vec![Family::IPV4],
+        )]));
+
+        let negotiated_gr = Some(NegotiatedGr {
+            families: vec![Family::IPV4],
+            restart_time: Duration::from_secs(90),
+        });
+        let mut session =
+            PeerSession::new_for_test(remote_addr, context, tables, Duration::from_secs(120));
+        session
+            .process_effects(
+                vec![GlobalEffect::GrSessionEstablished { negotiated_gr }],
+                &global,
+            )
+            .await;
+
+        let g = global.read().await;
+        // Timer must have been started.
+        assert!(g.selection_deferral_timer.is_some());
+        // selection_deferral is still Some (waiting for EOR).
+        assert!(g.selection_deferral.is_some());
+    }
+
+    #[tokio::test]
+    async fn selection_deferral_eor_received_completes_deferral() {
+        let global = make_global();
+        let tables = make_tables();
+        let remote_addr: IpAddr = "10.0.0.1".parse().unwrap();
+        let context = make_context(false);
+
+        // Install selection_deferral: one peer, one family.
+        global.write().await.selection_deferral = Some(make_selection_deferral(&[(
+            remote_addr,
+            vec![Family::IPV4],
+        )]));
+
+        let negotiated_gr = Some(NegotiatedGr {
+            families: vec![Family::IPV4],
+            restart_time: Duration::from_secs(90),
+        });
+        let mut session =
+            PeerSession::new_for_test(remote_addr, context, tables, Duration::from_secs(120));
+
+        // Establish → starts timer and moves to Deferring.
+        session
+            .process_effects(
+                vec![GlobalEffect::GrSessionEstablished { negotiated_gr }],
+                &global,
+            )
+            .await;
+
+        // EOR received → deferral completes.
+        session
+            .process_effects(
+                vec![GlobalEffect::GrEorReceived {
+                    family: Family::IPV4,
+                }],
+                &global,
+            )
+            .await;
+
+        let g = global.read().await;
+        // Deferral must be cleared after all EOR received.
+        assert!(g.selection_deferral.is_none());
+        assert!(g.selection_deferral_timer.is_none());
+    }
+
+    #[tokio::test]
+    async fn selection_deferral_timer_expired_clears_deferral() {
+        let global = make_global();
+        let tables = make_tables();
+        let remote_addr: IpAddr = "10.0.0.1".parse().unwrap();
+
+        // Install selection_deferral in Deferring state by processing PeerEstablished.
+        {
+            let mut g = global.write().await;
+            let mut deferral = make_selection_deferral(&[(remote_addr, vec![Family::IPV4])]);
+            // Advance to Deferring by feeding PeerEstablished.
+            deferral.process(crate::gr::RestartingInput::PeerEstablished(
+                remote_addr,
+                vec![Family::IPV4],
+            ));
+            g.selection_deferral = Some(deferral);
+        }
+
+        // Fire the timer directly.
+        gr_selection_deferral_timer_expired(global.clone(), tables).await;
+
+        let g = global.read().await;
+        // Deferral must be cleared after timer expiry.
+        assert!(g.selection_deferral.is_none());
+    }
+
+    #[tokio::test]
+    async fn selection_deferral_unknown_peer_established_is_noop() {
+        let global = make_global();
+        let tables = make_tables();
+        let remote_addr: IpAddr = "10.0.0.1".parse().unwrap();
+        let unknown_addr: IpAddr = "10.0.0.99".parse().unwrap();
+        let context = make_context(false);
+
+        // Install selection_deferral with remote_addr, but session is from unknown_addr.
+        global.write().await.selection_deferral = Some(make_selection_deferral(&[(
+            remote_addr,
+            vec![Family::IPV4],
+        )]));
+
+        let negotiated_gr = Some(NegotiatedGr {
+            families: vec![Family::IPV4],
+            restart_time: Duration::from_secs(90),
+        });
+        let mut session =
+            PeerSession::new_for_test(unknown_addr, context, tables, Duration::from_secs(120));
+        session
+            .process_effects(
+                vec![GlobalEffect::GrSessionEstablished { negotiated_gr }],
+                &global,
+            )
+            .await;
+
+        let g = global.read().await;
+        // Unknown peer: timer must NOT be started, deferral still in AwaitingStart.
+        assert!(g.selection_deferral_timer.is_none());
+        assert!(g.selection_deferral.is_some());
+    }
 }

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -3736,4 +3736,96 @@ mod tests {
         assert_eq!(best[0].rank, 1);
         assert!(best[0].source.is_stale());
     }
+
+    // ---- Selection Deferral (RFC 4724 section 4.1) ----
+
+    #[test]
+    fn deferral_suppresses_insert_changes() {
+        // While deferring, insert() stores the route but returns no changes.
+        let mut rt = RoutingTable::new();
+        let net = nlri(10, 0, 0, 0, 24);
+        let src = source(1, 65001, 65000, 1);
+
+        rt.start_deferral(Family::IPV4);
+
+        let changes = rt.insert(src, Family::IPV4, net, 0, nh(), empty_attrs(), false);
+        assert!(changes.is_empty(), "deferral must suppress insert changes");
+        assert!(
+            rt.global.get(&Family::IPV4).unwrap().deferring,
+            "deferring flag must be set"
+        );
+    }
+
+    #[test]
+    fn deferral_does_not_affect_other_families() {
+        // Deferring IPv4 must not suppress IPv6 inserts.
+        let mut rt = RoutingTable::new();
+        let net6 = packet::Nlri::V6(packet::bgp::Ipv6Net {
+            addr: std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0),
+            mask: 32,
+        });
+        let src = source(1, 65001, 65000, 1);
+
+        rt.start_deferral(Family::IPV4);
+
+        let nh6 = bgp::Nexthop::V6(std::net::Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1));
+        let changes = rt.insert(src, Family::IPV6, net6, 0, nh6, empty_attrs(), false);
+        assert!(!changes.is_empty(), "IPv6 insert must not be suppressed");
+    }
+
+    #[test]
+    fn end_deferral_returns_accumulated_routes() {
+        // Routes inserted during deferral are returned by end_deferral().
+        let mut rt = RoutingTable::new();
+        let n1 = nlri(10, 0, 0, 0, 24);
+        let n2 = nlri(10, 0, 1, 0, 24);
+        let src = source(1, 65001, 65000, 1);
+
+        rt.start_deferral(Family::IPV4);
+
+        // Both inserts are suppressed.
+        assert!(
+            rt.insert(src.clone(), Family::IPV4, n1, 0, nh(), empty_attrs(), false)
+                .is_empty()
+        );
+        assert!(
+            rt.insert(src, Family::IPV4, n2, 0, nh(), empty_attrs(), false)
+                .is_empty()
+        );
+
+        // end_deferral clears flag and returns all accumulated best paths.
+        let changes = rt.end_deferral(Family::IPV4);
+        assert_eq!(changes.len(), 2);
+        assert!(changes.iter().all(|c| c.rank == 1));
+        assert!(changes.iter().all(|c| c.old_rank == 0));
+        assert!(
+            !rt.global.get(&Family::IPV4).unwrap().deferring,
+            "deferring flag must be cleared"
+        );
+    }
+
+    #[test]
+    fn end_deferral_on_non_deferred_family_is_noop() {
+        // end_deferral on a family that was never deferred returns empty.
+        let mut rt = RoutingTable::new();
+        let changes = rt.end_deferral(Family::IPV4);
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn insert_after_end_deferral_distributes_normally() {
+        // After deferral ends, subsequent inserts produce changes as usual.
+        let mut rt = RoutingTable::new();
+        let net = nlri(10, 0, 0, 0, 24);
+        let src = source(1, 65001, 65000, 1);
+
+        rt.start_deferral(Family::IPV4);
+        rt.end_deferral(Family::IPV4);
+
+        let changes = rt.insert(src, Family::IPV4, net, 0, nh(), empty_attrs(), false);
+        assert!(
+            !changes.is_empty(),
+            "insert after end_deferral must produce changes"
+        );
+    }
 }


### PR DESCRIPTION
table: five unit tests for start_deferral/end_deferral:
- deferral_suppresses_insert_changes: insert() returns empty while deferring; deferring flag is set.
- deferral_does_not_affect_other_families: IPv4 deferral leaves IPv6 inserts unaffected.
- end_deferral_returns_accumulated_routes: routes inserted during deferral are returned by end_deferral() with old_rank=0.
- end_deferral_on_non_deferred_family_is_noop: calling end_deferral on a family that was never deferred is safe.
- insert_after_end_deferral_distributes_normally: inserts after end_deferral produce changes again.

daemon: four integration tests for the selection_deferral driver path:
- selection_deferral_peer_established_starts_timer: GrSessionEstablished feeds PeerEstablished into RestartingDeferral and starts the global Selection_Deferral_Timer.
- selection_deferral_eor_received_completes_deferral: EOR from the sole GR peer clears selection_deferral and cancels the timer.
- selection_deferral_timer_expired_clears_deferral: direct call to gr_selection_deferral_timer_expired clears selection_deferral.
- selection_deferral_unknown_peer_established_is_noop: a peer not in the configured GR set does not start the timer.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>