### PR TITLE
daemon: implement reset_peer (hard reset and soft reset IN/OUT)

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -1422,9 +1422,87 @@ impl GoBgpService for GrpcService {
     }
     async fn reset_peer(
         &self,
-        _request: tonic::Request<api::ResetPeerRequest>,
+        request: tonic::Request<api::ResetPeerRequest>,
     ) -> Result<tonic::Response<api::ResetPeerResponse>, tonic::Status> {
-        Err(tonic::Status::unimplemented("Not yet implemented"))
+        let req = request.into_inner();
+        let peer_addr = IpAddr::from_str(&req.address)
+            .map_err(|_| tonic::Status::invalid_argument("invalid peer address"))?;
+
+        if !req.soft {
+            // Hard reset: send CEASE NOTIFICATION to drop the session.
+            // Unlike delete_peer the peer remains in the configuration
+            // and will attempt to reconnect.
+            //
+            // If GR helper mode is active (stale routes held for the peer),
+            // aborting gr_restart_timer here causes the subsequent session
+            // teardown to withdraw the stale routes, which matches the
+            // behaviour of a restart-timer expiry.
+            let global = self.global.read().await;
+            let peer = global
+                .peers
+                .get(&peer_addr)
+                .ok_or_else(|| tonic::Status::not_found("peer not found"))?;
+            let cease = bgp::Message::Notification(rustybgp_packet::BgpError::Other {
+                code: 6,
+                subcode: 3,
+                data: vec![],
+            });
+            let mut ctx = peer.context.lock().unwrap();
+            if let Some(h) = ctx.gr_restart_timer.take() {
+                h.abort();
+            }
+            let mut arb = ctx.conn_arbiter.lock().unwrap();
+            for tx in [arb.active_close_tx.take(), arb.passive_close_tx.take()]
+                .into_iter()
+                .flatten()
+            {
+                let _ = tx.send(CloseReason::SendMessage(cease.clone()));
+            }
+            return Ok(tonic::Response::new(api::ResetPeerResponse {}));
+        }
+
+        // Soft reset: re-apply policy / re-advertise without dropping the session.
+        //
+        // Soft reset IN re-applies the current import policy to all non-stale
+        // RIB entries from this peer.  Stale entries (held during GR helper
+        // mode) are intentionally skipped: they are transient, awaiting either
+        // the peer's reconnection or restart-timer expiry.  Re-applying policy
+        // to them would cause spurious churn for no practical benefit.  There
+        // is no RFC guidance on this interaction; skipping stale entries is a
+        // pragmatic implementation choice.
+        //
+        // Soft reset OUT re-advertises the current best paths to this peer via
+        // do_route_refresh().  If the session is not Established (e.g., the
+        // peer is in GR helper mode and the session is currently down),
+        // do_route_refresh() exits early, making this a safe no-op.
+        let direction = api::reset_peer_request::Direction::try_from(req.direction)
+            .unwrap_or(api::reset_peer_request::Direction::Unspecified);
+        let (do_in, do_out) = match direction {
+            api::reset_peer_request::Direction::Both => (true, true),
+            api::reset_peer_request::Direction::In => (true, false),
+            api::reset_peer_request::Direction::Out => (false, true),
+            api::reset_peer_request::Direction::Unspecified => {
+                return Err(tonic::Status::invalid_argument(
+                    "direction must be specified",
+                ));
+            }
+        };
+
+        // Verify the peer exists before touching the table.
+        {
+            let global = self.global.read().await;
+            if !global.peers.contains_key(&peer_addr) {
+                return Err(tonic::Status::not_found("peer not found"));
+            }
+        }
+
+        if do_in {
+            self.tables.soft_reset_in(peer_addr).await;
+        }
+        if do_out {
+            self.tables.soft_reset_out(peer_addr).await;
+        }
+        Ok(tonic::Response::new(api::ResetPeerResponse {}))
     }
     async fn shutdown_peer(
         &self,
@@ -2806,6 +2884,8 @@ async fn add_policy_assignment(
 
 pub(crate) enum ToPeerEvent {
     NlriChange(table::NlriChange),
+    /// Trigger a soft reset OUT: re-advertise all current best paths.
+    SoftResetOut,
 }
 
 fn enable_active_connect(peer: &mut Peer, ch: mpsc::UnboundedSender<TcpStream>) {
@@ -4857,6 +4937,15 @@ impl PeerSession {
                     match msg {
                         Some(Some(ToPeerEvent::NlriChange(update))) => {
                             self.handle_prefix_update(update);
+                        }
+                        Some(Some(ToPeerEvent::SoftResetOut)) => {
+                            // Re-advertise all current best paths to this peer.
+                            // do_route_refresh() checks SessionState::Established
+                            // internally, so if the session is down (e.g. GR
+                            // helper mode) this is a safe no-op.
+                            for family in self.pending.keys().cloned().collect::<Vec<_>>() {
+                                self.do_route_refresh(family).await;
+                            }
                         }
                         Some(None) => {
                             self.peer_event_rx = None;

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -221,6 +221,45 @@ impl TableManager {
         );
     }
 
+    /// Re-applies the current import policy to all non-stale paths from `peer`
+    /// across every shard and distributes any routing changes to peers.
+    pub(crate) async fn soft_reset_in(&self, peer: IpAddr) {
+        let import_policy = self.import_policy.load_full();
+        let export_policy = self.export_policy.load_full();
+        let kernel_tx = self.kernel_tx.load_full();
+        for shard in &self.shards {
+            let mut t = shard.lock().await;
+            t.soft_reset_in(
+                peer,
+                import_policy.as_deref(),
+                kernel_tx.as_deref(),
+                export_policy.as_deref(),
+            );
+        }
+    }
+
+    /// Triggers a soft reset OUT for `peer`: re-advertises all current best
+    /// paths to that peer.  Sends a [`ToPeerEvent::SoftResetOut`] on the
+    /// peer's event channel; the peer session handles it by calling
+    /// `do_route_refresh` for each negotiated family.
+    ///
+    /// If the peer's session is not Established (e.g., peer is in GR helper
+    /// mode and the session is down), the peer session's `do_route_refresh`
+    /// exits early, making this a safe no-op.
+    pub(crate) async fn soft_reset_out(&self, peer: IpAddr) {
+        // All shards register the same sender for each peer; shard 0 suffices
+        // for the lookup.
+        let tx = self.shards[0]
+            .lock()
+            .await
+            .peer_event_tx
+            .get(&peer)
+            .cloned();
+        if let Some(tx) = tx {
+            let _ = tx.send(ToPeerEvent::SoftResetOut);
+        }
+    }
+
     pub(crate) async fn drop_families(&self, addr: IpAddr, families: &[Family]) {
         let kernel_tx = self.kernel_tx.load_full();
         for shard in &self.shards {
@@ -684,6 +723,44 @@ impl TableShard {
         // Fan out to all peer channels.
         for tx in self.peer_event_tx.values() {
             let _ = tx.send(ToPeerEvent::NlriChange(filtered_update.clone()));
+        }
+    }
+
+    /// Re-applies the current import policy to all non-stale paths from `peer`.
+    ///
+    /// Each path is re-inserted via [`table::Table::insert`] using its stored
+    /// pre-policy attributes (`original_attr`), which replaces the existing RIB
+    /// entry and triggers best-path recalculation and peer notification if the
+    /// post-policy result changed.
+    ///
+    /// Stale paths (GR helper mode) are skipped; see
+    /// [`table::Table::collect_peer_paths_for_soft_reset`] for the rationale.
+    pub(crate) fn soft_reset_in(
+        &mut self,
+        peer: std::net::IpAddr,
+        import_policy: Option<&table::PolicyAssignment>,
+        kernel_tx: Option<&mpsc::UnboundedSender<KernelRouteEvent>>,
+        export_policy: Option<&table::PolicyAssignment>,
+    ) {
+        let paths = self.rtable.collect_peer_paths_for_soft_reset(peer);
+        for (family, net, remote_path_id, nexthop, source, original_attr, timestamp) in paths {
+            let mut nh = nexthop;
+            let (filtered, post_policy_attr) =
+                crate::policy::apply_import(import_policy, &source, &net, &original_attr, &mut nh);
+            if let table::InsertResult::Changed(update) = self.rtable.insert(
+                source,
+                family,
+                net,
+                remote_path_id,
+                nh,
+                post_policy_attr,
+                Some(original_attr),
+                filtered,
+                None,
+                timestamp,
+            ) {
+                self.distribute_update(update, kernel_tx, export_policy);
+            }
         }
     }
 

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -419,6 +419,17 @@ impl InsertResult {
     }
 }
 
+/// One path entry returned by [`Table::collect_peer_paths_for_soft_reset`].
+pub type SoftResetPath = (
+    Family,
+    packet::Nlri,
+    u32,
+    bgp::Nexthop,
+    Arc<Source>,
+    Arc<Vec<packet::Attribute>>,
+    SystemTime,
+);
+
 /// Result of a single `Table::insert()` or `Table::remove()` operation.
 ///
 /// Non-Add-Path peers can skip processing when `best_changed` is false.
@@ -625,6 +636,47 @@ impl Table {
 
     pub fn families(&self) -> impl Iterator<Item = Family> + '_ {
         self.ribs.keys().filter(|f| **f != Family::EMPTY).copied()
+    }
+
+    /// Collects all non-stale paths from `peer` for use by soft reset IN.
+    ///
+    /// The returned tuples carry the pre-import-policy attributes
+    /// (`original_attr`) so the caller can re-apply the current import policy
+    /// and re-insert with [`Table::insert`].
+    ///
+    /// Stale paths (held during GR helper mode) are intentionally excluded.
+    /// They are transient entries awaiting either peer reconnection or restart
+    /// timer expiry; re-applying policy to them has no practical effect and
+    /// would cause spurious churn.  There is no RFC guidance on soft reset
+    /// interaction with GR stale routes -- this is a pragmatic implementation
+    /// choice.
+    pub fn collect_peer_paths_for_soft_reset(&self, peer: std::net::IpAddr) -> Vec<SoftResetPath> {
+        let mut out = Vec::new();
+        for (family, rib) in &self.ribs {
+            if *family == Family::EMPTY {
+                continue;
+            }
+            for (net, dst) in &rib.destinations {
+                for entry in &dst.entry {
+                    if entry.path.source.remote_addr != peer {
+                        continue;
+                    }
+                    if entry.path.source.is_stale() {
+                        continue;
+                    }
+                    out.push((
+                        *family,
+                        *net,
+                        entry.remote_path_id,
+                        entry.path.nexthop,
+                        Arc::clone(&entry.path.source),
+                        Arc::clone(&entry.original_attr),
+                        entry.timestamp,
+                    ));
+                }
+            }
+        }
+        out
     }
 
     /// Returns paths in the global RIB for the given destination.


### PR DESCRIPTION
Hard reset (soft=false): sends CEASE NOTIFICATION to drop the session without removing the peer from configuration.  The peer will attempt to reconnect.  If GR helper mode is active, gr_restart_timer is aborted before sending CEASE so the subsequent session teardown withdraws stale routes, matching the behaviour of a restart-timer expiry.

Soft reset IN (soft=true, direction=In|Both): re-applies the current import policy to all non-stale paths from the peer by re-inserting them into the RIB with their stored original_attr as input.  The existing Table::insert() machinery handles best-path recalculation and peer notification.  Stale paths (held during GR helper mode) are intentionally skipped -- they are transient entries awaiting reconnection or timer expiry, and re-applying policy to them has no practical benefit.  There is no RFC guidance on this interaction; skipping stale entries is a pragmatic implementation choice documented in the code.

Soft reset OUT (soft=true, direction=Out|Both): sends ToPeerEvent::SoftResetOut to the peer session, which calls do_route_refresh() for each negotiated family.  do_route_refresh() exits early when the session is not Established (e.g., peer in GR helper mode), making this a safe no-op.

Add Table::collect_peer_paths_for_soft_reset() and the SoftResetPath type alias to the table crate; add TableShard::soft_reset_in(), TableManager::soft_reset_in(), and TableManager::soft_reset_out() to the daemon.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>