### PR TITLE
packet,kernel,daemon: introduce KernelRouteChange for kernel FIB updates

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -2842,22 +2842,9 @@ impl GoBgpService for GrpcService {
                 tokio::spawn(connection);
                 let (tx, mut rx) = mpsc::unbounded_channel();
                 tokio::spawn(async move {
-                    while let Some(event) = rx.recv().await {
-                        match event {
-                            KernelRouteEvent::Install {
-                                dst,
-                                prefix_len,
-                                nexthop,
-                            } => {
-                                if let Err(e) = handle.install(dst, prefix_len, nexthop, 0).await {
-                                    log::error!("kernel route install failed: {}", e);
-                                }
-                            }
-                            KernelRouteEvent::Withdraw { dst, prefix_len } => {
-                                if let Err(e) = handle.withdraw(dst, prefix_len).await {
-                                    log::error!("kernel route withdraw failed: {}", e);
-                                }
-                            }
+                    while let Some(change) = rx.recv().await {
+                        if let Err(e) = handle.apply(&change).await {
+                            log::error!("kernel route update failed: {}", e);
                         }
                     }
                 });
@@ -3541,24 +3528,9 @@ impl Global {
                     tokio::spawn(connection);
                     let (tx, mut rx) = mpsc::unbounded_channel();
                     tokio::spawn(async move {
-                        while let Some(event) = rx.recv().await {
-                            match event {
-                                KernelRouteEvent::Install {
-                                    dst,
-                                    prefix_len,
-                                    nexthop,
-                                } => {
-                                    if let Err(e) =
-                                        handle.install(dst, prefix_len, nexthop, 0).await
-                                    {
-                                        log::error!("kernel route install failed: {}", e);
-                                    }
-                                }
-                                KernelRouteEvent::Withdraw { dst, prefix_len } => {
-                                    if let Err(e) = handle.withdraw(dst, prefix_len).await {
-                                        log::error!("kernel route withdraw failed: {}", e);
-                                    }
-                                }
+                        while let Some(change) = rx.recv().await {
+                            if let Err(e) = handle.apply(&change).await {
+                                log::error!("kernel route update failed: {}", e);
                             }
                         }
                     });
@@ -3852,18 +3824,6 @@ impl Global {
             global.write().await.listen_sockets.clear();
         }
     }
-}
-
-pub(crate) enum KernelRouteEvent {
-    Install {
-        dst: IpAddr,
-        prefix_len: u8,
-        nexthop: IpAddr,
-    },
-    Withdraw {
-        dst: IpAddr,
-        prefix_len: u8,
-    },
 }
 
 use crate::table_manager::{PeerDownData, PeerUpData, SubscriptionId, TableManager};

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -22,7 +22,7 @@ use tokio::sync::{Mutex, mpsc};
 use rustybgp_packet::{self as packet, Family, bgp};
 use rustybgp_table as table;
 
-use crate::event::{KernelRouteEvent, ToPeerEvent};
+use crate::event::ToPeerEvent;
 
 /// Opaque subscription handle returned by [`TableManager::subscribe`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -78,7 +78,7 @@ pub(crate) type TableHandle = Arc<TableManager>;
 pub(crate) struct TableManager {
     pub(crate) shards: Vec<Mutex<TableShard>>,
     rpki: std::sync::RwLock<table::RpkiTable>,
-    pub(crate) kernel_tx: ArcSwapOption<mpsc::UnboundedSender<KernelRouteEvent>>,
+    pub(crate) kernel_tx: ArcSwapOption<mpsc::UnboundedSender<packet::KernelRouteChange>>,
     pub(crate) import_policy: ArcSwapOption<table::PolicyAssignment>,
     pub(crate) export_policy: ArcSwapOption<table::PolicyAssignment>,
     next_sub_id: std::sync::atomic::AtomicU64,
@@ -524,7 +524,7 @@ impl TableShard {
         &mut self,
         addr: IpAddr,
         family: Family,
-        kernel_tx: Option<&mpsc::UnboundedSender<KernelRouteEvent>>,
+        kernel_tx: Option<&mpsc::UnboundedSender<packet::KernelRouteChange>>,
     ) {
         for change in self.rtable.drop(addr, family) {
             self.distribute_update(change, kernel_tx);
@@ -535,7 +535,7 @@ impl TableShard {
         &mut self,
         addr: IpAddr,
         family: Family,
-        kernel_tx: Option<&mpsc::UnboundedSender<KernelRouteEvent>>,
+        kernel_tx: Option<&mpsc::UnboundedSender<packet::KernelRouteChange>>,
     ) {
         for change in self.rtable.restale(addr, family) {
             self.distribute_update(change, kernel_tx);
@@ -565,47 +565,24 @@ impl TableShard {
         }
     }
 
-    pub(crate) fn distribute_update(
+    fn distribute_update(
         &self,
         update: table::NlriChange,
-        kernel_tx: Option<&mpsc::UnboundedSender<KernelRouteEvent>>,
+        kernel_tx: Option<&mpsc::UnboundedSender<packet::KernelRouteChange>>,
     ) {
         // Kernel route update for rank-1 best (raw, without export policy).
-        if update.best_changed
-            && let Some(tx) = kernel_tx
+        // kernel_tx is rarely set, so check it first.
+        if let Some(tx) = kernel_tx
+            && update.best_changed
         {
-            let (dst, prefix_len) = match update.net {
-                packet::Nlri::V4(net) => (IpAddr::from(net.addr), net.mask),
-                packet::Nlri::V6(net) => (IpAddr::from(net.addr), net.mask),
-                packet::Nlri::Mup(_) => {
-                    // Send to peers but skip kernel for MUP NLRIs.
-                    for tx in self.peer_event_tx.values() {
-                        let _ = tx.send(ToPeerEvent::NlriChange(update.clone()));
-                    }
-                    return;
-                }
+            let nexthops = match update.new_best() {
+                None => vec![],
+                Some(best) => best.nexthop.into_iter().collect(),
             };
-            match update.new_best() {
-                None => {
-                    let _ = tx.send(KernelRouteEvent::Withdraw { dst, prefix_len });
-                }
-                Some(best) => {
-                    if let Some(nexthop) = best.nexthop.map(|n| n.addr()) {
-                        if matches!(
-                            (dst, nexthop),
-                            (IpAddr::V4(_), IpAddr::V4(_)) | (IpAddr::V6(_), IpAddr::V6(_))
-                        ) {
-                            let _ = tx.send(KernelRouteEvent::Install {
-                                dst,
-                                prefix_len,
-                                nexthop,
-                            });
-                        } else {
-                            let _ = tx.send(KernelRouteEvent::Withdraw { dst, prefix_len });
-                        }
-                    }
-                }
-            }
+            let _ = tx.send(packet::KernelRouteChange {
+                net: update.net,
+                nexthops,
+            });
         }
 
         // Fan out raw NlriChange to all peer channels.
@@ -628,7 +605,7 @@ impl TableShard {
         &mut self,
         peer: std::net::IpAddr,
         import_policy: Option<&table::PolicyAssignment>,
-        kernel_tx: Option<&mpsc::UnboundedSender<KernelRouteEvent>>,
+        kernel_tx: Option<&mpsc::UnboundedSender<packet::KernelRouteChange>>,
     ) {
         let paths = self.rtable.collect_adj_in_paths(peer);
         for (family, net, remote_path_id, mut nh, source, original_attr, timestamp) in paths {
@@ -655,7 +632,7 @@ impl TableShard {
         &mut self,
         addr: IpAddr,
         family: Family,
-        kernel_tx: Option<&mpsc::UnboundedSender<KernelRouteEvent>>,
+        kernel_tx: Option<&mpsc::UnboundedSender<packet::KernelRouteChange>>,
     ) {
         for change in self.rtable.drop_stale(addr, family, None) {
             self.distribute_update(change, kernel_tx);
@@ -665,7 +642,7 @@ impl TableShard {
     pub(crate) fn end_deferral(
         &mut self,
         family: Family,
-        kernel_tx: Option<&mpsc::UnboundedSender<KernelRouteEvent>>,
+        kernel_tx: Option<&mpsc::UnboundedSender<packet::KernelRouteChange>>,
     ) {
         for change in self.rtable.end_deferral(family) {
             self.distribute_update(change, kernel_tx);

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 rtnetlink = "0.21"
 futures = "0.3"
 thiserror = "2"
+rustybgp-packet = { path = "../packet" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+use rustybgp_packet as packet;
+
 use futures::StreamExt;
 use futures::stream::TryStreamExt;
 use rtnetlink::packet_core::NetlinkPayload;
@@ -92,6 +94,28 @@ impl Handle {
             (IpAddr::V4(dst), IpAddr::V4(gw)) => self.install_v4(dst, prefix_len, gw, metric).await,
             (IpAddr::V6(dst), IpAddr::V6(gw)) => self.install_v6(dst, prefix_len, gw, metric).await,
             _ => Err(Error::FamilyMismatch),
+        }
+    }
+
+    /// Apply a `KernelRouteChange` to the kernel FIB.
+    ///
+    /// Empty `nexthops` withdraws the route; non-empty installs it.
+    /// MUP NLRIs are silently ignored (not representable as kernel routes).
+    /// Family mismatches between dst and nexthop are also silently skipped.
+    pub async fn apply(&self, change: &packet::KernelRouteChange) -> Result<(), Error> {
+        let (dst, prefix_len) = match change.net {
+            packet::Nlri::V4(net) => (IpAddr::V4(net.addr), net.mask),
+            packet::Nlri::V6(net) => (IpAddr::V6(net.addr), net.mask),
+            packet::Nlri::Mup(_) => return Ok(()),
+        };
+        if change.nexthops.is_empty() {
+            return self.withdraw(dst, prefix_len).await;
+        }
+        // Use the first nexthop; multipath support to be added later.
+        let nexthop = change.nexthops[0].addr();
+        match self.install(dst, prefix_len, nexthop, 0).await {
+            Err(Error::FamilyMismatch) => Ok(()),
+            other => other,
         }
     }
 

--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -20,6 +20,14 @@ pub use self::bgp::{
 pub use self::error::{BgpError, Error};
 pub use self::frame::BgpFramer;
 
+/// A route change to be applied to the kernel FIB.
+///
+/// `nexthops` empty means withdraw; non-empty means install (multipath when >1).
+pub struct KernelRouteChange {
+    pub net: Nlri,
+    pub nexthops: Vec<bgp::Nexthop>,
+}
+
 pub mod bmp;
 pub mod error;
 pub mod frame;


### PR DESCRIPTION
Previously KernelRouteEvent (Install/Withdraw) was defined in the daemon and converted from NlriChange inside distribute_update, mixing kernel FIB concerns into the routing table layer.

Add KernelRouteChange { net, nexthops } to rustybgp-packet, where empty nexthops means withdraw and multiple nexthops prepares for ECMP support.  The kernel crate gains Handle::apply() which translates KernelRouteChange into netlink install/withdraw calls; family-specific exclusions (MUP, family mismatch) are handled there rather than in daemon.

daemon's distribute_update now builds a KernelRouteChange directly from NlriChange.new_best() and sends it on the channel, removing KernelRouteEvent entirely.  kernel_tx is checked before best_changed since kernel integration is rarely enabled.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>