### PR TITLE
daemon: enable unreachable_pub lint

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #![recursion_limit = "1024"]
+#![warn(unreachable_pub)]
 pub(crate) use rustybgp_api as api;
 pub(crate) use rustybgp_config as config;
 mod auth;


### PR DESCRIPTION
Catches pub(crate) items that are only used within the same module and should be private, keeping visibility declarations accurate.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>