### PR TITLE
event,bmp: replace subscribe() with subscribe_with() closure API

### DIFF
--- a/daemon/src/bmp.rs
+++ b/daemon/src/bmp.rs
@@ -245,19 +245,11 @@ impl BmpClient {
             ]))
             .await;
 
-        let subscription = tables.subscribe().await;
-        let mut rx = subscription.rx;
-
-        // Buffer all snapshot events until EndOfInitDump.
         let mut snapshot: SnapshotMap = FnvHashMap::default();
-        loop {
-            match rx.recv().await {
-                Some(BgpEvent::AdjRibIn(change)) => apply_snapshot(&mut snapshot, change),
-                Some(BgpEvent::PeerUp(_)) | Some(BgpEvent::PeerDown(_)) => {}
-                Some(BgpEvent::EndOfInitDump) => break,
-                None => return,
-            }
-        }
+        let subscription = tables
+            .subscribe_with(|change| apply_snapshot(&mut snapshot, change))
+            .await;
+        let rx = subscription.rx;
 
         // Send PeerUp for all established peers.
         let local_id = global.read().await.router_id;
@@ -354,7 +346,6 @@ impl BmpClient {
                                 break;
                             }
                         }
-                        Some(BgpEvent::EndOfInitDump) => {}
                         None => break,
                     }
                 }

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -1465,7 +1465,6 @@ impl GoBgpService for GrpcService {
                                 )),
                             }
                         }
-                        BgpEvent::EndOfInitDump => continue,
                     };
                     if tx.send(Ok(r)).await.is_err() {
                         break;
@@ -3381,8 +3380,6 @@ pub(crate) enum BgpEvent {
     AdjRibIn(AdjRibInChange),
     PeerUp(PeerUpData),
     PeerDown(PeerDownData),
-    /// Signals that the initial snapshot from `subscribe()` is fully delivered.
-    EndOfInitDump,
 }
 
 pub(crate) struct Subscription {
@@ -3576,9 +3573,12 @@ impl TableManager {
         }
     }
 
-    /// Subscribe with full snapshot: sends all current routes as AdjRibIn events per shard,
-    /// then two EndOfRib signals. Registers for live events atomically per shard.
-    pub(crate) async fn subscribe(&self) -> Subscription {
+    /// Subscribe with snapshot: calls `on_change` for each current route (per shard, under lock),
+    /// then registers for live AdjRibIn/PeerUp/PeerDown events.
+    pub(crate) async fn subscribe_with<F>(&self, mut on_change: F) -> Subscription
+    where
+        F: FnMut(AdjRibInChange),
+    {
         let id = SubscriptionId(
             self.next_sub_id
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
@@ -3589,26 +3589,24 @@ impl TableManager {
             let mut subs = self.subscribers.lock().await;
             subs.insert(id, tx.clone());
         }
-        // Snapshot each shard atomically and register for AdjRibIn events.
-        for i in 0..self.shards.len() {
-            let mut shard = self.shards[i].lock().await;
-            for f in shard.rtable.families().collect::<Vec<_>>() {
-                for reach in shard.rtable.iter_reach(f) {
-                    let addpath = shard.has_addpath(&reach.source.remote_addr, &f);
-                    let _ = tx.send(BgpEvent::AdjRibIn(AdjRibInChange {
+        // Snapshot each shard atomically while registering for live AdjRibIn events.
+        for shard in &self.shards {
+            let mut t = shard.lock().await;
+            for f in t.rtable.families().collect::<Vec<_>>() {
+                for reach in t.rtable.iter_reach(f) {
+                    let addpath = t.has_addpath(&reach.source.remote_addr, &f);
+                    on_change(AdjRibInChange {
                         source: reach.source,
                         family: f,
                         addpath,
                         nlris: vec![reach.net],
                         attrs: Some(reach.attr),
                         nexthop: Some(reach.nexthop),
-                    }));
+                    });
                 }
             }
-            shard.subscribers.insert(id, tx.clone());
+            t.subscribers.insert(id, tx.clone());
         }
-        // Signal end of initial snapshot.
-        let _ = tx.send(BgpEvent::EndOfInitDump);
         Subscription { rx, id }
     }
 


### PR DESCRIPTION
subscribe() sent snapshot routes through a channel and terminated with EndOfInitDump, forcing callers to run a receive loop just to collect the initial state before processing live events.

subscribe_with() takes a closure that receives each AdjRibInChange directly while the shard lock is held.  The snapshot is fully built by the time subscribe_with() returns, with no intermediate channel buffering and no sentinel event needed.

BMP drops its pre-loop, the EndOfInitDump match arm in the live loop, and the re-wrapping of rx into UnboundedReceiverStream before the live loop.  BgpEvent::EndOfInitDump is removed.  The dead EndOfInitDump => continue arm in watch_event (which uses subscribe_live) is also removed.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>