### PR TITLE
daemon: suppress GR helper mode when peer is admin-down

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -5213,8 +5213,20 @@ impl PeerSession {
 
     async fn run(mut self, global: GlobalHandle, active_conn_tx: mpsc::UnboundedSender<TcpStream>) {
         let tables = self.tables.clone();
-        let info = self.session_loop(&global).await;
+        let mut info = self.session_loop(&global).await;
         let remote_addr = info.remote_addr;
+
+        // Suppress GR helper mode when the peer is admin-down: holding stale
+        // routes for a peer that is intentionally disabled serves no purpose.
+        if global
+            .read()
+            .await
+            .peers
+            .get(&remote_addr)
+            .is_some_and(|p| p.admin_down)
+        {
+            info.negotiated_gr = None;
+        }
 
         // Operate on PeerContext directly via self.context — no global lock needed
         // for the ctx-only operations.


### PR DESCRIPTION
When disable_peer is called with notification_enabled GR negotiated, apply_disconnect could enter GR helper mode (starting gr_restart_timer and holding stale routes) even though the peer is intentionally disabled and will not reconnect.

Check admin_down in PeerSession::run after session_loop returns and clear negotiated_gr so apply_disconnect takes the non-GR path. Stale routes are not held for admin-down peers.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>