### PR TITLE
table,daemon: move RpkiTable to TableManager with RwLock; add source …

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -3288,6 +3288,7 @@ pub(crate) type TableHandle = Arc<TableManager>;
 
 pub(crate) struct TableManager {
     shards: Vec<Mutex<TableShard>>,
+    rpki: std::sync::RwLock<table::RpkiTable>,
     kernel_tx: ArcSwapOption<mpsc::UnboundedSender<KernelRouteEvent>>,
     import_policy: ArcSwapOption<table::PolicyAssignment>,
     export_policy: ArcSwapOption<table::PolicyAssignment>,
@@ -3308,6 +3309,7 @@ impl TableManager {
                     })
                 })
                 .collect(),
+            rpki: std::sync::RwLock::new(table::RpkiTable::new()),
             kernel_tx: ArcSwapOption::const_empty(),
             import_policy: ArcSwapOption::const_empty(),
             export_policy: ArcSwapOption::const_empty(),
@@ -3344,7 +3346,6 @@ impl TableManager {
         let mut nh = nexthop;
         let filtered = crate::policy::apply_import(
             import_policy.as_deref(),
-            &t.rtable,
             &source,
             &net.nlri,
             &attr,
@@ -3457,23 +3458,22 @@ impl TableManager {
     }
 
     async fn rpki_insert(&self, roas: Vec<(packet::IpNet, Arc<table::Roa>)>) {
-        for shard in &self.shards {
-            shard.lock().await.insert_roa(roas.clone());
+        let mut rpki = self.rpki.write().unwrap();
+        for (net, roa) in roas {
+            rpki.insert(net, roa);
         }
     }
 
     async fn rpki_reset(&self, addr: Arc<IpAddr>, roas: Vec<(packet::IpNet, Arc<table::Roa>)>) {
-        for shard in &self.shards {
-            let mut t = shard.lock().await;
-            t.rpki_drop(addr.clone());
-            t.insert_roa(roas.clone());
+        let mut rpki = self.rpki.write().unwrap();
+        rpki.drop_source(addr);
+        for (net, roa) in roas {
+            rpki.insert(net, roa);
         }
     }
 
     async fn rpki_drop_all(&self, addr: Arc<IpAddr>) {
-        for shard in &self.shards {
-            shard.lock().await.rpki_drop(addr.clone());
-        }
+        self.rpki.write().unwrap().drop_source(addr);
     }
 
     pub(crate) async fn table_state(&self, family: Family) -> table::TableState {
@@ -3485,17 +3485,16 @@ impl TableManager {
     }
 
     pub(crate) async fn collect_roa(&self, family: Family) -> Vec<(packet::IpNet, table::Roa)> {
-        self.shards[0]
-            .lock()
-            .await
-            .rtable
-            .iter_roa(family)
+        self.rpki
+            .read()
+            .unwrap()
+            .iter(family)
             .map(|(net, roa)| (net, roa.clone()))
             .collect()
     }
 
     pub(crate) async fn rpki_state(&self, addr: &IpAddr) -> table::RpkiTableState {
-        self.shards[0].lock().await.rtable.rpki_state(addr)
+        self.rpki.read().unwrap().state(addr)
     }
 
     pub(crate) async fn collect_paths(
@@ -3510,6 +3509,7 @@ impl TableManager {
         } else {
             None
         };
+        // Phase 1: collect from each shard (validation: None); shard lock released after each.
         let mut out = Vec::new();
         for shard in &self.shards {
             let t = shard.lock().await;
@@ -3520,6 +3520,13 @@ impl TableManager {
                 prefixes.clone(),
                 export_policy.clone(),
             ));
+        }
+        // Phase 2: apply RPKI validation without holding any shard lock.
+        let rpki = self.rpki.read().unwrap();
+        for dest in &mut out {
+            for path in &mut dest.paths {
+                path.validation = rpki.validate(family, &path.source, &dest.net, &path.attr);
+            }
         }
         out
     }
@@ -3718,7 +3725,7 @@ impl TableShard {
         let filtered_new_best: Option<table::Path> = if let Some(best) = update.new_best() {
             let mut nexthop = best.nexthop;
             if export_policy.is_some_and(|policy| {
-                self.rtable.apply_policy(
+                table::Table::apply_policy(
                     policy,
                     &best.source,
                     &update.net,
@@ -3749,7 +3756,7 @@ impl TableShard {
                     .filter_map(|p| {
                         let mut nexthop = p.nexthop;
                         if export_policy.is_some_and(|policy| {
-                            self.rtable.apply_policy(
+                            table::Table::apply_policy(
                                 policy,
                                 &p.source,
                                 &update.net,
@@ -3845,7 +3852,6 @@ impl TableShard {
                     let mut nh = nexthop.unwrap();
                     let filtered = crate::policy::apply_import(
                         import_policy,
-                        &self.rtable,
                         &source,
                         &net.nlri,
                         &attrs,
@@ -3898,16 +3904,6 @@ impl TableShard {
         for change in self.rtable.end_deferral(family) {
             self.distribute_update(change, kernel_tx, export_policy);
         }
-    }
-
-    fn insert_roa(&mut self, roas: Vec<(packet::IpNet, Arc<table::Roa>)>) {
-        for (net, roa) in roas {
-            self.rtable.roa_insert(net, roa);
-        }
-    }
-
-    fn rpki_drop(&mut self, addr: Arc<IpAddr>) {
-        self.rtable.rpki_drop(addr);
     }
 }
 
@@ -4536,7 +4532,7 @@ impl PeerSession {
             for path in paths.iter().take(effective_max) {
                 let mut nexthop = path.nexthop;
                 if export_policy.as_ref().is_some_and(|a| {
-                    rtable.apply_policy(
+                    table::Table::apply_policy(
                         a,
                         &path.source,
                         &net,

--- a/daemon/src/policy.rs
+++ b/daemon/src/policy.rs
@@ -18,21 +18,20 @@
 //! Pure logic — no async, no I/O.
 
 use rustybgp_packet::bgp::Nexthop;
-use rustybgp_table::{Disposition, PolicyAssignment, Table};
+use rustybgp_table::{Disposition, PolicyAssignment};
 use std::sync::Arc;
 
 /// Apply import policy to a route and return whether it should be filtered
 /// (rejected). Also applies any nexthop rewriting action.
 pub(crate) fn apply_import(
     import_policy: Option<&PolicyAssignment>,
-    rtable: &Table,
     source: &Arc<rustybgp_table::Source>,
     nlri: &rustybgp_packet::Nlri,
     attrs: &Arc<Vec<rustybgp_packet::Attribute>>,
     nexthop: &mut Nexthop,
 ) -> bool {
     import_policy.is_some_and(|a| {
-        rtable.apply_policy(a, source, nlri, attrs, nexthop, source.local_addr)
+        rustybgp_table::Table::apply_policy(a, source, nlri, attrs, nexthop, source.local_addr)
             == Disposition::Reject
     })
 }
@@ -100,14 +99,12 @@ mod tests {
 
     #[test]
     fn import_no_policy_accepts() {
-        let rtable = Table::new();
         let attrs = Arc::new(vec![
             packet::Attribute::new_with_value(packet::Attribute::ORIGIN, 0).unwrap(),
         ]);
         let mut nh = Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
         let filtered = apply_import(
             None,
-            &rtable,
             &source(1),
             &packet::Nlri::from_str("10.0.0.0/24").unwrap(),
             &attrs,
@@ -118,7 +115,6 @@ mod tests {
 
     #[test]
     fn import_rejected_by_policy() {
-        let rtable = Table::new();
         let policy = reject_policy();
         let attrs = Arc::new(vec![
             packet::Attribute::new_with_value(packet::Attribute::ORIGIN, 0).unwrap(),
@@ -126,7 +122,6 @@ mod tests {
         let mut nh = Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
         let filtered = apply_import(
             Some(&policy),
-            &rtable,
             &source(1),
             &packet::Nlri::from_str("10.0.0.0/24").unwrap(),
             &attrs,

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -66,6 +66,7 @@ pub struct DestinationEntry {
 }
 
 pub struct PathEntry {
+    pub source: Arc<Source>,
     pub id: u32,
     pub timestamp: SystemTime,
     pub attr: Arc<Vec<packet::Attribute>>,
@@ -451,7 +452,6 @@ pub struct Rib {
 pub struct Table {
     ribs: FnvHashMap<Family, Rib>,
     route_stats: FnvHashMap<IpAddr, FnvHashMap<Family, PrefixStats>>,
-    rpki: RpkiTable,
 }
 
 impl Default for Table {
@@ -461,14 +461,6 @@ impl Default for Table {
 }
 
 impl Table {
-    pub fn new() -> Self {
-        Table {
-            ribs: vec![(Family::EMPTY, Rib::default())].into_iter().collect(),
-            route_stats: FnvHashMap::default(),
-            rpki: RpkiTable::new(),
-        }
-    }
-
     /// Returns all current unfiltered paths grouped by destination.
     /// Each tuple is (nlri, paths_sorted_by_preference).
     pub fn best_paths(&self, family: &Family) -> Vec<(packet::Nlri, Vec<Path>)> {
@@ -607,7 +599,7 @@ impl Table {
                                 );
                                 if let Some(pa) = &export_policy {
                                     let mut nh = p.path.nexthop;
-                                    if self.apply_policy(
+                                    if Self::apply_policy(
                                         pa,
                                         &p.path.source,
                                         net,
@@ -627,19 +619,17 @@ impl Table {
                                 Some((p, p.path.attr.clone()))
                             }
                         })
-                        .map(|(p, attr)| {
-                            let validation = self.rpki.validate(family, &p.path.source, net, &attr);
-                            PathEntry {
-                                id: if table_type == TableType::AdjOut {
-                                    0
-                                } else {
-                                    p.id
-                                },
-                                timestamp: p.timestamp,
-                                attr,
-                                validation,
-                                stale: p.path.source.is_stale(),
-                            }
+                        .map(|(p, attr)| PathEntry {
+                            source: p.path.source.clone(),
+                            id: if table_type == TableType::AdjOut {
+                                0
+                            } else {
+                                p.id
+                            },
+                            timestamp: p.timestamp,
+                            attr,
+                            validation: None,
+                            stale: p.path.source.is_stale(),
                         })
                         .collect()
                 },
@@ -1078,99 +1068,14 @@ impl Table {
         changes
     }
 
-    pub fn iter_roa(&self, family: Family) -> impl Iterator<Item = (packet::IpNet, &Roa)> + '_ {
-        self.rpki
-            .roas
-            .get(&family)
-            .unwrap()
-            .iter()
-            .flat_map(|(n, e)| {
-                let net = RpkiTable::key_to_addr(n);
-                e.iter().map(move |r| (net.clone(), r.as_ref()))
-            })
-    }
-
-    pub fn rpki_state(&self, addr: &IpAddr) -> RpkiTableState {
-        let mut state = RpkiTableState::default();
-        for (family, roas) in self.rpki.roas.iter() {
-            let mut records = 0;
-            let mut prefixes = 0;
-            for (_, e) in roas.iter() {
-                for r in e {
-                    if &*r.source == addr {
-                        prefixes += 1;
-                    }
-                }
-                if prefixes != 0 {
-                    records += 1;
-                }
-            }
-            match *family {
-                Family::IPV4 => {
-                    state.num_records_v4 += records;
-                    state.num_prefixes_v4 += prefixes;
-                }
-                Family::IPV6 => {
-                    state.num_records_v6 += records;
-                    state.num_prefixes_v6 += prefixes;
-                }
-                _ => {}
-            }
-        }
-        state
-    }
-    pub fn rpki_drop(&mut self, source: Arc<IpAddr>) {
-        for (_, roa) in self.rpki.roas.iter_mut() {
-            let mut empty = Vec::new();
-            for (n, e) in roa.iter_mut() {
-                let mut i = 0;
-                while i != e.len() {
-                    if Arc::ptr_eq(&e[i].source, &source) {
-                        e.remove(i);
-                    } else {
-                        i += 1;
-                    }
-                }
-                if e.is_empty() {
-                    empty.push(n);
-                }
-            }
-            for n in empty {
-                roa.remove(n);
-            }
-        }
-    }
-
-    pub fn roa_insert(&mut self, net: packet::IpNet, roa: Arc<Roa>) {
-        let (family, mut key, mask) = match net {
-            packet::IpNet::V4(net) => (Family::IPV4, net.addr.octets().to_vec(), net.mask),
-            packet::IpNet::V6(net) => (Family::IPV6, net.addr.octets().to_vec(), net.mask),
-        };
-        key.push(mask);
-        match self.rpki.roas.get_mut(&family).unwrap().get_mut(&key) {
-            Some(entry) => {
-                for e in entry.iter() {
-                    if Arc::ptr_eq(&e.source, &roa.source)
-                        && e.max_length == roa.max_length
-                        && e.as_number == roa.as_number
-                    {
-                        return;
-                    }
-                }
-                entry.push(roa);
-            }
-            None => {
-                self.rpki
-                    .roas
-                    .get_mut(&family)
-                    .unwrap()
-                    .insert(key, vec![roa]);
-            }
+    pub fn new() -> Self {
+        Table {
+            ribs: vec![(Family::EMPTY, Rib::default())].into_iter().collect(),
+            route_stats: FnvHashMap::default(),
         }
     }
 
     pub fn apply_policy(
-        &self,
         assignment: &PolicyAssignment,
         source: &Arc<Source>,
         net: &packet::Nlri,
@@ -1178,7 +1083,7 @@ impl Table {
         nexthop: &mut bgp::Nexthop,
         local_addr: IpAddr,
     ) -> Disposition {
-        assignment.apply(&self.rpki, source, net, attr, nexthop, local_addr)
+        assignment.apply(source, net, attr, nexthop, local_addr)
     }
 }
 
@@ -1735,7 +1640,6 @@ pub struct PolicyAssignment {
 impl PolicyAssignment {
     fn apply(
         &self,
-        _rpki: &RpkiTable,
         source: &Arc<Source>,
         net: &packet::Nlri,
         attr: &Arc<Vec<packet::Attribute>>,
@@ -2154,7 +2058,7 @@ pub struct RpkiTable {
 }
 
 impl RpkiTable {
-    fn new() -> Self {
+    pub fn new() -> Self {
         let roas: FnvHashMap<Family, PatriciaMap<_>> = vec![
             (Family::IPV4, PatriciaMap::default()),
             (Family::IPV6, PatriciaMap::default()),
@@ -2182,7 +2086,7 @@ impl RpkiTable {
         packet::IpNet::new(prefix, mask)
     }
 
-    fn validate(
+    pub fn validate(
         &self,
         family: Family,
         source: &Arc<Source>,
@@ -2248,6 +2152,89 @@ impl RpkiTable {
                 Some(result)
             }
         }
+    }
+
+    pub fn insert(&mut self, net: packet::IpNet, roa: Arc<Roa>) {
+        let (family, mut key, mask) = match net {
+            packet::IpNet::V4(net) => (Family::IPV4, net.addr.octets().to_vec(), net.mask),
+            packet::IpNet::V6(net) => (Family::IPV6, net.addr.octets().to_vec(), net.mask),
+        };
+        key.push(mask);
+        match self.roas.get_mut(&family).unwrap().get_mut(&key) {
+            Some(entry) => {
+                for e in entry.iter() {
+                    if Arc::ptr_eq(&e.source, &roa.source)
+                        && e.max_length == roa.max_length
+                        && e.as_number == roa.as_number
+                    {
+                        return;
+                    }
+                }
+                entry.push(roa);
+            }
+            None => {
+                self.roas.get_mut(&family).unwrap().insert(key, vec![roa]);
+            }
+        }
+    }
+
+    pub fn drop_source(&mut self, source: Arc<IpAddr>) {
+        for (_, roa) in self.roas.iter_mut() {
+            let mut empty = Vec::new();
+            for (n, e) in roa.iter_mut() {
+                let mut i = 0;
+                while i != e.len() {
+                    if Arc::ptr_eq(&e[i].source, &source) {
+                        e.remove(i);
+                    } else {
+                        i += 1;
+                    }
+                }
+                if e.is_empty() {
+                    empty.push(n);
+                }
+            }
+            for n in empty {
+                roa.remove(n);
+            }
+        }
+    }
+
+    pub fn state(&self, addr: &IpAddr) -> RpkiTableState {
+        let mut state = RpkiTableState::default();
+        for (family, roas) in self.roas.iter() {
+            let mut records = 0;
+            let mut prefixes = 0;
+            for (_, e) in roas.iter() {
+                for r in e {
+                    if &*r.source == addr {
+                        prefixes += 1;
+                    }
+                }
+                if prefixes != 0 {
+                    records += 1;
+                }
+            }
+            match *family {
+                Family::IPV4 => {
+                    state.num_records_v4 += records;
+                    state.num_prefixes_v4 += prefixes;
+                }
+                Family::IPV6 => {
+                    state.num_records_v6 += records;
+                    state.num_prefixes_v6 += prefixes;
+                }
+                _ => {}
+            }
+        }
+        state
+    }
+
+    pub fn iter(&self, family: Family) -> impl Iterator<Item = (packet::IpNet, &Roa)> + '_ {
+        self.roas.get(&family).unwrap().iter().flat_map(|(n, e)| {
+            let net = RpkiTable::key_to_addr(n);
+            e.iter().map(move |r| (net.clone(), r.as_ref()))
+        })
     }
 }
 
@@ -3186,7 +3173,7 @@ mod tests {
 
         let s = source(1, 65001, 65000, 1);
         let net = nlri(10, 0, 0, 0, 24);
-        let result = rt.apply_policy(
+        let result = Table::apply_policy(
             &assignment,
             &s,
             &net,
@@ -3236,7 +3223,7 @@ mod tests {
         let s = source(1, 65001, 65000, 1);
         // Different prefix → no match → default disposition (Accept)
         let net = nlri(192, 168, 0, 0, 24);
-        let result = rt.apply_policy(
+        let result = Table::apply_policy(
             &assignment,
             &s,
             &net,
@@ -3290,7 +3277,7 @@ mod tests {
         let s = source(1, 65001, 65000, 1);
         let net = nlri(10, 0, 0, 0, 24);
         let mut nexthop = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
-        let result = rt.apply_policy(
+        let result = Table::apply_policy(
             &assignment,
             &s,
             &net,
@@ -3344,7 +3331,7 @@ mod tests {
         let net = nlri(10, 0, 0, 0, 24);
         let local_addr = IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1));
         let mut nexthop = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
-        let result = rt.apply_policy(
+        let result = Table::apply_policy(
             &assignment,
             &s,
             &net,
@@ -3401,7 +3388,7 @@ mod tests {
         let net = nlri(192, 168, 0, 0, 24);
         let original = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut nexthop = original;
-        let _result = rt.apply_policy(
+        let _result = Table::apply_policy(
             &assignment,
             &s,
             &net,


### PR DESCRIPTION
…to PathEntry

Previously ROA data was replicated across every TableShard, requiring all shards to be locked for each RPKI write. Multiple peers doing concurrent export could not read ROA while any shard lock was held.

Move RpkiTable out of Table and into TableManager behind a single RwLock. Add source: Arc<Source> to PathEntry so ROA validation can be applied after all shard locks are released. collect_paths now uses a two-phase approach: phase 1 collects routes from each shard (brief shard lock, validation: None); phase 2 acquires rpki.read() and fills in validation without holding any shard lock. Multiple peers can now evaluate export policy and ROA concurrently.

Table::apply_policy becomes an associated function (no longer needs &self) and PolicyAssignment::apply loses the unused _rpki parameter.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>