### PR TITLE
tests/e2e: add RFC 4724 Graceful Restart restarting-speaker e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,6 +67,28 @@ jobs:
           RUSTYBGP_DOCKERFILE: Dockerfile
         run: ./run-test.sh
 
+  e2e-rfc4724-restarting:
+    name: RFC 4724 Graceful Restart (restarting speaker) end-to-end
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: rustybgpd-musl
+          path: /tmp/rustybgp-prebuilt
+      - name: prepare prebuilt context
+        run: |
+          chmod +x /tmp/rustybgp-prebuilt/rustybgpd
+          cp tests/e2e/shared/Dockerfile.rustybgp-prebuilt /tmp/rustybgp-prebuilt/Dockerfile
+      - name: Run RFC 4724 restarting speaker e2e test
+        working-directory: tests/e2e/rfc4724-restarting
+        env:
+          RUSTYBGP_BUILD_CONTEXT: /tmp/rustybgp-prebuilt
+          RUSTYBGP_DOCKERFILE: Dockerfile
+        run: ./run-test.sh
+
   e2e-rfc4724-helper:
     name: RFC 4724 Graceful Restart (helper side) end-to-end
     needs: build

--- a/tests/e2e/rfc4724-restarting/docker-compose.yml
+++ b/tests/e2e/rfc4724-restarting/docker-compose.yml
@@ -1,0 +1,50 @@
+networks:
+  bgp-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.5.0/24
+          gateway: 172.30.5.254
+
+services:
+  # frr-helper (AS 65002): GR-capable peer that advertises routes and
+  # preserves stale routes while rustybgp is restarting.
+  frr-helper:
+    image: quay.io/frrouting/frr:10.6.0
+    container_name: frr-helper
+    privileged: true
+    volumes:
+      - ./frr-helper/frr.conf:/etc/frr/frr.conf:ro
+      - ../shared/daemons:/etc/frr/daemons:ro
+    networks:
+      bgp-net:
+        ipv4_address: 172.30.5.2
+
+  # rustybgp: restarting speaker under test.
+  router-rusty:
+    build:
+      context: ${RUSTYBGP_BUILD_CONTEXT:-../../..}
+      dockerfile: ${RUSTYBGP_DOCKERFILE:-tests/e2e/shared/Dockerfile.rustybgp}
+      args:
+        RUST_TARGET: ${RUST_TARGET:-aarch64-unknown-linux-musl}
+    container_name: router-rusty
+    privileged: true
+    networks:
+      bgp-net:
+        ipv4_address: 172.30.5.1
+    volumes:
+      - ./rustybgp.yaml:/etc/rustybgp.yaml:ro
+      - ./entrypoint-rusty.sh:/entrypoint.sh:ro
+
+  # frr-receiver (AS 65003): plain eBGP peer that receives routes from
+  # rustybgp only after the Selection Deferral Timer completes.
+  frr-receiver:
+    image: quay.io/frrouting/frr:10.6.0
+    container_name: frr-receiver
+    privileged: true
+    volumes:
+      - ./frr-receiver/frr.conf:/etc/frr/frr.conf:ro
+      - ../shared/daemons:/etc/frr/daemons:ro
+    networks:
+      bgp-net:
+        ipv4_address: 172.30.5.3

--- a/tests/e2e/rfc4724-restarting/entrypoint-rusty.sh
+++ b/tests/e2e/rfc4724-restarting/entrypoint-rusty.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Start rustybgpd in the background.
+rustybgpd -f /etc/rustybgp.yaml &
+
+# Wait for gRPC API to become available.
+MAX_ATTEMPTS=30
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    if gobgp global 2>/dev/null; then
+        echo "rustybgpd gRPC API is ready"
+        break
+    fi
+    if [ "$i" -eq "$MAX_ATTEMPTS" ]; then
+        echo "rustybgpd gRPC API not ready after $MAX_ATTEMPTS attempts"
+        exit 1
+    fi
+    sleep 1
+done
+
+# Keep the container alive so the test script can kill and restart
+# rustybgpd (docker exec) without the container exiting.
+exec sleep infinity

--- a/tests/e2e/rfc4724-restarting/frr-helper/frr.conf
+++ b/tests/e2e/rfc4724-restarting/frr-helper/frr.conf
@@ -1,0 +1,18 @@
+frr defaults traditional
+hostname frr-helper
+log syslog informational
+!
+router bgp 65002
+ bgp router-id 172.30.5.2
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ bgp graceful-restart restart-time 30
+ neighbor 172.30.5.1 remote-as 65001
+ neighbor 172.30.5.1 graceful-restart
+ !
+ address-family ipv4 unicast
+  neighbor 172.30.5.1 activate
+  network 192.168.10.0/24
+  network 192.168.20.0/24
+ exit-address-family
+!

--- a/tests/e2e/rfc4724-restarting/frr-receiver/frr.conf
+++ b/tests/e2e/rfc4724-restarting/frr-receiver/frr.conf
@@ -1,0 +1,13 @@
+frr defaults traditional
+hostname frr-receiver
+log syslog informational
+!
+router bgp 65003
+ bgp router-id 172.30.5.3
+ no bgp ebgp-requires-policy
+ neighbor 172.30.5.1 remote-as 65001
+ !
+ address-family ipv4 unicast
+  neighbor 172.30.5.1 activate
+ exit-address-family
+!

--- a/tests/e2e/rfc4724-restarting/run-test.sh
+++ b/tests/e2e/rfc4724-restarting/run-test.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# RFC 4724 Graceful Restart - Restarting Speaker Side End-to-End Test
+#
+# Topology:
+#   [frr-helper (AS 65002, GR)] <-> [router-rusty (AS 65001)] <-> [frr-receiver (AS 65003)]
+#
+# frr-helper advertises: 192.168.10.0/24, 192.168.20.0/24
+#
+# Tests:
+#   1. Normal operation: sessions establish, frr-receiver sees routes
+#   2. rustybgp restarts with --graceful-restart:
+#      a. frr-helper preserves sessions as stale (helper side)
+#      b. rustybgp defers route selection until EOR from frr-helper
+#      c. After EOR, frr-receiver sees routes again
+#
+# NOTE: rustybgpd is killed (SIGKILL) and restarted inside the container.
+# frr-helper uses docker compose kill (SIGKILL) is NOT used here; the
+# helper stays running throughout to simulate the helper role.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+source ../shared/helpers.sh
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    docker compose down --volumes --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Count routes in frr-receiver's BGP table for a given prefix.
+receiver_route_count() {
+    local prefix=$1
+    docker exec frr-receiver vtysh \
+        -c "show bgp ipv4 unicast $prefix json" 2>/dev/null \
+        | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('paths', [])))" \
+        2>/dev/null || echo 0
+}
+
+# Wait for rustybgpd gRPC API to become available inside the container.
+wait_for_rusty_api() {
+    local max=30
+    for i in $(seq 1 $max); do
+        if docker exec router-rusty gobgp global 2>/dev/null; then
+            echo "  rustybgpd gRPC API ready after ${i}s"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "  rustybgpd gRPC API not ready after ${max}s"
+    return 1
+}
+
+echo "=== RFC 4724 Graceful Restart (Restarting Speaker) End-to-End Test ==="
+echo ""
+
+echo "Building and starting containers..."
+docker compose up -d --build 2>&1
+
+# --- Test 1: Normal operation ---
+echo ""
+echo "Waiting for BGP sessions to establish..."
+MAX_WAIT=60
+HELPER_OK=false
+RECEIVER_OK=false
+
+for i in $(seq 1 $MAX_WAIT); do
+    if ! $HELPER_OK && [ "$(frr_bgp_state frr-helper 172.30.5.1)" = "Established" ]; then
+        HELPER_OK=true
+        echo "  frr-helper session established after ${i}s"
+    fi
+    if ! $RECEIVER_OK && [ "$(frr_bgp_state frr-receiver 172.30.5.1)" = "Established" ]; then
+        RECEIVER_OK=true
+        echo "  frr-receiver session established after ${i}s"
+    fi
+    $HELPER_OK && $RECEIVER_OK && break
+    sleep 1
+done
+
+if $HELPER_OK; then
+    pass "frr-helper session established"
+else
+    fail "frr-helper session established"
+fi
+
+if $RECEIVER_OK; then
+    pass "frr-receiver session established"
+else
+    fail "frr-receiver session established"
+fi
+
+# Wait for route propagation
+sleep 5
+
+ROUTE_COUNT=$(receiver_route_count "192.168.10.0/24")
+if [ "$ROUTE_COUNT" -ge 1 ]; then
+    pass "frr-receiver sees 192.168.10.0/24 in normal operation"
+else
+    fail "frr-receiver should see 192.168.10.0/24 (got $ROUTE_COUNT paths)"
+fi
+
+ROUTE_COUNT=$(receiver_route_count "192.168.20.0/24")
+if [ "$ROUTE_COUNT" -ge 1 ]; then
+    pass "frr-receiver sees 192.168.20.0/24 in normal operation"
+else
+    fail "frr-receiver should see 192.168.20.0/24 (got $ROUTE_COUNT paths)"
+fi
+
+# --- Test 2: Restart with --graceful-restart ---
+echo ""
+echo "Killing rustybgpd to simulate restart..."
+docker exec router-rusty pkill -9 rustybgpd 2>/dev/null || true
+sleep 3
+
+echo "Restarting rustybgpd with --graceful-restart..."
+docker exec -d router-rusty sh -c \
+    'rustybgpd -f /etc/rustybgp.yaml --graceful-restart > /tmp/rustybgpd.log 2>&1'
+
+echo "Waiting for rustybgpd gRPC API to be ready..."
+if wait_for_rusty_api; then
+    pass "rustybgpd restarted with --graceful-restart"
+else
+    fail "rustybgpd failed to restart"
+fi
+
+# Wait for frr-helper to reconnect and send EOR, ending deferral.
+echo "Waiting for frr-helper to re-establish and send EOR..."
+HELPER_OK=false
+for i in $(seq 1 $MAX_WAIT); do
+    if [ "$(frr_bgp_state frr-helper 172.30.5.1)" = "Established" ]; then
+        HELPER_OK=true
+        echo "  frr-helper session re-established after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+if $HELPER_OK; then
+    pass "frr-helper re-established after GR restart"
+else
+    fail "frr-helper re-established after GR restart"
+fi
+
+# Wait for deferral to end (EOR processing + route advertisement).
+sleep 10
+
+RECEIVER_OK=false
+for i in $(seq 1 $MAX_WAIT); do
+    if [ "$(frr_bgp_state frr-receiver 172.30.5.1)" = "Established" ]; then
+        RECEIVER_OK=true
+        echo "  frr-receiver session re-established after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+if $RECEIVER_OK; then
+    pass "frr-receiver session re-established after restart"
+else
+    fail "frr-receiver session re-established after restart"
+fi
+
+sleep 5
+
+ROUTE_COUNT=$(receiver_route_count "192.168.10.0/24")
+if [ "$ROUTE_COUNT" -ge 1 ]; then
+    pass "frr-receiver sees 192.168.10.0/24 after GR restart and deferral"
+else
+    fail "frr-receiver should see 192.168.10.0/24 after restart (got $ROUTE_COUNT paths)"
+fi
+
+ROUTE_COUNT=$(receiver_route_count "192.168.20.0/24")
+if [ "$ROUTE_COUNT" -ge 1 ]; then
+    pass "frr-receiver sees 192.168.20.0/24 after GR restart and deferral"
+else
+    fail "frr-receiver should see 192.168.20.0/24 after restart (got $ROUTE_COUNT paths)"
+fi
+
+# --- Summary ---
+echo ""
+echo "--- rustybgp RIB at end of test ---"
+docker exec router-rusty gobgp global rib -a ipv4 2>/dev/null || true
+echo ""
+echo "--- frr-receiver BGP table ---"
+docker exec frr-receiver vtysh -c "show bgp ipv4 unicast" 2>/dev/null || true
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "--- rustybgpd logs ---"
+    docker exec router-rusty cat /tmp/rustybgpd.log 2>/dev/null | tail -30 || true
+    docker logs router-rusty 2>&1 | tail -20
+    exit 1
+fi

--- a/tests/e2e/rfc4724-restarting/rustybgp.yaml
+++ b/tests/e2e/rfc4724-restarting/rustybgp.yaml
@@ -1,0 +1,29 @@
+global:
+  config:
+    as: 65001
+    router-id: "172.30.5.1"
+
+neighbors:
+  # frr-helper: GR-capable peer. RustyBGP defers route selection until
+  # EOR is received from this peer when started with --graceful-restart.
+  - config:
+      neighbor-address: "172.30.5.2"
+      peer-as: 65002
+    graceful-restart:
+      config:
+        enabled: true
+        restart-time: 30
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast
+        mp-graceful-restart:
+          config:
+            enabled: true
+
+  # frr-receiver: plain eBGP peer, receives routes after deferral ends.
+  - config:
+      neighbor-address: "172.30.5.3"
+      peer-as: 65003
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast


### PR DESCRIPTION
Tests the Restarting Speaker behavior (rfc4724-restarting/) with a 3-node topology:
  frr-helper (AS 65002, GR) <-> router-rusty (AS 65001) <-> frr-receiver (AS 65003)

frr-helper advertises: 192.168.10.0/24, 192.168.20.0/24

Two test scenarios:

1. Normal operation: both sessions establish, frr-receiver sees routes from frr-helper via rustybgp.

2. GR restart: rustybgpd is killed (SIGKILL) and restarted inside the container with --graceful-restart. rustybgp defers route selection until frr-helper reconnects and sends EOR. After deferral ends, frr-receiver sees routes again.

The test uses 'docker exec pkill -9 rustybgpd' to simulate a crash and 'docker exec -d rustybgpd ... --graceful-restart' to restart in Restarting Speaker mode. frr-receiver route presence is checked via FRR's vtysh JSON output.

Also adds e2e-rfc4724-restarting job to e2e.yml (needs: build, parallel with other e2e jobs).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>