### PR TITLE
bmp: replace polling with CancellationToken for clean task shutdown

### DIFF
--- a/daemon/src/bmp.rs
+++ b/daemon/src/bmp.rs
@@ -16,10 +16,12 @@ use fnv::{FnvHashMap, FnvHashSet};
 use futures::{SinkExt, StreamExt};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 use tokio::net::TcpStream;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::codec::Framed;
+use tokio_util::sync::CancellationToken;
 
 use rustybgp_packet::{self as packet, Family, bgp, bmp};
 
@@ -193,27 +195,36 @@ pub(crate) fn session_down_to_bmp(
     }
 }
 
-#[derive(Default)]
+pub(crate) struct BmpClientState {
+    pub(crate) uptime: AtomicU64,
+    pub(crate) downtime: AtomicU64,
+}
+
+impl BmpClientState {
+    fn new() -> Arc<Self> {
+        Arc::new(BmpClientState {
+            uptime: AtomicU64::new(0),
+            downtime: AtomicU64::new(0),
+        })
+    }
+}
+
 pub(crate) struct BmpClient {
-    pub(crate) configured_time: u64,
-    pub(crate) uptime: u64,
-    pub(crate) downtime: u64,
+    pub(crate) cancel: CancellationToken,
+    pub(crate) state: Arc<BmpClientState>,
 }
 
 impl BmpClient {
     pub(crate) fn new() -> Self {
         BmpClient {
-            configured_time: SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-            ..Default::default()
+            cancel: CancellationToken::new(),
+            state: BmpClientState::new(),
         }
     }
 
-    pub(crate) async fn serve(
+    async fn serve(
         stream: TcpStream,
-        _sockaddr: SocketAddr,
+        cancel: CancellationToken,
         global: GlobalHandle,
         tables: TableHandle,
     ) {
@@ -349,6 +360,7 @@ impl BmpClient {
                         None => break,
                     }
                 }
+                _ = cancel.cancelled() => break,
             }
         }
         tables.unsubscribe(subscription.id).await;
@@ -356,44 +368,54 @@ impl BmpClient {
 
     pub(crate) fn try_connect(
         sockaddr: SocketAddr,
-        configured_time: u64,
+        cancel: CancellationToken,
+        state: Arc<BmpClientState>,
         global: GlobalHandle,
         tables: TableHandle,
     ) {
         tokio::spawn(async move {
             loop {
-                if let Ok(Ok(stream)) = tokio::time::timeout(
-                    tokio::time::Duration::from_secs(5),
-                    TcpStream::connect(sockaddr),
-                )
-                .await
-                {
-                    if let Some(client) = global.write().await.bmp_clients.get_mut(&sockaddr) {
-                        client.uptime = SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs();
-                    } else {
-                        break;
-                    }
-                    BmpClient::serve(stream, sockaddr, global.clone(), tables.clone()).await;
-                    if let Some(client) = global.write().await.bmp_clients.get_mut(&sockaddr) {
-                        client.downtime = SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs();
-                    } else {
-                        break;
-                    }
+                let stream = tokio::select! {
+                    r = tokio::time::timeout(
+                        tokio::time::Duration::from_secs(5),
+                        TcpStream::connect(sockaddr),
+                    ) => match r {
+                        Ok(Ok(s)) => s,
+                        _ => {
+                            tokio::select! {
+                                _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {}
+                                _ = cancel.cancelled() => return,
+                            }
+                            continue;
+                        }
+                    },
+                    _ = cancel.cancelled() => return,
+                };
+
+                state.uptime.store(
+                    SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs(),
+                    Ordering::Relaxed,
+                );
+
+                tokio::select! {
+                    _ = BmpClient::serve(stream, cancel.clone(), global.clone(), tables.clone()) => {}
+                    _ = cancel.cancelled() => return,
                 }
-                tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
-                if let Some(client) = global.write().await.bmp_clients.get_mut(&sockaddr) {
-                    if client.configured_time != configured_time {
-                        break;
-                    }
-                } else {
-                    // de-configured
-                    break;
+
+                state.downtime.store(
+                    SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs(),
+                    Ordering::Relaxed,
+                );
+
+                tokio::select! {
+                    _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {}
+                    _ = cancel.cancelled() => return,
                 }
             }
         });

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -38,6 +38,7 @@ use tokio::sync::mpsc;
 use tokio::time::Duration;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::codec::Framed;
+use tokio_util::sync::CancellationToken;
 
 use crate::api::go_bgp_service_server::{GoBgpService, GoBgpServiceServer};
 
@@ -2232,27 +2233,41 @@ impl GoBgpService for GrpcService {
         }
 
         let sockaddr = SocketAddr::new(addr, request.port as u16);
-        match self.global.write().await.bmp_clients.entry(sockaddr) {
-            Occupied(_) => {
+        match self.global.write().await.add_bmp_client(sockaddr) {
+            Err(()) => {
                 return Err(tonic::Status::new(
                     tonic::Code::AlreadyExists,
                     format!("bmp client {} already exists", sockaddr),
                 ));
             }
-            Vacant(v) => {
-                let client = BmpClient::new();
-                let t = client.configured_time;
-                v.insert(client);
-                BmpClient::try_connect(sockaddr, t, self.global.clone(), self.tables.clone());
+            Ok((cancel, state)) => {
+                BmpClient::try_connect(
+                    sockaddr,
+                    cancel,
+                    state,
+                    self.global.clone(),
+                    self.tables.clone(),
+                );
             }
         }
         Ok(tonic::Response::new(api::AddBmpResponse {}))
     }
     async fn delete_bmp(
         &self,
-        _request: tonic::Request<api::DeleteBmpRequest>,
+        request: tonic::Request<api::DeleteBmpRequest>,
     ) -> Result<tonic::Response<api::DeleteBmpResponse>, tonic::Status> {
-        Err(tonic::Status::unimplemented("Not yet implemented"))
+        let request = request.into_inner();
+        let addr = IpAddr::from_str(&request.address)
+            .map_err(|_| tonic::Status::new(tonic::Code::InvalidArgument, "invalid address"))?;
+        let sockaddr = SocketAddr::new(addr, request.port as u16);
+        if self.global.write().await.remove_bmp_client(sockaddr) {
+            Ok(tonic::Response::new(api::DeleteBmpResponse {}))
+        } else {
+            Err(tonic::Status::new(
+                tonic::Code::NotFound,
+                format!("bmp client {} not found", sockaddr),
+            ))
+        }
     }
     type ListBmpStream = Pin<
         Box<dyn Stream<Item = Result<api::ListBmpResponse, tonic::Status>> + Send + Sync + 'static>,
@@ -2265,8 +2280,7 @@ impl GoBgpService for GrpcService {
             .global
             .read()
             .await
-            .bmp_clients
-            .iter()
+            .iter_bmp_clients()
             .map(|(k, v)| api::ListBmpResponse {
                 station: Some(api::list_bmp_response::BmpStation {
                     conf: Some(api::list_bmp_response::bmp_station::Conf {
@@ -2275,11 +2289,13 @@ impl GoBgpService for GrpcService {
                     }),
                     state: Some(api::list_bmp_response::bmp_station::State {
                         uptime: Some(prost_types::Timestamp {
-                            seconds: v.uptime as i64,
+                            seconds: v.state.uptime.load(std::sync::atomic::Ordering::Relaxed)
+                                as i64,
                             nanos: 0,
                         }),
                         downtime: Some(prost_types::Timestamp {
-                            seconds: v.downtime as i64,
+                            seconds: v.state.downtime.load(std::sync::atomic::Ordering::Relaxed)
+                                as i64,
                             nanos: 0,
                         }),
                     }),
@@ -2624,7 +2640,7 @@ pub(crate) struct Global {
     ptable: table::PolicyTable,
 
     rpki_clients: FnvHashMap<SocketAddr, RpkiClient>,
-    pub(crate) bmp_clients: FnvHashMap<SocketAddr, BmpClient>,
+    bmp_clients: FnvHashMap<SocketAddr, BmpClient>,
     pub(crate) mrt_filenames: FnvHashSet<String>,
 
     /// Selection Deferral state machine for the Restarting Speaker (RFC 4724 §4.1).
@@ -2674,6 +2690,36 @@ impl Global {
             selection_deferral: None,
             selection_deferral_timer: None,
         }
+    }
+
+    fn add_bmp_client(
+        &mut self,
+        sockaddr: SocketAddr,
+    ) -> Result<(CancellationToken, Arc<crate::bmp::BmpClientState>), ()> {
+        use std::collections::hash_map::Entry;
+        match self.bmp_clients.entry(sockaddr) {
+            Entry::Occupied(_) => Err(()),
+            Entry::Vacant(v) => {
+                let client = BmpClient::new();
+                let cancel = client.cancel.clone();
+                let state = Arc::clone(&client.state);
+                v.insert(client);
+                Ok((cancel, state))
+            }
+        }
+    }
+
+    fn remove_bmp_client(&mut self, sockaddr: SocketAddr) -> bool {
+        if let Some(client) = self.bmp_clients.remove(&sockaddr) {
+            client.cancel.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn iter_bmp_clients(&self) -> impl Iterator<Item = (&SocketAddr, &BmpClient)> {
+        self.bmp_clients.iter()
     }
 
     fn add_peer(
@@ -2984,15 +3030,16 @@ impl Global {
                 let config = s.config.as_ref().unwrap();
                 let sockaddr =
                     SocketAddr::new(config.address.unwrap(), config.port.unwrap() as u16);
-                match server.bmp_clients.entry(sockaddr) {
-                    Occupied(_) => {
-                        panic!("duplicated bmp server {}", sockaddr);
-                    }
-                    Vacant(v) => {
-                        let client = BmpClient::new();
-                        let t = client.configured_time;
-                        v.insert(client);
-                        BmpClient::try_connect(sockaddr, t, global.clone(), tables.clone());
+                match server.add_bmp_client(sockaddr) {
+                    Err(()) => panic!("duplicated bmp server {}", sockaddr),
+                    Ok((cancel, state)) => {
+                        BmpClient::try_connect(
+                            sockaddr,
+                            cancel,
+                            state,
+                            global.clone(),
+                            tables.clone(),
+                        );
                     }
                 }
             }


### PR DESCRIPTION
The try_connect task previously detected BMP client deletion by sleeping 10 seconds then checking bmp_clients under the global write lock.  This caused up to 10 seconds of delay and required direct map access from inside the task.

Replace the polling approach with CancellationToken (already available via tokio_util).  Each BmpClient carries a token; delete_bmp cancels it and the task exits promptly at whichever select! it is currently blocked on -- the connect attempt, the serve loop (socket read), or the reconnect delay.

uptime/downtime are moved to BmpClientState (Arc<AtomicU64>) so the task can update them without acquiring the global write lock.

bmp_clients is no longer pub(crate); callers use add_bmp_client / remove_bmp_client / iter_bmp_clients on Global instead.

delete_bmp is implemented (was unimplemented!).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>