### PR TITLE
gr,daemon: read Selection_Deferral_Timer from Global GR config

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -3424,8 +3424,23 @@ impl Global {
                     })
                     .collect()
             };
-            let duration = std::time::Duration::from_secs(360);
-            let (deferral, init_outputs) = crate::gr::RestartingDeferral::new(gr_peers, duration);
+            // Read Selection_Deferral_Timer from Global GR config (stale_routes_time).
+            // None → default 360 s; 0 → disabled (wait indefinitely); >0 → use that value.
+            let selection_deferral_time: Option<std::time::Duration> = bgp
+                .as_ref()
+                .and_then(|b| b.global.as_ref())
+                .and_then(|g| g.graceful_restart.as_ref())
+                .and_then(|gr| gr.config.as_ref())
+                .and_then(|c| c.stale_routes_time)
+                .map_or(Some(std::time::Duration::from_secs(360)), |secs| {
+                    if secs == 0.0 {
+                        None
+                    } else {
+                        Some(std::time::Duration::from_secs_f64(secs))
+                    }
+                });
+            let (deferral, init_outputs) =
+                crate::gr::RestartingDeferral::new(gr_peers, selection_deferral_time);
             if !deferral.is_completed() {
                 for output in &init_outputs {
                     if let crate::gr::RestartingOutput::DeferFamilies(families) = output {
@@ -3931,7 +3946,8 @@ async fn process_restarting_outputs(
 ) -> Option<std::time::Duration> {
     let mut complete_families: Vec<Family> = vec![];
     let mut end_remaining: Option<Vec<Family>> = None;
-    let mut start_timer: Option<std::time::Duration> = None;
+    // None: no StartDeferralTimer output; Some(None): timer disabled; Some(Some(d)): start timer
+    let mut start_timer: Option<Option<std::time::Duration>> = None;
 
     for output in outputs {
         match output {
@@ -3964,7 +3980,8 @@ async fn process_restarting_outputs(
         server.clear_restarting();
     }
 
-    start_timer
+    // Flatten: None (no output) and Some(None) (disabled) both mean "don't start timer".
+    start_timer.flatten()
 }
 
 async fn gr_selection_deferral_timer_expired(global: GlobalHandle, tables: TableHandle) {
@@ -6202,7 +6219,7 @@ mod tests {
 
     fn make_selection_deferral(peers: &[(IpAddr, Vec<Family>)]) -> crate::gr::RestartingDeferral {
         let map: fnv::FnvHashMap<IpAddr, Vec<Family>> = peers.iter().cloned().collect();
-        let (deferral, _) = crate::gr::RestartingDeferral::new(map, Duration::from_secs(360));
+        let (deferral, _) = crate::gr::RestartingDeferral::new(map, Some(Duration::from_secs(360)));
         deferral
     }
 

--- a/daemon/src/gr.rs
+++ b/daemon/src/gr.rs
@@ -242,8 +242,9 @@ pub(crate) enum RestartingInput {
 pub(crate) enum RestartingOutput {
     /// Emitted from `new()`: set the table deferral flag for these families.
     DeferFamilies(Vec<Family>),
-    /// Start the global Selection Deferral Timer with this duration.
-    StartDeferralTimer(Duration),
+    /// Start the global Selection Deferral Timer.
+    /// `None` means the timer is disabled (wait indefinitely for EOR).
+    StartDeferralTimer(Option<Duration>),
     /// This family is fully acknowledged: clear its table flag and re-advertise.
     FamilyDeferralComplete(Family),
     /// All deferral is done.  Remaining families (non-empty only on timer expiry)
@@ -290,7 +291,8 @@ pub(crate) enum RestartingOutput {
 enum RestartingInner {
     AwaitingStart {
         pending: FnvHashMap<IpAddr, FnvHashSet<Family>>,
-        duration: Duration,
+        /// `None` means the Selection Deferral Timer is disabled.
+        duration: Option<Duration>,
     },
     Deferring {
         pending: FnvHashMap<IpAddr, FnvHashSet<Family>>,
@@ -316,9 +318,11 @@ impl RestartingDeferral {
     /// `gr_peers`: each peer's configured GR families (peers with an empty
     /// list are skipped).  Returns `(machine, outputs)` where outputs contains
     /// at most one `DeferFamilies` action.
+    /// `duration`: how long to run the Selection Deferral Timer after the first
+    /// peer establishes.  `None` disables the timer (EOR is awaited indefinitely).
     pub(crate) fn new(
         gr_peers: FnvHashMap<IpAddr, Vec<Family>>,
-        duration: Duration,
+        duration: Option<Duration>,
     ) -> (Self, Vec<RestartingOutput>) {
         let pending: FnvHashMap<IpAddr, FnvHashSet<Family>> = gr_peers
             .into_iter()
@@ -510,7 +514,7 @@ impl RestartingDeferral {
 
     fn finish_awaiting(
         pending: FnvHashMap<IpAddr, FnvHashSet<Family>>,
-        duration: Duration,
+        duration: Option<Duration>,
         mut outputs: Vec<RestartingOutput>,
     ) -> (RestartingInner, Vec<RestartingOutput>) {
         if pending.is_empty() {
@@ -764,7 +768,7 @@ mod tests {
         peers: &[(IpAddr, Vec<Family>)],
     ) -> (RestartingDeferral, Vec<RestartingOutput>) {
         let map: FnvHashMap<IpAddr, Vec<Family>> = peers.iter().cloned().collect();
-        RestartingDeferral::new(map, deferral_time())
+        RestartingDeferral::new(map, Some(deferral_time()))
     }
 
     fn rd_deferred_families(outputs: &[RestartingOutput]) -> Vec<Family> {
@@ -843,7 +847,7 @@ mod tests {
         assert!(has_start_timer(&outputs));
         assert!(matches!(
             outputs.last(),
-            Some(RestartingOutput::StartDeferralTimer(d)) if *d == deferral_time()
+            Some(RestartingOutput::StartDeferralTimer(Some(d))) if *d == deferral_time()
         ));
         assert!(matches!(rd.state, RestartingInner::Deferring { .. }));
     }


### PR DESCRIPTION
RestartingDeferral::new() now takes Option<Duration> instead of Duration for the Selection_Deferral_Timer:
- Some(d): start timer with d when the first GR peer establishes
- None: disable the timer (wait indefinitely for all peers to send EOR)

RestartingOutput::StartDeferralTimer is updated to Option<Duration> so the disabled state flows through to the driver. process_restarting_outputs() flattens the Option: None (no output) and Some(None) (disabled) both suppress timer spawning.

serve() reads stale_routes_time from bgp.global.graceful_restart.config (OpenConfig / RFC 4724 Selection_Deferral_Timer) to determine the value:
- field absent: default 360 s (Cisco stalepath-time default)
- field = 0:    timer disabled
- field > 0:    use the configured value

Tests updated to pass Some(deferral_time()) where Duration was expected.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>