### PR TITLE
daemon: allow shutdown_peer on admin-down peers

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -1511,12 +1511,6 @@ impl GoBgpService for GrpcService {
         if let Ok(peer_addr) = IpAddr::from_str(&request.into_inner().address) {
             for (addr, p) in &mut self.global.write().await.peers {
                 if addr == &peer_addr {
-                    if p.admin_down {
-                        return Err(tonic::Status::new(
-                            tonic::Code::InvalidArgument,
-                            "peer is admin-down",
-                        ));
-                    }
                     let ctx = p.context.lock().unwrap();
                     let mut arb = ctx.conn_arbiter.lock().unwrap();
                     for tx in [arb.active_close_tx.take(), arb.passive_close_tx.take()]


### PR DESCRIPTION
Returning InvalidArgument when the peer was already admin-down was over-strict. RustyBGP follows a desired-state API design where operations are idempotent: if the peer is already down the goal is satisfied, so shutdown_peer succeeds silently as a no-op.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>