### PR TITLE
fsm,event: derive R-bit from global restarting state at connect time

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -467,7 +467,7 @@ impl PeerParams {
     /// `local_router_id` is needed to construct `PeerFsm` for collision
     /// detection; it is only known once `Global::router_id` is set, so callers
     /// always go through `Global::add_peer` rather than calling this directly.
-    fn build(mut self, local_router_id: u32, global_asn: u32, is_restarting: bool) -> Peer {
+    fn build(mut self, local_router_id: u32, global_asn: u32) -> Peer {
         if self.local_asn == 0 {
             self.local_asn = global_asn;
         }
@@ -504,10 +504,10 @@ impl PeerParams {
             }
         }
         if let Some(gr) = &self.graceful_restart {
-            // R-bit (0x8): local speaker is currently restarting (RFC 4724).
             // N-bit (0x4): supports GR for NOTIFICATION and Hold Timer (RFC 8538).
-            let flags =
-                if is_restarting { 0x8 } else { 0 } | if gr.notification_enabled { 0x4 } else { 0 };
+            // R-bit (0x8) is NOT set here; it is applied at connection time in
+            // PeerFsm::on_connected() based on the current global restarting state.
+            let flags = if gr.notification_enabled { 0x4 } else { 0 };
             local_cap.push(packet::Capability::GracefulRestart {
                 flags,
                 restart_time: gr.restart_time,
@@ -1187,10 +1187,6 @@ impl GoBgpService for GrpcService {
         request: tonic::Request<api::AddPeerRequest>,
     ) -> Result<tonic::Response<api::AddPeerResponse>, tonic::Status> {
         let api_peer = request.into_inner().peer.ok_or(Error::EmptyArgument)?;
-        let is_restarting = api_peer
-            .graceful_restart
-            .as_ref()
-            .is_some_and(|gr| gr.local_restarting);
         let params = PeerParams::try_from(&api_peer)?;
         let mut global = self.global.write().await;
         if let Some(password) = params.password.as_ref() {
@@ -1198,7 +1194,7 @@ impl GoBgpService for GrpcService {
                 auth::set_md5sig(*fd, &params.remote_addr, password);
             }
         }
-        global.add_peer(params, Some(self.active_conn_tx.clone()), is_restarting)?;
+        global.add_peer(params, Some(self.active_conn_tx.clone()))?;
         Ok(tonic::Response::new(api::AddPeerResponse {}))
     }
     async fn delete_peer(
@@ -2686,14 +2682,13 @@ impl Global {
         &mut self,
         params: PeerParams,
         tx: Option<mpsc::UnboundedSender<TcpStream>>,
-        is_restarting: bool,
     ) -> std::result::Result<(), Error> {
         if self.peers.contains_key(&params.remote_addr) {
             return Err(Error::AlreadyExists(
                 "peer address already exists".to_string(),
             ));
         }
-        let mut peer = params.build(u32::from(self.router_id), self.asn, is_restarting);
+        let mut peer = params.build(u32::from(self.router_id), self.asn);
         if peer.admin_down {
             peer.state
                 .fsm
@@ -2717,6 +2712,7 @@ async fn accept_connection(
     let remote_sockaddr = stream.peer_addr().ok()?;
     let remote_addr = remote_sockaddr.ip();
     let mut g = global.write().await;
+    let is_restarting = g.selection_deferral.is_some();
     let peer = match g.peers.get_mut(&remote_addr) {
         Some(peer) => {
             if peer.admin_down {
@@ -2791,7 +2787,6 @@ async fn accept_connection(
                     graceful_restart: None,
                 },
                 None,
-                false,
             );
             g.peers.get_mut(&remote_addr).unwrap()
         }
@@ -2823,6 +2818,7 @@ async fn accept_connection(
         remote_addr,
         peer.config.local_asn,
         peer.config.local_cap.to_owned(),
+        is_restarting,
         peer.config.route_server_client,
         role,
         conn_arbiter,
@@ -3129,9 +3125,7 @@ impl Global {
             for p in peers {
                 match PeerParams::try_from(p) {
                     Ok(params) => {
-                        if let Err(e) =
-                            server.add_peer(params, Some(active_tx.clone()), is_restarting)
-                        {
+                        if let Err(e) = server.add_peer(params, Some(active_tx.clone())) {
                             eprintln!("failed to add peer from config: {}", e);
                         }
                     }
@@ -3419,15 +3413,9 @@ async fn process_restarting_outputs(
             h.abort();
         }
         server.selection_deferral = None;
-        // Clear the Restart State (R) bit so future OPENs no longer
-        // advertise the restarting-speaker state.
-        for peer in server.peers.values_mut() {
-            for cap in &mut peer.config.local_cap {
-                if let packet::Capability::GracefulRestart { flags, .. } = cap {
-                    *flags &= !0x8;
-                }
-            }
-        }
+        // R-bit is no longer stored in peer config; it is derived from
+        // selection_deferral.is_some() at connection time (PeerFsm::on_connected).
+        // Setting selection_deferral = None is sufficient.
         println!("graceful-restart: all peers sent EOR; cleared restarting state");
     }
 
@@ -3591,6 +3579,10 @@ struct PeerSession {
     counter_rx: Arc<MessageCounter>,
 
     local_cap: Vec<packet::Capability>,
+    /// True if the local router is the restarting speaker at session creation
+    /// time (i.e., Global::selection_deferral was Some when the session was
+    /// constructed).  Used to set the R-bit in the GR capability of the OPEN.
+    is_restarting: bool,
 
     rs_client: bool,
 
@@ -3632,6 +3624,7 @@ impl PeerSession {
         remote_addr: IpAddr,
         local_asn: u32,
         local_cap: Vec<packet::Capability>,
+        is_restarting: bool,
         rs_client: bool,
         role: crate::fsm::Role,
         conn_arbiter: Arc<std::sync::Mutex<ConnArbiter>>,
@@ -3672,6 +3665,7 @@ impl PeerSession {
             counter_tx,
             counter_rx,
             local_cap,
+            is_restarting,
             rs_client,
             conn_arbiter,
             role,
@@ -3739,6 +3733,7 @@ impl PeerSession {
             counter_tx: Default::default(),
             counter_rx: Default::default(),
             local_cap: vec![],
+            is_restarting: false,
             rs_client: false,
             conn_arbiter,
             role: crate::fsm::Role::Passive,
@@ -4450,7 +4445,7 @@ impl PeerSession {
             .conn_arbiter
             .lock()
             .unwrap()
-            .process(self.role, crate::fsm::Input::Connected);
+            .process(self.role, crate::fsm::Input::Connected(self.is_restarting));
         let effects = self
             .apply_outputs(outputs, local_sockaddr, remote_sockaddr)
             .await;
@@ -4862,8 +4857,7 @@ mod tests {
 
         {
             let mut g = global.write().await;
-            g.add_peer(default_peer_params(remote_addr), None, false)
-                .unwrap();
+            g.add_peer(default_peer_params(remote_addr), None).unwrap();
         }
 
         let h = accept_connection(&global, &tables, server, crate::fsm::Role::Passive).await;
@@ -4896,8 +4890,7 @@ mod tests {
 
         {
             let mut g = global.write().await;
-            g.add_peer(default_peer_params(remote_addr), None, false)
-                .unwrap();
+            g.add_peer(default_peer_params(remote_addr), None).unwrap();
         }
 
         let h = accept_connection(&global, &tables, server, crate::fsm::Role::Active).await;
@@ -4932,7 +4925,6 @@ mod tests {
                     ..default_peer_params(remote_addr)
                 },
                 None,
-                false,
             )
             .unwrap();
         }
@@ -4950,8 +4942,7 @@ mod tests {
 
         {
             let mut g = global.write().await;
-            g.add_peer(default_peer_params(remote_addr), None, false)
-                .unwrap();
+            g.add_peer(default_peer_params(remote_addr), None).unwrap();
             let (tx, _rx) = tokio::sync::oneshot::channel::<CloseReason>();
             g.peers
                 .get_mut(&remote_addr)
@@ -5027,8 +5018,7 @@ mod tests {
     ) -> PeerSession {
         {
             let mut g = global.write().await;
-            g.add_peer(default_peer_params(remote_addr), None, false)
-                .unwrap();
+            g.add_peer(default_peer_params(remote_addr), None).unwrap();
         }
         accept_connection(global, tables, server, crate::fsm::Role::Passive)
             .await
@@ -5051,7 +5041,10 @@ mod tests {
                 capability: vec![],
             });
             let mut arb = conn.conn_arbiter.lock().unwrap();
-            arb.process(crate::fsm::Role::Passive, crate::fsm::Input::Connected);
+            arb.process(
+                crate::fsm::Role::Passive,
+                crate::fsm::Input::Connected(false),
+            );
             arb.process(
                 crate::fsm::Role::Passive,
                 crate::fsm::Input::MessageReceived(open),
@@ -5293,13 +5286,19 @@ mod tests {
         {
             let mut arb = conn_arbiter.lock().unwrap();
             // Active → OpenConfirm
-            arb.process(crate::fsm::Role::Active, crate::fsm::Input::Connected);
+            arb.process(
+                crate::fsm::Role::Active,
+                crate::fsm::Input::Connected(false),
+            );
             arb.process(
                 crate::fsm::Role::Active,
                 crate::fsm::Input::MessageReceived(open_msg.clone()),
             );
             // Passive → OpenConfirm → collision detected → CEASE sent directly to active_close_tx
-            arb.process(crate::fsm::Role::Passive, crate::fsm::Input::Connected);
+            arb.process(
+                crate::fsm::Role::Passive,
+                crate::fsm::Input::Connected(false),
+            );
             arb.process(
                 crate::fsm::Role::Passive,
                 crate::fsm::Input::MessageReceived(open_msg),
@@ -5636,8 +5635,7 @@ mod tests {
 
         {
             let mut g = global.write().await;
-            g.add_peer(default_peer_params(remote_addr), None, false)
-                .unwrap();
+            g.add_peer(default_peer_params(remote_addr), None).unwrap();
         }
 
         let session = accept_connection(&global, &tables, server, crate::fsm::Role::Passive)

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -67,7 +67,9 @@ impl TryFrom<u8> for State {
 /// Events fed into the session FSM.
 pub(crate) enum Input {
     /// TCP connection established; start the OPEN exchange.
-    Connected,
+    /// The bool indicates whether the local speaker is currently the restarting
+    /// speaker (R-bit in the GR capability of the OPEN).
+    Connected(bool),
     /// A complete BGP message was received from the peer.
     MessageReceived(bgp::Message),
     /// The keepalive timer fired (send direction: we may need to send KEEPALIVE).
@@ -194,7 +196,7 @@ impl Connection {
     /// Process an input event and return actions for the I/O driver.
     pub(crate) fn process(&mut self, input: Input) -> Vec<Output> {
         match input {
-            Input::Connected => self.on_connected(),
+            Input::Connected(_) => self.on_connected(),
             Input::MessageReceived(msg) => self.on_message(msg),
             Input::KeepaliveTimerExpired => self.on_keepalive_timer_expired(),
             Input::HoldTimerExpired => self.on_hold_timer_expired(),
@@ -503,8 +505,8 @@ impl PeerFsm {
     /// Includes collision detection: if both Connections reach OpenConfirm,
     /// the loser is sent a CEASE notification and closed.
     pub(crate) fn process(&mut self, role: Role, input: Input) -> Vec<PeerFsmOutput> {
-        if matches!(input, Input::Connected) {
-            return self.on_connected(role);
+        if let Input::Connected(is_restarting) = input {
+            return self.on_connected(role, is_restarting);
         }
         let Some(session) = self.connection_mut(role) else {
             return Vec::new();
@@ -541,7 +543,7 @@ impl PeerFsm {
     /// Handle a new TCP connection for the given role.
     /// Creates a Connection and starts the OPEN exchange, or returns CloseConnection
     /// if a Connection for this role already exists.
-    fn on_connected(&mut self, role: Role) -> Vec<PeerFsmOutput> {
+    fn on_connected(&mut self, role: Role, is_restarting: bool) -> Vec<PeerFsmOutput> {
         let slot = match role {
             Role::Active => &mut self.active,
             Role::Passive => &mut self.passive,
@@ -549,15 +551,41 @@ impl PeerFsm {
         if slot.is_some() {
             return vec![PeerFsmOutput::CloseConnection];
         }
+        // Apply R-bit (0x8) to the GR capability when the local speaker is
+        // the restarting speaker.  local_cap stores caps without R-bit so that
+        // no mutation is needed when recovery completes.
+        let effective_cap = if is_restarting {
+            self.local_cap
+                .iter()
+                .map(|c| {
+                    if let Capability::GracefulRestart {
+                        flags,
+                        restart_time,
+                        families,
+                    } = c
+                    {
+                        Capability::GracefulRestart {
+                            flags: flags | 0x8,
+                            restart_time: *restart_time,
+                            families: families.clone(),
+                        }
+                    } else {
+                        c.clone()
+                    }
+                })
+                .collect()
+        } else {
+            self.local_cap.clone()
+        };
         *slot = Some(Connection::new(
             self.local_asn,
             self.local_router_id,
-            self.local_cap.clone(),
+            effective_cap,
             self.local_holdtime,
             self.expected_remote_asn,
             self.send_max.clone(),
         ));
-        let outputs = slot.as_mut().unwrap().process(Input::Connected);
+        let outputs = slot.as_mut().unwrap().process(Input::Connected(false));
         outputs
             .into_iter()
             .map(|o| PeerFsmOutput::Connection(role, o))
@@ -653,7 +681,7 @@ mod tests {
         let mut s = basic_connection();
         assert_eq!(s.state(), State::Idle);
 
-        let out = s.process(Input::Connected);
+        let out = s.process(Input::Connected(false));
         assert_eq!(s.state(), State::OpenSent);
         assert!(has_output(&out, |o| matches!(
             o,
@@ -668,7 +696,7 @@ mod tests {
     #[test]
     fn open_exchange_reaches_established() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         assert_eq!(s.state(), State::OpenSent);
 
         // Receive remote OPEN
@@ -712,7 +740,7 @@ mod tests {
     #[test]
     fn asn_mismatch_sends_notification() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
 
         let out = s.process(Input::MessageReceived(remote_open(
             65099,
@@ -729,7 +757,7 @@ mod tests {
     #[test]
     fn open_in_unexpected_state_sends_fsm_error() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         let _ = s.process(Input::MessageReceived(remote_open(
             65002,
             remote_router_id(),
@@ -764,7 +792,7 @@ mod tests {
             0, // accept any
             FnvHashMap::default(),
         );
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
 
         let out = s.process(Input::MessageReceived(remote_open(
             65099,
@@ -778,7 +806,7 @@ mod tests {
     #[test]
     fn holdtime_negotiation_uses_minimum() {
         let mut s = basic_connection(); // local_holdtime = 90
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
 
         let _ = s.process(Input::MessageReceived(remote_open(
             65002,
@@ -791,7 +819,7 @@ mod tests {
     #[test]
     fn holdtimer_expiry_shuts_down() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         let _ = s.process(Input::MessageReceived(remote_open(
             65002,
             remote_router_id(),
@@ -810,7 +838,7 @@ mod tests {
     #[test]
     fn connected_starts_initial_hold_timer() {
         let mut s = basic_connection();
-        let out = s.process(Input::Connected);
+        let out = s.process(Input::Connected(false));
         assert!(has_output(&out, |o| matches!(
             o,
             Output::SetHoldTimer(INITIAL_HOLD_SECS)
@@ -820,7 +848,7 @@ mod tests {
     #[test]
     fn hold_timer_expired_in_open_sent_shuts_down() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         let out = s.process(Input::HoldTimerExpired);
         assert!(has_output(&out, |o| matches!(
             o,
@@ -831,7 +859,7 @@ mod tests {
     #[test]
     fn keepalive_timer_expired_sends_keepalive_and_rearms() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         let _ = s.process(Input::MessageReceived(remote_open(
             65002,
             remote_router_id(),
@@ -854,7 +882,7 @@ mod tests {
     #[test]
     fn keepalive_timer_expired_in_established_sends_keepalive_and_rearms() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         let _ = s.process(Input::MessageReceived(remote_open(
             65002,
             remote_router_id(),
@@ -889,7 +917,7 @@ mod tests {
     #[test]
     fn keepalive_in_established_resets_hold_timer() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         let _ = s.process(Input::MessageReceived(remote_open(
             65002,
             remote_router_id(),
@@ -907,7 +935,7 @@ mod tests {
     #[test]
     fn update_in_established_resets_hold_timer() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         let _ = s.process(Input::MessageReceived(remote_open(
             65002,
             remote_router_id(),
@@ -943,7 +971,7 @@ mod tests {
     #[test]
     fn keepalive_in_unexpected_state_sends_fsm_error() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         // State is now OpenSent — KEEPALIVE before OPEN is an FSM error
         let out = s.process(Input::MessageReceived(bgp::Message::Keepalive));
         assert!(has_output(&out, |o| matches!(
@@ -959,7 +987,7 @@ mod tests {
     #[test]
     fn route_refresh_in_established_triggers_readvertise() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         let _ = s.process(Input::MessageReceived(remote_open(
             65002,
             remote_router_id(),
@@ -981,7 +1009,7 @@ mod tests {
     #[test]
     fn route_refresh_in_non_established_sends_fsm_error() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         // State is OpenSent
         let out = s.process(Input::MessageReceived(bgp::Message::RouteRefresh {
             family: Family::IPV4,
@@ -999,7 +1027,7 @@ mod tests {
     #[test]
     fn notification_received_shuts_down() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
 
         let notif = bgp::Message::Notification(rustybgp_packet::BgpError::Other {
             code: 6,
@@ -1016,7 +1044,7 @@ mod tests {
     #[test]
     fn update_in_non_established_shuts_down() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         assert_eq!(s.state(), State::OpenSent);
 
         let update = bgp::Message::Update(bgp::Update {
@@ -1034,7 +1062,7 @@ mod tests {
     #[test]
     fn update_sent_in_established_resets_keepalive_timer() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         let _ = s.process(Input::MessageReceived(remote_open(
             65002,
             remote_router_id(),
@@ -1053,7 +1081,7 @@ mod tests {
     #[test]
     fn update_sent_in_non_established_is_noop() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
         assert_eq!(s.state(), State::OpenSent);
 
         let out = s.process(Input::UpdateSent);
@@ -1063,7 +1091,7 @@ mod tests {
     #[test]
     fn admin_shutdown_sends_cease() {
         let mut s = basic_connection();
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
 
         let out = s.process(Input::AdminShutdown);
         assert!(has_output(&out, |o| matches!(
@@ -1086,7 +1114,7 @@ mod tests {
             65002,
             FnvHashMap::default(),
         );
-        let _ = s.process(Input::Connected);
+        let _ = s.process(Input::Connected(false));
 
         let out = s.process(Input::MessageReceived(remote_open(
             65002,
@@ -1115,7 +1143,7 @@ mod tests {
     }
 
     fn connect(peer: &mut PeerFsm, role: Role) -> Vec<PeerFsmOutput> {
-        peer.process(role, Input::Connected)
+        peer.process(role, Input::Connected(false))
     }
 
     fn remote_open_msg(asn: u32, router_id: u32) -> bgp::Message {
@@ -1486,7 +1514,7 @@ mod tests {
         assert!(peer.connection(Role::Active).is_none());
 
         // Reconnect succeeds: OPEN is sent, no CloseConnection.
-        let out = peer.process(Role::Active, Input::Connected);
+        let out = peer.process(Role::Active, Input::Connected(false));
         assert!(!has_peer_output(&out, |o| matches!(
             o,
             PeerFsmOutput::CloseConnection


### PR DESCRIPTION
The R-bit (Restart State) in the GR capability is a transient global property -- it signals that *this router* is currently the restarting speaker -- yet it was being baked into per-peer PeerConfig::local_cap at add_peer time (is_restarting parameter to PeerParams::build).  This forced process_restarting_outputs() to iterate every peer and scrub the bit when recovery completed, which was both awkward and fragile.

The fix:
- local_cap now stores the GR capability without the R-bit (N-bit only).
- Input::Connected gains a bool payload (is_restarting).
- PeerFsm::on_connected() uses that bool to build the Connection's effective caps with R-bit set only when needed.
- accept_connection() reads selection_deferral.is_some() -- the single source of truth for restarting state -- and passes it through.
- The per-peer R-bit scrub loop in process_restarting_outputs() is removed; setting selection_deferral = None is sufficient.
- PeerParams::build() and Global::add_peer() drop the is_restarting parameter entirely.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>