### PR TITLE
convert: fix fragile get_mut() + set_position() in write_extcom

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -561,8 +561,9 @@ fn write_extcom(c: &mut Cursor<Vec<u8>>, com: api::ExtendedCommunity) -> Result<
                 segment_id2: ensure_u16("segment_id2", m.segment_id2)?,
                 segment_id4: m.segment_id4,
             };
-            mup_ec.encode(c.get_mut());
-            c.set_position(c.position() + 8);
+            let mut buf = bytes::BytesMut::with_capacity(mup::MupExtended::LEN);
+            mup_ec.encode(&mut buf);
+            c.write_all(&buf).unwrap();
         }
         api::extended_community::Extcom::Unknown(u) => {
             if u.value.len() != 8 {
@@ -571,8 +572,7 @@ fn write_extcom(c: &mut Cursor<Vec<u8>>, com: api::ExtendedCommunity) -> Result<
                     u.value.len()
                 )));
             }
-            c.get_mut().extend_from_slice(&u.value);
-            c.set_position(c.position() + 8);
+            c.write_all(&u.value).unwrap();
         }
         _ => {
             return Err(Error::InvalidArgument(


### PR DESCRIPTION
The Mup and Unknown arms used get_mut() to append bytes directly to the underlying Vec regardless of cursor position, then manually advanced the cursor with set_position(). This is fragile: it relies on the cursor always being at the end of the Vec.

Replace both arms with standard Write methods that handle cursor position correctly:
- Mup: encode into a temporary BytesMut buffer via MupExtended::encode, then flush with write_all, keeping encoding details inside the type.
- Unknown: replace extend_from_slice + set_position with write_all.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>