### PR TITLE
daemon: expand PeerGroup fields and add inheritance tests

### DIFF
--- a/daemon/src/auth.rs
+++ b/daemon/src/auth.rs
@@ -73,3 +73,36 @@ pub(crate) fn set_md5sig(rawfd: RawFd, addr: &IpAddr, key: &str) {
 // for now, let's keep things simple
 #[cfg(not(target_os = "linux"))]
 pub(crate) fn set_md5sig(_rawfd: RawFd, _addr: &IpAddr, _key: &str) {}
+
+/// Set the minimum acceptable TTL for incoming packets (RFC 5082 GTSM).
+/// Packets arriving with TTL < ttl_min are dropped by the kernel.
+/// IPv4 uses IP_MINTTL; IPv6 uses IPV6_MINHOPCOUNT.
+#[cfg(target_os = "linux")]
+pub(crate) fn set_min_ttl(rawfd: RawFd, addr: &IpAddr, ttl_min: u8) {
+    let ttl_min = ttl_min as libc::c_int;
+    unsafe {
+        match addr {
+            IpAddr::V4(_) => {
+                let _ = libc::setsockopt(
+                    rawfd,
+                    libc::IPPROTO_IP,
+                    libc::IP_MINTTL,
+                    &ttl_min as *const _ as *const _,
+                    std::mem::size_of::<libc::c_int>() as u32,
+                );
+            }
+            IpAddr::V6(_) => {
+                let _ = libc::setsockopt(
+                    rawfd,
+                    libc::IPPROTO_IPV6,
+                    libc::IPV6_MINHOPCOUNT,
+                    &ttl_min as *const _ as *const _,
+                    std::mem::size_of::<libc::c_int>() as u32,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn set_min_ttl(_rawfd: RawFd, _addr: &IpAddr, _ttl_min: u8) {}

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -810,42 +810,7 @@ impl TryFrom<&api::Peer> for PeerParams {
             })
             .collect();
 
-        let graceful_restart = {
-            const DEFAULT_RESTART_TIME: u16 = 120;
-
-            let gr = p.graceful_restart.as_ref();
-            if gr.is_some_and(|g| g.enabled) {
-                let gr_families: Vec<Family> = p
-                    .afi_safis
-                    .iter()
-                    .filter(|a| {
-                        a.mp_graceful_restart
-                            .as_ref()
-                            .is_some_and(|m| m.config.as_ref().is_some_and(|c| c.enabled))
-                    })
-                    .filter_map(|a| {
-                        let f = a.config.as_ref()?.family.as_ref()?;
-                        Some(convert::family_from_api(f))
-                    })
-                    .collect();
-
-                if !gr_families.is_empty() {
-                    let restart_time = gr
-                        .and_then(|g| u16::try_from(g.restart_time).ok())
-                        .unwrap_or(DEFAULT_RESTART_TIME);
-                    let notification_enabled = gr.is_some_and(|g| g.notification_enabled);
-                    Some(GrPeerConfig {
-                        restart_time,
-                        notification_enabled,
-                        families: gr_families,
-                    })
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        };
+        let graceful_restart = { parse_gr_api(p.graceful_restart.as_ref(), &p.afi_safis) };
 
         let holdtime = {
             let t = p
@@ -968,6 +933,75 @@ fn parse_afi_safis_yaml(
     (families, send_max)
 }
 
+/// Build GrPeerConfig from gRPC GracefulRestart message + per-family mp_graceful_restart flags.
+fn parse_gr_api(
+    gr: Option<&api::GracefulRestart>,
+    afi_safis: &[api::AfiSafi],
+) -> Option<GrPeerConfig> {
+    const DEFAULT_RESTART_TIME: u16 = 120;
+    if !gr.is_some_and(|g| g.enabled) {
+        return None;
+    }
+    let gr_families: Vec<Family> = afi_safis
+        .iter()
+        .filter(|a| {
+            a.mp_graceful_restart
+                .as_ref()
+                .is_some_and(|m| m.config.as_ref().is_some_and(|c| c.enabled))
+        })
+        .filter_map(|a| {
+            let f = a.config.as_ref()?.family.as_ref()?;
+            Some(convert::family_from_api(f))
+        })
+        .collect();
+    if gr_families.is_empty() {
+        return None;
+    }
+    Some(GrPeerConfig {
+        restart_time: gr
+            .and_then(|g| u16::try_from(g.restart_time).ok())
+            .unwrap_or(DEFAULT_RESTART_TIME),
+        notification_enabled: gr.is_some_and(|g| g.notification_enabled),
+        families: gr_families,
+    })
+}
+
+/// Build GrPeerConfig from YAML GracefulRestartConfig + per-family mp-graceful-restart flags.
+fn parse_gr_yaml(
+    afi_safis: &[config::AfiSafi],
+    gr_config: Option<&config::GracefulRestartConfig>,
+) -> Option<GrPeerConfig> {
+    const DEFAULT_RESTART_TIME: u16 = 120;
+    if !gr_config.and_then(|c| c.enabled).unwrap_or(false) {
+        return None;
+    }
+    let gr_families: Vec<Family> = afi_safis
+        .iter()
+        .filter(|a| {
+            a.mp_graceful_restart
+                .as_ref()
+                .and_then(|gr| gr.config.as_ref())
+                .and_then(|c| c.enabled)
+                .unwrap_or(false)
+        })
+        .filter_map(|a| {
+            convert::family_from_config(a.config.as_ref()?.afi_safi_name.as_ref()?).ok()
+        })
+        .collect();
+    if gr_families.is_empty() {
+        return None;
+    }
+    Some(GrPeerConfig {
+        restart_time: gr_config
+            .and_then(|c| c.restart_time)
+            .unwrap_or(DEFAULT_RESTART_TIME),
+        notification_enabled: gr_config
+            .and_then(|c| c.notification_enabled)
+            .unwrap_or(false),
+        families: gr_families,
+    })
+}
+
 impl TryFrom<&config::Neighbor> for PeerParams {
     type Error = String;
 
@@ -985,51 +1019,12 @@ impl TryFrom<&config::Neighbor> for PeerParams {
         let timer_config = n.timers.as_ref().and_then(|t| t.config.as_ref());
 
         let (families, send_max) = parse_afi_safis_yaml(afi_safis);
-
-        // Build GR helper config from graceful-restart + per-family mp-graceful-restart.
-        let graceful_restart = {
-            const DEFAULT_RESTART_TIME: u16 = 120;
-
-            let gr_config = n
-                .graceful_restart
+        let graceful_restart = parse_gr_yaml(
+            afi_safis,
+            n.graceful_restart
                 .as_ref()
-                .and_then(|gr| gr.config.as_ref());
-            let gr_enabled = gr_config.and_then(|c| c.enabled).unwrap_or(false);
-
-            if gr_enabled {
-                let gr_families: Vec<Family> = afi_safis
-                    .iter()
-                    .filter(|a| {
-                        a.mp_graceful_restart
-                            .as_ref()
-                            .and_then(|gr| gr.config.as_ref())
-                            .and_then(|c| c.enabled)
-                            .unwrap_or(false)
-                    })
-                    .filter_map(|a| {
-                        convert::family_from_config(a.config.as_ref()?.afi_safi_name.as_ref()?).ok()
-                    })
-                    .collect();
-
-                if !gr_families.is_empty() {
-                    let restart_time = gr_config
-                        .and_then(|c| c.restart_time)
-                        .unwrap_or(DEFAULT_RESTART_TIME);
-                    let notification_enabled = gr_config
-                        .and_then(|c| c.notification_enabled)
-                        .unwrap_or(false);
-                    Some(GrPeerConfig {
-                        restart_time,
-                        notification_enabled,
-                        families: gr_families,
-                    })
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        };
+                .and_then(|gr| gr.config.as_ref()),
+        );
 
         // Extract per-family prefix limits.
         let mut prefix_limits: FnvHashMap<Family, u32> = FnvHashMap::default();
@@ -1124,6 +1119,7 @@ struct PeerGroup {
     connect_retry_time: Option<u64>,
     families: FnvHashMap<Family, u8>,
     send_max: FnvHashMap<Family, usize>,
+    graceful_restart: Option<GrPeerConfig>,
 }
 
 fn peer_group_to_api(name: &str, pg: &PeerGroup) -> api::PeerGroup {
@@ -1189,25 +1185,45 @@ fn peer_group_to_api(name: &str, pg: &PeerGroup) -> api::PeerGroup {
         afi_safis: pg
             .families
             .iter()
-            .map(|(family, mode)| api::AfiSafi {
-                config: Some(api::AfiSafiConfig {
-                    family: Some(convert::family_to_api(*family)),
-                    ..Default::default()
-                }),
-                add_paths: if *mode != 0 {
-                    Some(api::AddPaths {
-                        config: Some(api::AddPathsConfig {
-                            receive: (*mode & 1) != 0,
-                            send_max: pg.send_max.get(family).copied().unwrap_or(0) as u32,
-                        }),
+            .map(|(family, mode)| {
+                let gr_enabled = pg
+                    .graceful_restart
+                    .as_ref()
+                    .is_some_and(|gr| gr.families.contains(family));
+                api::AfiSafi {
+                    config: Some(api::AfiSafiConfig {
+                        family: Some(convert::family_to_api(*family)),
                         ..Default::default()
-                    })
-                } else {
-                    None
-                },
-                ..Default::default()
+                    }),
+                    add_paths: if *mode != 0 {
+                        Some(api::AddPaths {
+                            config: Some(api::AddPathsConfig {
+                                receive: (*mode & 1) != 0,
+                                send_max: pg.send_max.get(family).copied().unwrap_or(0) as u32,
+                            }),
+                            ..Default::default()
+                        })
+                    } else {
+                        None
+                    },
+                    mp_graceful_restart: if gr_enabled {
+                        Some(api::MpGracefulRestart {
+                            config: Some(api::MpGracefulRestartConfig { enabled: true }),
+                            ..Default::default()
+                        })
+                    } else {
+                        None
+                    },
+                    ..Default::default()
+                }
             })
             .collect(),
+        graceful_restart: pg.graceful_restart.as_ref().map(|gr| api::GracefulRestart {
+            enabled: true,
+            restart_time: gr.restart_time as u32,
+            notification_enabled: gr.notification_enabled,
+            ..Default::default()
+        }),
         ..Default::default()
     }
 }
@@ -1265,6 +1281,7 @@ impl From<api::PeerGroup> for PeerGroup {
                 })
                 .collect(),
             send_max: FnvHashMap::default(),
+            graceful_restart: parse_gr_api(p.graceful_restart.as_ref(), &p.afi_safis),
         }
     }
 }
@@ -1329,6 +1346,12 @@ impl PeerGroup {
                 .filter(|&t| t != 0),
             families,
             send_max,
+            graceful_restart: parse_gr_yaml(
+                pg.afi_safis.as_deref().unwrap_or_default(),
+                pg.graceful_restart
+                    .as_ref()
+                    .and_then(|gr| gr.config.as_ref()),
+            ),
         }
     }
 }
@@ -3633,7 +3656,7 @@ async fn accept_connection(
                 families: group.families.clone(),
                 send_max: group.send_max.clone(),
                 prefix_limits: FnvHashMap::default(),
-                graceful_restart: None,
+                graceful_restart: group.graceful_restart.clone(),
             };
             let _ = g.add_peer(params, None);
             g.peers.get_mut(&remote_addr).unwrap()
@@ -3974,6 +3997,7 @@ impl Global {
                     connect_retry_time: None,
                     families: FnvHashMap::default(),
                     send_max: FnvHashMap::default(),
+                    graceful_restart: None,
                 },
             );
         }
@@ -6120,6 +6144,7 @@ mod tests {
                     connect_retry_time: None,
                     families: FnvHashMap::default(),
                     send_max: FnvHashMap::default(),
+                    graceful_restart: None,
                 },
             );
         }
@@ -6163,6 +6188,7 @@ mod tests {
                     connect_retry_time: Some(30),
                     families: FnvHashMap::default(),
                     send_max: FnvHashMap::default(),
+                    graceful_restart: None,
                 },
             );
         }
@@ -6581,6 +6607,219 @@ mod tests {
         assert_eq!(*pg.send_max.get(&Family::IPV4).unwrap(), 4);
     }
 
+    // --- PeerGroup graceful_restart tests ---
+
+    #[test]
+    fn peer_group_yaml_gr_parsed() {
+        let yaml_pg = config::PeerGroup {
+            config: Some(config::PeerGroupConfig {
+                peer_group_name: Some("g".to_string()),
+                ..Default::default()
+            }),
+            afi_safis: Some(vec![config::AfiSafi {
+                config: Some(config::AfiSafiConfig {
+                    afi_safi_name: Some(config::AfiSafiType::Ipv4Unicast),
+                    ..Default::default()
+                }),
+                mp_graceful_restart: Some(config::MpGracefulRestart {
+                    config: Some(config::MpGracefulRestartConfig {
+                        enabled: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }]),
+            graceful_restart: Some(config::GracefulRestart {
+                config: Some(config::GracefulRestartConfig {
+                    enabled: Some(true),
+                    restart_time: Some(90),
+                    notification_enabled: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pg = PeerGroup::from_yaml(&yaml_pg);
+        let gr = pg.graceful_restart.as_ref().expect("GR should be Some");
+        assert_eq!(gr.restart_time, 90);
+        assert!(gr.notification_enabled);
+        assert_eq!(gr.families, vec![Family::IPV4]);
+    }
+
+    #[test]
+    fn peer_group_yaml_gr_disabled_yields_none() {
+        let yaml_pg = config::PeerGroup {
+            config: Some(config::PeerGroupConfig {
+                peer_group_name: Some("g".to_string()),
+                ..Default::default()
+            }),
+            graceful_restart: Some(config::GracefulRestart {
+                config: Some(config::GracefulRestartConfig {
+                    enabled: Some(false),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pg = PeerGroup::from_yaml(&yaml_pg);
+        assert!(pg.graceful_restart.is_none());
+    }
+
+    #[test]
+    fn peer_group_yaml_gr_no_families_yields_none() {
+        // GR enabled but no afi-safi has mp-graceful-restart -> None
+        let yaml_pg = config::PeerGroup {
+            config: Some(config::PeerGroupConfig {
+                peer_group_name: Some("g".to_string()),
+                ..Default::default()
+            }),
+            afi_safis: Some(vec![config::AfiSafi {
+                config: Some(config::AfiSafiConfig {
+                    afi_safi_name: Some(config::AfiSafiType::Ipv4Unicast),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }]),
+            graceful_restart: Some(config::GracefulRestart {
+                config: Some(config::GracefulRestartConfig {
+                    enabled: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pg = PeerGroup::from_yaml(&yaml_pg);
+        assert!(pg.graceful_restart.is_none());
+    }
+
+    #[tokio::test]
+    async fn peer_group_grpc_gr_roundtrip() {
+        let svc = make_grpc_service();
+        svc.add_peer_group(tonic::Request::new(api::AddPeerGroupRequest {
+            peer_group: Some(api::PeerGroup {
+                conf: Some(api::PeerGroupConf {
+                    peer_group_name: "gr-grp".to_string(),
+                    ..Default::default()
+                }),
+                graceful_restart: Some(api::GracefulRestart {
+                    enabled: true,
+                    restart_time: 150,
+                    notification_enabled: true,
+                    ..Default::default()
+                }),
+                afi_safis: vec![api::AfiSafi {
+                    config: Some(api::AfiSafiConfig {
+                        family: Some(api::Family {
+                            afi: api::family::Afi::Ip as i32,
+                            safi: api::family::Safi::Unicast as i32,
+                        }),
+                        ..Default::default()
+                    }),
+                    mp_graceful_restart: Some(api::MpGracefulRestart {
+                        config: Some(api::MpGracefulRestartConfig { enabled: true }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+        }))
+        .await
+        .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        svc.list_peer_group(tonic::Request::new(api::ListPeerGroupRequest {
+            peer_group_name: "gr-grp".to_string(),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .for_each(|r| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(r.unwrap().peer_group.unwrap()).await;
+            }
+        })
+        .await;
+
+        let got = rx.recv().await.unwrap();
+        let gr = got.graceful_restart.as_ref().expect("GR should be Some");
+        assert!(gr.enabled);
+        assert_eq!(gr.restart_time, 150);
+        assert!(gr.notification_enabled);
+        // mp_graceful_restart should be reflected in afi_safis
+        assert_eq!(got.afi_safis.len(), 1);
+        assert!(
+            got.afi_safis[0]
+                .mp_graceful_restart
+                .as_ref()
+                .and_then(|m| m.config.as_ref())
+                .is_some_and(|c| c.enabled)
+        );
+    }
+
+    #[tokio::test]
+    async fn dynamic_peer_inherits_gr_from_group() {
+        let global = make_global();
+        let tables = make_tables();
+        let (client, server) = loopback_pair().await;
+        let remote_addr = client.local_addr().unwrap().ip();
+
+        let mut families = FnvHashMap::default();
+        families.insert(Family::IPV4, 0u8);
+
+        {
+            let mut g = global.write().await;
+            g.peer_group.insert(
+                "gr-group".to_string(),
+                PeerGroup {
+                    as_number: 65002,
+                    dynamic_peers: vec![DynamicPeer {
+                        prefix: packet::IpNet::new(remote_addr, 32),
+                    }],
+                    route_server_client: false,
+                    holdtime: None,
+                    local_asn: 0,
+                    passive: false,
+                    route_reflector: RouteReflectorConfig::default(),
+                    multihop_ttl: None,
+                    auth_password: None,
+                    connect_retry_time: None,
+                    families,
+                    send_max: FnvHashMap::default(),
+                    graceful_restart: Some(GrPeerConfig {
+                        restart_time: 120,
+                        notification_enabled: false,
+                        families: vec![Family::IPV4],
+                    }),
+                },
+            );
+        }
+
+        let h = accept_connection(&global, &tables, server, crate::fsm::Role::Passive).await;
+        assert!(h.is_some());
+
+        let g = global.read().await;
+        let peer = g.peers.get(&remote_addr).unwrap();
+        let gr = peer
+            .config
+            .graceful_restart
+            .as_ref()
+            .expect("GR should be inherited");
+        assert_eq!(gr.restart_time, 120);
+        assert_eq!(gr.families, vec![Family::IPV4]);
+        // GR capability should appear in local_cap
+        let has_gr_cap = peer
+            .config
+            .local_cap
+            .iter()
+            .any(|c| matches!(c, packet::Capability::GracefulRestart { .. }));
+        assert!(has_gr_cap);
+    }
+
     #[tokio::test]
     async fn dynamic_peer_inherits_families_from_group() {
         let global = make_global();
@@ -6611,6 +6850,7 @@ mod tests {
                     connect_retry_time: None,
                     families,
                     send_max: FnvHashMap::default(),
+                    graceful_restart: None,
                 },
             );
         }

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -1106,9 +1106,14 @@ struct DynamicPeer {
 struct PeerGroup {
     as_number: u32,
     dynamic_peers: Vec<DynamicPeer>,
-    // passive: bool,
     route_server_client: bool,
     holdtime: Option<u64>,
+    local_asn: u32,
+    passive: bool,
+    route_reflector: RouteReflectorConfig,
+    multihop_ttl: Option<u8>,
+    auth_password: Option<String>,
+    connect_retry_time: Option<u64>,
 }
 
 fn peer_group_to_api(name: &str, pg: &PeerGroup) -> api::PeerGroup {
@@ -1116,16 +1121,27 @@ fn peer_group_to_api(name: &str, pg: &PeerGroup) -> api::PeerGroup {
         conf: Some(api::PeerGroupConf {
             peer_group_name: name.to_string(),
             peer_asn: pg.as_number,
+            local_asn: pg.local_asn,
+            auth_password: pg.auth_password.clone().unwrap_or_default(),
             ..Default::default()
         }),
-        timers: pg.holdtime.map(|h| api::Timers {
-            config: Some(api::TimersConfig {
-                hold_time: h,
-                keepalive_interval: h / 3,
-                ..Default::default()
-            }),
-            ..Default::default()
-        }),
+        timers: {
+            let has_holdtime = pg.holdtime.is_some();
+            let has_connect_retry = pg.connect_retry_time.is_some();
+            if has_holdtime || has_connect_retry {
+                Some(api::Timers {
+                    config: Some(api::TimersConfig {
+                        hold_time: pg.holdtime.unwrap_or(0),
+                        keepalive_interval: pg.holdtime.map(|h| h / 3).unwrap_or(0),
+                        connect_retry: pg.connect_retry_time.unwrap_or(0),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+            } else {
+                None
+            }
+        },
         route_server: if pg.route_server_client {
             Some(api::RouteServer {
                 route_server_client: true,
@@ -1134,21 +1150,137 @@ fn peer_group_to_api(name: &str, pg: &PeerGroup) -> api::PeerGroup {
         } else {
             None
         },
+        transport: if pg.passive {
+            Some(api::Transport {
+                passive_mode: true,
+                ..Default::default()
+            })
+        } else {
+            None
+        },
+        route_reflector: if pg.route_reflector.route_reflector_client
+            || pg.route_reflector.route_reflector_cluster_id.is_some()
+        {
+            Some(api::RouteReflector {
+                route_reflector_client: pg.route_reflector.route_reflector_client,
+                route_reflector_cluster_id: pg
+                    .route_reflector
+                    .route_reflector_cluster_id
+                    .map(|a| a.to_string())
+                    .unwrap_or_default(),
+            })
+        } else {
+            None
+        },
+        ebgp_multihop: pg.multihop_ttl.map(|ttl| api::EbgpMultihop {
+            enabled: true,
+            multihop_ttl: ttl as u32,
+        }),
         ..Default::default()
     }
 }
 
 impl From<api::PeerGroup> for PeerGroup {
     fn from(p: api::PeerGroup) -> PeerGroup {
+        let conf = p.conf.as_ref();
         PeerGroup {
-            as_number: p.conf.map_or(0, |c| c.peer_asn),
+            as_number: conf.map_or(0, |c| c.peer_asn),
             dynamic_peers: Vec::new(),
             route_server_client: p.route_server.is_some_and(|c| c.route_server_client),
             holdtime: p
                 .timers
-                .and_then(|t| t.config)
+                .as_ref()
+                .and_then(|t| t.config.as_ref())
                 .map(|c| c.hold_time)
                 .filter(|&h| h != 0),
+            local_asn: conf.map_or(0, |c| c.local_asn),
+            passive: p.transport.is_some_and(|t| t.passive_mode),
+            route_reflector: {
+                let rr = p.route_reflector.as_ref();
+                RouteReflectorConfig {
+                    route_reflector_client: rr.is_some_and(|x| x.route_reflector_client),
+                    route_reflector_cluster_id: rr
+                        .map(|x| x.route_reflector_cluster_id.as_str())
+                        .filter(|s| !s.is_empty())
+                        .and_then(|s| Ipv4Addr::from_str(s).ok()),
+                }
+            },
+            multihop_ttl: p.ebgp_multihop.and_then(|x| {
+                if x.enabled && x.multihop_ttl != 0 {
+                    Some(x.multihop_ttl as u8)
+                } else {
+                    None
+                }
+            }),
+            auth_password: conf
+                .map(|c| c.auth_password.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string()),
+            connect_retry_time: p
+                .timers
+                .and_then(|t| t.config)
+                .map(|c| c.connect_retry)
+                .filter(|&t| t != 0),
+        }
+    }
+}
+
+impl PeerGroup {
+    fn from_yaml(pg: &config::PeerGroup) -> Self {
+        let timer_config = pg.timers.as_ref().and_then(|t| t.config.as_ref());
+        PeerGroup {
+            as_number: pg.config.as_ref().and_then(|c| c.peer_as).unwrap_or(0),
+            dynamic_peers: Vec::new(),
+            route_server_client: pg
+                .route_server
+                .as_ref()
+                .and_then(|rs| rs.config.as_ref())
+                .and_then(|c| c.route_server_client)
+                .unwrap_or(false),
+            holdtime: timer_config
+                .and_then(|c| c.hold_time)
+                .map(|h| h as u64)
+                .filter(|&h| h != 0),
+            local_asn: pg.config.as_ref().and_then(|c| c.local_as).unwrap_or(0),
+            passive: pg
+                .transport
+                .as_ref()
+                .and_then(|t| t.config.as_ref())
+                .and_then(|c| c.passive_mode)
+                .unwrap_or(false),
+            route_reflector: {
+                let rr = pg.route_reflector.as_ref().and_then(|r| r.config.as_ref());
+                RouteReflectorConfig {
+                    route_reflector_client: rr
+                        .and_then(|c| c.route_reflector_client)
+                        .unwrap_or(false),
+                    route_reflector_cluster_id: rr
+                        .and_then(|c| c.route_reflector_cluster_id.as_deref())
+                        .filter(|s| !s.is_empty())
+                        .and_then(|s| Ipv4Addr::from_str(s).ok()),
+                }
+            },
+            multihop_ttl: pg
+                .ebgp_multihop
+                .as_ref()
+                .and_then(|m| m.config.as_ref())
+                .and_then(|c| {
+                    if c.enabled.unwrap_or(false) {
+                        c.multihop_ttl
+                    } else {
+                        None
+                    }
+                }),
+            auth_password: pg
+                .config
+                .as_ref()
+                .and_then(|c| c.auth_password.as_deref())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string()),
+            connect_retry_time: timer_config
+                .and_then(|c| c.connect_retry)
+                .map(|t| t as u64)
+                .filter(|&t| t != 0),
         }
     }
 }
@@ -1958,6 +2090,12 @@ impl GoBgpService for GrpcService {
                 entry.as_number = updated.as_number;
                 entry.route_server_client = updated.route_server_client;
                 entry.holdtime = updated.holdtime;
+                entry.local_asn = updated.local_asn;
+                entry.passive = updated.passive;
+                entry.route_reflector = updated.route_reflector;
+                entry.multihop_ttl = updated.multihop_ttl;
+                entry.auth_password = updated.auth_password;
+                entry.connect_retry_time = updated.connect_retry_time;
                 Ok(tonic::Response::new(api::UpdatePeerGroupResponse {
                     needs_soft_reset_in: false,
                 }))
@@ -3415,51 +3553,41 @@ async fn accept_connection(
             peer
         }
         None => {
-            let mut is_dynamic = false;
-            let mut rs_client = false;
-            let mut remote_asn = 0;
-            let mut holdtime = None;
-            for p in &g.peer_group {
-                for d in &p.1.dynamic_peers {
-                    if d.prefix.contains(&remote_addr) {
-                        remote_asn = p.1.as_number;
-                        is_dynamic = true;
-                        rs_client = p.1.route_server_client;
-                        holdtime = p.1.holdtime;
-                        break;
-                    }
-                }
-            }
-            if !is_dynamic {
+            let group = g.peer_group.values().find(|pg| {
+                pg.dynamic_peers
+                    .iter()
+                    .any(|d| d.prefix.contains(&remote_addr))
+            });
+            let Some(group) = group else {
                 log::warn!(
                     "can't find configuration a new passive connection {}",
                     remote_addr
                 );
                 return None;
-            }
-            let _ = g.add_peer(
-                PeerParams {
-                    remote_addr,
-                    remote_port: Global::BGP_PORT,
-                    expected_remote_asn: remote_asn,
-                    local_asn: 0,
-                    passive: false,
-                    rs_client,
-                    route_reflector: RouteReflectorConfig::default(),
-                    delete_on_disconnected: true,
-                    admin_down: false,
-                    state: SessionState::Active,
-                    holdtime: holdtime.unwrap_or(PeerParams::DEFAULT_HOLD_TIME),
-                    connect_retry_time: PeerParams::DEFAULT_CONNECT_RETRY_TIME,
-                    multihop_ttl: None,
-                    password: None,
-                    families: FnvHashMap::default(),
-                    send_max: FnvHashMap::default(),
-                    prefix_limits: FnvHashMap::default(),
-                    graceful_restart: None,
-                },
-                None,
-            );
+            };
+            let params = PeerParams {
+                remote_addr,
+                remote_port: Global::BGP_PORT,
+                expected_remote_asn: group.as_number,
+                local_asn: group.local_asn,
+                passive: group.passive,
+                rs_client: group.route_server_client,
+                route_reflector: group.route_reflector.clone(),
+                delete_on_disconnected: true,
+                admin_down: false,
+                state: SessionState::Active,
+                holdtime: group.holdtime.unwrap_or(PeerParams::DEFAULT_HOLD_TIME),
+                connect_retry_time: group
+                    .connect_retry_time
+                    .unwrap_or(PeerParams::DEFAULT_CONNECT_RETRY_TIME),
+                multihop_ttl: group.multihop_ttl,
+                password: group.auth_password.clone(),
+                families: FnvHashMap::default(),
+                send_max: FnvHashMap::default(),
+                prefix_limits: FnvHashMap::default(),
+                graceful_restart: None,
+            };
+            let _ = g.add_peer(params, None);
             g.peers.get_mut(&remote_addr).unwrap()
         }
     };
@@ -3622,28 +3750,7 @@ impl Global {
             let mut server = global.write().await;
             for pg in groups {
                 if let Some(name) = pg.config.as_ref().and_then(|x| x.peer_group_name.clone()) {
-                    server.peer_group.insert(
-                        name,
-                        PeerGroup {
-                            as_number: pg.config.as_ref().map_or(0, |x| x.peer_as.map_or(0, |x| x)),
-                            dynamic_peers: Vec::new(),
-                            route_server_client: pg.route_server.as_ref().is_some_and(|x| {
-                                x.config
-                                    .as_ref()
-                                    .is_some_and(|x| x.route_server_client.unwrap_or(false))
-                            }),
-                            holdtime: pg.timers.as_ref().and_then(|x| {
-                                x.config
-                                    .as_ref()
-                                    .and_then(|x| x.hold_time.as_ref().map(|x| *x as u64))
-                            }),
-                            // passive: pg.transport.as_ref().map_or(false, |x| {
-                            //     x.config
-                            //         .as_ref()
-                            //         .map_or(false, |x| x.passive_mode.map_or(false, |x| x))
-                            // }),
-                        },
-                    );
+                    server.peer_group.insert(name, PeerGroup::from_yaml(pg));
                 }
             }
         }
@@ -3809,9 +3916,14 @@ impl Global {
                             prefix: packet::IpNet::from_str("::/0").unwrap(),
                         },
                     ],
-                    // passive: true,
                     route_server_client: false,
                     holdtime: None,
+                    local_asn: 0,
+                    passive: false,
+                    route_reflector: RouteReflectorConfig::default(),
+                    multihop_ttl: None,
+                    auth_password: None,
+                    connect_retry_time: None,
                 },
             );
         }
@@ -5950,6 +6062,12 @@ mod tests {
                     }],
                     route_server_client: false,
                     holdtime: None,
+                    local_asn: 0,
+                    passive: false,
+                    route_reflector: RouteReflectorConfig::default(),
+                    multihop_ttl: None,
+                    auth_password: None,
+                    connect_retry_time: None,
                 },
             );
         }
@@ -5961,6 +6079,319 @@ mod tests {
         assert!(g.peers.contains_key(&remote_addr));
         let peer = g.peers.get(&remote_addr).unwrap();
         assert!(peer.config.delete_on_disconnected);
+    }
+
+    #[tokio::test]
+    async fn dynamic_peer_inherits_all_group_fields() {
+        let global = make_global();
+        let tables = make_tables();
+        let (client, server) = loopback_pair().await;
+        let remote_addr = client.local_addr().unwrap().ip();
+        let cluster_id: Ipv4Addr = "1.2.3.4".parse().unwrap();
+
+        {
+            let mut g = global.write().await;
+            g.peer_group.insert(
+                "full-group".to_string(),
+                PeerGroup {
+                    as_number: 65002,
+                    dynamic_peers: vec![DynamicPeer {
+                        prefix: packet::IpNet::new(remote_addr, 32),
+                    }],
+                    route_server_client: false,
+                    holdtime: Some(90),
+                    local_asn: 65001,
+                    passive: true,
+                    route_reflector: RouteReflectorConfig {
+                        route_reflector_client: true,
+                        route_reflector_cluster_id: Some(cluster_id),
+                    },
+                    multihop_ttl: Some(5),
+                    auth_password: Some("secret".to_string()),
+                    connect_retry_time: Some(30),
+                },
+            );
+        }
+
+        let h = accept_connection(&global, &tables, server, crate::fsm::Role::Passive).await;
+        assert!(h.is_some());
+
+        let g = global.read().await;
+        let peer = g.peers.get(&remote_addr).unwrap();
+        assert_eq!(peer.config.expected_remote_asn, 65002);
+        assert_eq!(peer.config.local_asn, 65001);
+        assert!(peer.config.passive);
+        assert!(peer.config.route_reflector.route_reflector_client);
+        assert_eq!(
+            peer.config.route_reflector.route_reflector_cluster_id,
+            Some(cluster_id)
+        );
+        assert_eq!(peer.config.multihop_ttl, Some(5));
+        assert_eq!(peer.config.password, Some("secret".to_string()));
+        assert_eq!(peer.config.holdtime, 90);
+        assert_eq!(peer.config.connect_retry_time, 30);
+        assert!(peer.config.delete_on_disconnected);
+    }
+
+    // --- PeerGroup gRPC round-trip tests ---
+
+    fn make_full_api_peer_group(name: &str) -> api::PeerGroup {
+        api::PeerGroup {
+            conf: Some(api::PeerGroupConf {
+                peer_group_name: name.to_string(),
+                peer_asn: 65002,
+                local_asn: 65001,
+                auth_password: "secret".to_string(),
+                ..Default::default()
+            }),
+            timers: Some(api::Timers {
+                config: Some(api::TimersConfig {
+                    hold_time: 90,
+                    connect_retry: 30,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            route_server: Some(api::RouteServer {
+                route_server_client: false,
+                ..Default::default()
+            }),
+            transport: Some(api::Transport {
+                passive_mode: true,
+                ..Default::default()
+            }),
+            route_reflector: Some(api::RouteReflector {
+                route_reflector_client: true,
+                route_reflector_cluster_id: "1.2.3.4".to_string(),
+            }),
+            ebgp_multihop: Some(api::EbgpMultihop {
+                enabled: true,
+                multihop_ttl: 5,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn peer_group_grpc_roundtrip_all_fields() {
+        let svc = make_grpc_service();
+        let pg = make_full_api_peer_group("grp");
+        svc.add_peer_group(tonic::Request::new(api::AddPeerGroupRequest {
+            peer_group: Some(pg),
+        }))
+        .await
+        .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        svc.list_peer_group(tonic::Request::new(api::ListPeerGroupRequest {
+            peer_group_name: "grp".to_string(),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .for_each(|r| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(r.unwrap().peer_group.unwrap()).await;
+            }
+        })
+        .await;
+
+        let got = rx.recv().await.unwrap();
+        let conf = got.conf.as_ref().unwrap();
+        assert_eq!(conf.peer_asn, 65002);
+        assert_eq!(conf.local_asn, 65001);
+        assert_eq!(conf.auth_password, "secret");
+        let tc = got.timers.as_ref().unwrap().config.as_ref().unwrap();
+        assert_eq!(tc.hold_time, 90);
+        assert_eq!(tc.connect_retry, 30);
+        assert!(got.transport.as_ref().unwrap().passive_mode);
+        let rr = got.route_reflector.as_ref().unwrap();
+        assert!(rr.route_reflector_client);
+        assert_eq!(rr.route_reflector_cluster_id, "1.2.3.4");
+        let mh = got.ebgp_multihop.as_ref().unwrap();
+        assert!(mh.enabled);
+        assert_eq!(mh.multihop_ttl, 5);
+    }
+
+    #[tokio::test]
+    async fn peer_group_grpc_update_all_fields() {
+        let svc = make_grpc_service();
+
+        // Add with initial values.
+        svc.add_peer_group(tonic::Request::new(api::AddPeerGroupRequest {
+            peer_group: Some(make_full_api_peer_group("grp")),
+        }))
+        .await
+        .unwrap();
+
+        // Update with new values.
+        let updated = api::PeerGroup {
+            conf: Some(api::PeerGroupConf {
+                peer_group_name: "grp".to_string(),
+                peer_asn: 65003,
+                local_asn: 65004,
+                auth_password: "new-secret".to_string(),
+                ..Default::default()
+            }),
+            timers: Some(api::Timers {
+                config: Some(api::TimersConfig {
+                    hold_time: 120,
+                    connect_retry: 60,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            transport: Some(api::Transport {
+                passive_mode: false,
+                ..Default::default()
+            }),
+            ebgp_multihop: Some(api::EbgpMultihop {
+                enabled: true,
+                multihop_ttl: 10,
+            }),
+            ..Default::default()
+        };
+        svc.update_peer_group(tonic::Request::new(api::UpdatePeerGroupRequest {
+            peer_group: Some(updated),
+            ..Default::default()
+        }))
+        .await
+        .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        svc.list_peer_group(tonic::Request::new(api::ListPeerGroupRequest {
+            peer_group_name: "grp".to_string(),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .for_each(|r| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(r.unwrap().peer_group.unwrap()).await;
+            }
+        })
+        .await;
+
+        let got = rx.recv().await.unwrap();
+        let conf = got.conf.as_ref().unwrap();
+        assert_eq!(conf.peer_asn, 65003);
+        assert_eq!(conf.local_asn, 65004);
+        assert_eq!(conf.auth_password, "new-secret");
+        let tc = got.timers.as_ref().unwrap().config.as_ref().unwrap();
+        assert_eq!(tc.hold_time, 120);
+        assert_eq!(tc.connect_retry, 60);
+        assert!(
+            !got.transport
+                .as_ref()
+                .map(|t| t.passive_mode)
+                .unwrap_or(false)
+        );
+        let mh = got.ebgp_multihop.as_ref().unwrap();
+        assert_eq!(mh.multihop_ttl, 10);
+    }
+
+    // --- PeerGroup YAML parsing tests ---
+
+    fn make_yaml_peer_group() -> config::PeerGroup {
+        config::PeerGroup {
+            config: Some(config::PeerGroupConfig {
+                peer_group_name: Some("yaml-grp".to_string()),
+                peer_as: Some(65002),
+                local_as: Some(65001),
+                auth_password: Some("yaml-secret".to_string()),
+                ..Default::default()
+            }),
+            timers: Some(config::Timers {
+                config: Some(config::TimersConfig {
+                    hold_time: Some(90.0),
+                    connect_retry: Some(30.0),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            transport: Some(config::Transport {
+                config: Some(config::TransportConfig {
+                    passive_mode: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            route_reflector: Some(config::RouteReflector {
+                config: Some(config::RouteReflectorConfig {
+                    route_reflector_client: Some(true),
+                    route_reflector_cluster_id: Some("1.2.3.4".to_string()),
+                }),
+                ..Default::default()
+            }),
+            ebgp_multihop: Some(config::EbgpMultihop {
+                config: Some(config::EbgpMultihopConfig {
+                    enabled: Some(true),
+                    multihop_ttl: Some(5),
+                }),
+                ..Default::default()
+            }),
+            route_server: Some(config::RouteServer {
+                config: Some(config::RouteServerConfig {
+                    route_server_client: Some(false),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn peer_group_yaml_parses_all_fields() {
+        let pg = PeerGroup::from_yaml(&make_yaml_peer_group());
+        assert_eq!(pg.as_number, 65002);
+        assert_eq!(pg.local_asn, 65001);
+        assert_eq!(pg.auth_password, Some("yaml-secret".to_string()));
+        assert_eq!(pg.holdtime, Some(90));
+        assert_eq!(pg.connect_retry_time, Some(30));
+        assert!(pg.passive);
+        assert!(pg.route_reflector.route_reflector_client);
+        assert_eq!(
+            pg.route_reflector.route_reflector_cluster_id,
+            Some("1.2.3.4".parse().unwrap())
+        );
+        assert_eq!(pg.multihop_ttl, Some(5));
+    }
+
+    #[test]
+    fn peer_group_yaml_empty_password_becomes_none() {
+        let yaml_pg = config::PeerGroup {
+            config: Some(config::PeerGroupConfig {
+                peer_group_name: Some("g".to_string()),
+                auth_password: Some(String::new()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pg = PeerGroup::from_yaml(&yaml_pg);
+        assert!(pg.auth_password.is_none());
+    }
+
+    #[test]
+    fn peer_group_yaml_multihop_disabled_yields_none() {
+        let yaml_pg = config::PeerGroup {
+            config: Some(config::PeerGroupConfig {
+                peer_group_name: Some("g".to_string()),
+                ..Default::default()
+            }),
+            ebgp_multihop: Some(config::EbgpMultihop {
+                config: Some(config::EbgpMultihopConfig {
+                    enabled: Some(false),
+                    multihop_ttl: Some(5),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pg = PeerGroup::from_yaml(&yaml_pg);
+        assert!(pg.multihop_ttl.is_none());
     }
 
     fn cease_notification() -> bgp::Message {

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -923,6 +923,51 @@ impl TryFrom<&api::Peer> for PeerParams {
     }
 }
 
+/// Parse an afi-safis slice from YAML config into (families, send_max) maps.
+///
+/// Returns a map of Family -> add-path mode (RFC 7911 2-bit: bit0=RX, bit1=TX)
+/// and a separate send_max map for families where add-path TX is configured.
+fn parse_afi_safis_yaml(
+    afi_safis: &[config::AfiSafi],
+) -> (FnvHashMap<Family, u8>, FnvHashMap<Family, usize>) {
+    let mut base_families: Vec<Family> = Vec::new();
+    let addpath_entries: Vec<(packet::Family, u8, usize)> = afi_safis
+        .iter()
+        .filter(|x| {
+            let name = x.config.as_ref().and_then(|c| c.afi_safi_name.as_ref());
+            let Some(f) = name else { return false };
+            if let Ok(family) = convert::family_from_config(f) {
+                base_families.push(family);
+            }
+            true
+        })
+        .filter_map(|x| {
+            let ap_config = x.add_paths.as_ref()?.config.as_ref()?;
+            let rx = ap_config.receive.unwrap_or(false);
+            let send_max = ap_config.send_max.unwrap_or(0) as usize;
+            let tx = send_max > 0;
+            let mode = u8::from(rx) | (u8::from(tx) << 1);
+            if mode == 0 {
+                return None;
+            }
+            let family =
+                convert::family_from_config(x.config.as_ref()?.afi_safi_name.as_ref()?).ok()?;
+            Some((family, mode, send_max))
+        })
+        .collect();
+
+    let mut families: FnvHashMap<Family, u8> =
+        base_families.into_iter().map(|f| (f, 0u8)).collect();
+    let mut send_max: FnvHashMap<Family, usize> = FnvHashMap::default();
+    for (f, mode, sm) in addpath_entries {
+        families.insert(f, mode & 0x3);
+        if sm > 0 {
+            send_max.insert(f, sm);
+        }
+    }
+    (families, send_max)
+}
+
 impl TryFrom<&config::Neighbor> for PeerParams {
     type Error = String;
 
@@ -939,44 +984,7 @@ impl TryFrom<&config::Neighbor> for PeerParams {
         let transport_config = n.transport.as_ref().and_then(|t| t.config.as_ref());
         let timer_config = n.timers.as_ref().and_then(|t| t.config.as_ref());
 
-        // Collect address families and add-path configuration.
-        let mut base_families: Vec<Family> = Vec::new();
-        let addpath_entries: Vec<(packet::Family, u8, usize)> = afi_safis
-            .iter()
-            .filter(|x| {
-                let name = x.config.as_ref().and_then(|c| c.afi_safi_name.as_ref());
-                let Some(f) = name else { return false };
-                if let Ok(family) = convert::family_from_config(f) {
-                    base_families.push(family);
-                }
-                true
-            })
-            .filter_map(|x| {
-                let ap_config = x.add_paths.as_ref()?.config.as_ref()?;
-                let rx = ap_config.receive.unwrap_or(false);
-                let send_max = ap_config.send_max.unwrap_or(0) as usize;
-                let tx = send_max > 0;
-                let mode = u8::from(rx) | (u8::from(tx) << 1);
-                if mode == 0 {
-                    return None;
-                }
-                let family =
-                    convert::family_from_config(x.config.as_ref()?.afi_safi_name.as_ref()?).ok()?;
-                Some((family, mode, send_max))
-            })
-            .collect();
-
-        // Build families map: start with plain entries, then override with add-path modes.
-        let mut families: FnvHashMap<Family, u8> =
-            base_families.into_iter().map(|f| (f, 0u8)).collect();
-        let mut send_max: FnvHashMap<Family, usize> = FnvHashMap::default();
-        for (f, mode, sm) in addpath_entries {
-            // RFC 7911 mode is 2 bits: bit 0 = receive, bit 1 = send
-            families.insert(f, mode & 0x3);
-            if sm > 0 {
-                send_max.insert(f, sm);
-            }
-        }
+        let (families, send_max) = parse_afi_safis_yaml(afi_safis);
 
         // Build GR helper config from graceful-restart + per-family mp-graceful-restart.
         let graceful_restart = {
@@ -1114,6 +1122,8 @@ struct PeerGroup {
     multihop_ttl: Option<u8>,
     auth_password: Option<String>,
     connect_retry_time: Option<u64>,
+    families: FnvHashMap<Family, u8>,
+    send_max: FnvHashMap<Family, usize>,
 }
 
 fn peer_group_to_api(name: &str, pg: &PeerGroup) -> api::PeerGroup {
@@ -1176,6 +1186,28 @@ fn peer_group_to_api(name: &str, pg: &PeerGroup) -> api::PeerGroup {
             enabled: true,
             multihop_ttl: ttl as u32,
         }),
+        afi_safis: pg
+            .families
+            .iter()
+            .map(|(family, mode)| api::AfiSafi {
+                config: Some(api::AfiSafiConfig {
+                    family: Some(convert::family_to_api(*family)),
+                    ..Default::default()
+                }),
+                add_paths: if *mode != 0 {
+                    Some(api::AddPaths {
+                        config: Some(api::AddPathsConfig {
+                            receive: (*mode & 1) != 0,
+                            send_max: pg.send_max.get(family).copied().unwrap_or(0) as u32,
+                        }),
+                        ..Default::default()
+                    })
+                } else {
+                    None
+                },
+                ..Default::default()
+            })
+            .collect(),
         ..Default::default()
     }
 }
@@ -1221,6 +1253,18 @@ impl From<api::PeerGroup> for PeerGroup {
                 .and_then(|t| t.config)
                 .map(|c| c.connect_retry)
                 .filter(|&t| t != 0),
+            families: p
+                .afi_safis
+                .iter()
+                .filter(|x| x.config.as_ref().is_some_and(|c| c.family.is_some()))
+                .map(|x| {
+                    let f = convert::family_from_api(
+                        x.config.as_ref().unwrap().family.as_ref().unwrap(),
+                    );
+                    (f, 0u8)
+                })
+                .collect(),
+            send_max: FnvHashMap::default(),
         }
     }
 }
@@ -1228,6 +1272,8 @@ impl From<api::PeerGroup> for PeerGroup {
 impl PeerGroup {
     fn from_yaml(pg: &config::PeerGroup) -> Self {
         let timer_config = pg.timers.as_ref().and_then(|t| t.config.as_ref());
+        let (families, send_max) =
+            parse_afi_safis_yaml(pg.afi_safis.as_deref().unwrap_or_default());
         PeerGroup {
             as_number: pg.config.as_ref().and_then(|c| c.peer_as).unwrap_or(0),
             dynamic_peers: Vec::new(),
@@ -1281,6 +1327,8 @@ impl PeerGroup {
                 .and_then(|c| c.connect_retry)
                 .map(|t| t as u64)
                 .filter(|&t| t != 0),
+            families,
+            send_max,
         }
     }
 }
@@ -3582,8 +3630,8 @@ async fn accept_connection(
                     .unwrap_or(PeerParams::DEFAULT_CONNECT_RETRY_TIME),
                 multihop_ttl: group.multihop_ttl,
                 password: group.auth_password.clone(),
-                families: FnvHashMap::default(),
-                send_max: FnvHashMap::default(),
+                families: group.families.clone(),
+                send_max: group.send_max.clone(),
                 prefix_limits: FnvHashMap::default(),
                 graceful_restart: None,
             };
@@ -3924,6 +3972,8 @@ impl Global {
                     multihop_ttl: None,
                     auth_password: None,
                     connect_retry_time: None,
+                    families: FnvHashMap::default(),
+                    send_max: FnvHashMap::default(),
                 },
             );
         }
@@ -6068,6 +6118,8 @@ mod tests {
                     multihop_ttl: None,
                     auth_password: None,
                     connect_retry_time: None,
+                    families: FnvHashMap::default(),
+                    send_max: FnvHashMap::default(),
                 },
             );
         }
@@ -6109,6 +6161,8 @@ mod tests {
                     multihop_ttl: Some(5),
                     auth_password: Some("secret".to_string()),
                     connect_retry_time: Some(30),
+                    families: FnvHashMap::default(),
+                    send_max: FnvHashMap::default(),
                 },
             );
         }
@@ -6392,6 +6446,195 @@ mod tests {
         };
         let pg = PeerGroup::from_yaml(&yaml_pg);
         assert!(pg.multihop_ttl.is_none());
+    }
+
+    // --- PeerGroup families tests ---
+
+    fn make_api_peer_group_with_families(name: &str) -> api::PeerGroup {
+        api::PeerGroup {
+            conf: Some(api::PeerGroupConf {
+                peer_group_name: name.to_string(),
+                peer_asn: 65002,
+                ..Default::default()
+            }),
+            afi_safis: vec![
+                api::AfiSafi {
+                    config: Some(api::AfiSafiConfig {
+                        family: Some(api::Family {
+                            afi: api::family::Afi::Ip as i32,
+                            safi: api::family::Safi::Unicast as i32,
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                api::AfiSafi {
+                    config: Some(api::AfiSafiConfig {
+                        family: Some(api::Family {
+                            afi: api::family::Afi::Ip6 as i32,
+                            safi: api::family::Safi::Unicast as i32,
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn peer_group_grpc_families_roundtrip() {
+        let svc = make_grpc_service();
+        svc.add_peer_group(tonic::Request::new(api::AddPeerGroupRequest {
+            peer_group: Some(make_api_peer_group_with_families("grp")),
+        }))
+        .await
+        .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        svc.list_peer_group(tonic::Request::new(api::ListPeerGroupRequest {
+            peer_group_name: "grp".to_string(),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .for_each(|r| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(r.unwrap().peer_group.unwrap()).await;
+            }
+        })
+        .await;
+
+        let got = rx.recv().await.unwrap();
+        assert_eq!(got.afi_safis.len(), 2);
+        let afis: Vec<i32> = got
+            .afi_safis
+            .iter()
+            .map(|a| a.config.as_ref().unwrap().family.as_ref().unwrap().afi)
+            .collect();
+        assert!(afis.contains(&(api::family::Afi::Ip as i32)));
+        assert!(afis.contains(&(api::family::Afi::Ip6 as i32)));
+    }
+
+    #[test]
+    fn peer_group_yaml_families_parsed() {
+        let yaml_pg = config::PeerGroup {
+            config: Some(config::PeerGroupConfig {
+                peer_group_name: Some("g".to_string()),
+                ..Default::default()
+            }),
+            afi_safis: Some(vec![
+                config::AfiSafi {
+                    config: Some(config::AfiSafiConfig {
+                        afi_safi_name: Some(config::AfiSafiType::Ipv4Unicast),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                config::AfiSafi {
+                    config: Some(config::AfiSafiConfig {
+                        afi_safi_name: Some(config::AfiSafiType::Ipv6Unicast),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        };
+        let pg = PeerGroup::from_yaml(&yaml_pg);
+        assert_eq!(pg.families.len(), 2);
+        assert!(pg.families.contains_key(&Family::IPV4));
+        assert!(pg.families.contains_key(&Family::IPV6));
+        assert!(pg.send_max.is_empty());
+    }
+
+    #[test]
+    fn peer_group_yaml_addpath_send_max_parsed() {
+        let yaml_pg = config::PeerGroup {
+            config: Some(config::PeerGroupConfig {
+                peer_group_name: Some("g".to_string()),
+                ..Default::default()
+            }),
+            afi_safis: Some(vec![config::AfiSafi {
+                config: Some(config::AfiSafiConfig {
+                    afi_safi_name: Some(config::AfiSafiType::Ipv4Unicast),
+                    ..Default::default()
+                }),
+                add_paths: Some(config::AddPaths {
+                    config: Some(config::AddPathsConfig {
+                        receive: Some(true),
+                        send_max: Some(4),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let pg = PeerGroup::from_yaml(&yaml_pg);
+        assert_eq!(pg.families.len(), 1);
+        // mode: bit0=RX(1), bit1=TX(1) -> 3
+        assert_eq!(*pg.families.get(&Family::IPV4).unwrap(), 3u8);
+        assert_eq!(*pg.send_max.get(&Family::IPV4).unwrap(), 4);
+    }
+
+    #[tokio::test]
+    async fn dynamic_peer_inherits_families_from_group() {
+        let global = make_global();
+        let tables = make_tables();
+        let (client, server) = loopback_pair().await;
+        let remote_addr = client.local_addr().unwrap().ip();
+
+        let mut families = FnvHashMap::default();
+        families.insert(Family::IPV4, 0u8);
+        families.insert(Family::IPV6, 0u8);
+
+        {
+            let mut g = global.write().await;
+            g.peer_group.insert(
+                "fam-group".to_string(),
+                PeerGroup {
+                    as_number: 65002,
+                    dynamic_peers: vec![DynamicPeer {
+                        prefix: packet::IpNet::new(remote_addr, 32),
+                    }],
+                    route_server_client: false,
+                    holdtime: None,
+                    local_asn: 0,
+                    passive: false,
+                    route_reflector: RouteReflectorConfig::default(),
+                    multihop_ttl: None,
+                    auth_password: None,
+                    connect_retry_time: None,
+                    families,
+                    send_max: FnvHashMap::default(),
+                },
+            );
+        }
+
+        let h = accept_connection(&global, &tables, server, crate::fsm::Role::Passive).await;
+        assert!(h.is_some());
+
+        let g = global.read().await;
+        let peer = g.peers.get(&remote_addr).unwrap();
+        // Inherited families should appear in local_cap as MultiProtocol capabilities.
+        let mp_families: Vec<Family> = peer
+            .config
+            .local_cap
+            .iter()
+            .filter_map(|c| {
+                if let packet::Capability::MultiProtocol(f) = c {
+                    Some(*f)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert!(mp_families.contains(&Family::IPV4));
+        assert!(mp_families.contains(&Family::IPV6));
     }
 
     fn cease_notification() -> bgp::Message {

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -274,6 +274,10 @@ struct PeerConfig {
     /// detection without holding the global lock.
     local_router_id: Ipv4Addr,
     multihop_ttl: Option<u8>,
+    /// GTSM minimum TTL (RFC 5082); None = GTSM disabled.
+    /// When set, outgoing TTL is 255 and incoming packets below this value are dropped.
+    /// Takes priority over multihop_ttl when both are configured.
+    ttl_security: Option<u8>,
     password: Option<String>,
     /// Per-family prefix limits from config.
     /// Used to initialize PeerSession::prefix_counters in accept_connection().
@@ -505,6 +509,7 @@ struct PeerParams {
     holdtime: u64,
     connect_retry_time: u64,
     multihop_ttl: Option<u8>,
+    ttl_security: Option<u8>,
     password: Option<String>,
     /// Per-family add-path mode (RFC 7911 2-bit flags); mode 0 means plain MP.
     families: FnvHashMap<Family, u8>,
@@ -628,6 +633,7 @@ impl PeerParams {
                 route_reflector: self.route_reflector.clone(),
                 local_router_id: Ipv4Addr::from(local_router_id),
                 multihop_ttl: self.multihop_ttl,
+                ttl_security: self.ttl_security,
                 password: self.password,
                 prefix_limits: self.prefix_limits,
                 graceful_restart: self.graceful_restart,
@@ -785,6 +791,10 @@ impl From<&PeerView> for api::Peer {
             }),
             afi_safis: afisafis,
             graceful_restart,
+            ttl_security: p.config.ttl_security.map(|ttl_min| api::TtlSecurity {
+                enabled: true,
+                ttl_min: ttl_min as u32,
+            }),
             ..Default::default()
         }
     }
@@ -871,6 +881,18 @@ impl TryFrom<&api::Peer> for PeerParams {
             multihop_ttl: p.ebgp_multihop.as_ref().and_then(|x| {
                 if x.enabled && x.multihop_ttl != 0 {
                     Some(x.multihop_ttl as u8)
+                } else {
+                    None
+                }
+            }),
+            ttl_security: p.ttl_security.as_ref().and_then(|ts| {
+                if ts.enabled {
+                    let min = if ts.ttl_min == 0 {
+                        255
+                    } else {
+                        ts.ttl_min as u8
+                    };
+                    Some(min)
                 } else {
                     None
                 }
@@ -1093,6 +1115,21 @@ impl TryFrom<&config::Neighbor> for PeerParams {
                 .as_ref()
                 .and_then(|m| m.config.as_ref())
                 .and_then(|c| c.enabled.filter(|&en| en).and(c.multihop_ttl)),
+            ttl_security: n
+                .ttl_security
+                .as_ref()
+                .and_then(|ts| ts.config.as_ref())
+                .and_then(|c| {
+                    if c.enabled.unwrap_or(false) {
+                        Some(
+                            c.ttl_min
+                                .map(|v| if v == 0 { 255 } else { v })
+                                .unwrap_or(255),
+                        )
+                    } else {
+                        None
+                    }
+                }),
             password: c.auth_password.clone(),
             families,
             send_max,
@@ -1115,6 +1152,7 @@ struct PeerGroup {
     passive: bool,
     route_reflector: RouteReflectorConfig,
     multihop_ttl: Option<u8>,
+    ttl_security: Option<u8>,
     auth_password: Option<String>,
     connect_retry_time: Option<u64>,
     families: FnvHashMap<Family, u8>,
@@ -1224,6 +1262,10 @@ fn peer_group_to_api(name: &str, pg: &PeerGroup) -> api::PeerGroup {
             notification_enabled: gr.notification_enabled,
             ..Default::default()
         }),
+        ttl_security: pg.ttl_security.map(|ttl_min| api::TtlSecurity {
+            enabled: true,
+            ttl_min: ttl_min as u32,
+        }),
         ..Default::default()
     }
 }
@@ -1256,6 +1298,18 @@ impl From<api::PeerGroup> for PeerGroup {
             multihop_ttl: p.ebgp_multihop.and_then(|x| {
                 if x.enabled && x.multihop_ttl != 0 {
                     Some(x.multihop_ttl as u8)
+                } else {
+                    None
+                }
+            }),
+            ttl_security: p.ttl_security.as_ref().and_then(|ts| {
+                if ts.enabled {
+                    let min = if ts.ttl_min == 0 {
+                        255
+                    } else {
+                        ts.ttl_min as u8
+                    };
+                    Some(min)
                 } else {
                     None
                 }
@@ -1330,6 +1384,21 @@ impl PeerGroup {
                 .and_then(|c| {
                     if c.enabled.unwrap_or(false) {
                         c.multihop_ttl
+                    } else {
+                        None
+                    }
+                }),
+            ttl_security: pg
+                .ttl_security
+                .as_ref()
+                .and_then(|ts| ts.config.as_ref())
+                .and_then(|c| {
+                    if c.enabled.unwrap_or(false) {
+                        Some(
+                            c.ttl_min
+                                .map(|v| if v == 0 { 255 } else { v })
+                                .unwrap_or(255),
+                        )
                     } else {
                         None
                     }
@@ -1771,6 +1840,7 @@ impl GoBgpService for GrpcService {
                 route_reflector: new_params.route_reflector.clone(),
                 local_router_id: Ipv4Addr::from(router_id),
                 multihop_ttl: new_params.multihop_ttl,
+                ttl_security: new_params.ttl_security,
                 password: new_params.password.clone(),
                 prefix_limits: new_params.prefix_limits,
                 graceful_restart: new_params.graceful_restart.clone(),
@@ -3652,6 +3722,7 @@ async fn accept_connection(
                     .connect_retry_time
                     .unwrap_or(PeerParams::DEFAULT_CONNECT_RETRY_TIME),
                 multihop_ttl: group.multihop_ttl,
+                ttl_security: group.ttl_security,
                 password: group.auth_password.clone(),
                 families: group.families.clone(),
                 send_max: group.send_max.clone(),
@@ -3662,7 +3733,11 @@ async fn accept_connection(
             g.peers.get_mut(&remote_addr).unwrap()
         }
     };
-    if let Some(ttl) = peer.config.multihop_ttl {
+    if let Some(ttl_min) = peer.config.ttl_security {
+        // GTSM (RFC 5082): send with TTL=255, drop incoming below ttl_min.
+        let _ = stream.set_ttl(255);
+        auth::set_min_ttl(stream.as_raw_fd(), &remote_addr, ttl_min);
+    } else if let Some(ttl) = peer.config.multihop_ttl {
         if peer.config.expected_remote_asn != peer.config.local_asn {
             let _ = stream.set_ttl(ttl.into());
         }
@@ -3993,6 +4068,7 @@ impl Global {
                     passive: false,
                     route_reflector: RouteReflectorConfig::default(),
                     multihop_ttl: None,
+                    ttl_security: None,
                     auth_password: None,
                     connect_retry_time: None,
                     families: FnvHashMap::default(),
@@ -5977,6 +6053,7 @@ mod tests {
             holdtime: PeerParams::DEFAULT_HOLD_TIME,
             connect_retry_time: PeerParams::DEFAULT_CONNECT_RETRY_TIME,
             multihop_ttl: None,
+            ttl_security: None,
             password: None,
             families: FnvHashMap::default(),
             send_max: FnvHashMap::default(),
@@ -6140,6 +6217,7 @@ mod tests {
                     passive: false,
                     route_reflector: RouteReflectorConfig::default(),
                     multihop_ttl: None,
+                    ttl_security: None,
                     auth_password: None,
                     connect_retry_time: None,
                     families: FnvHashMap::default(),
@@ -6184,6 +6262,7 @@ mod tests {
                         route_reflector_cluster_id: Some(cluster_id),
                     },
                     multihop_ttl: Some(5),
+                    ttl_security: None,
                     auth_password: Some("secret".to_string()),
                     connect_retry_time: Some(30),
                     families: FnvHashMap::default(),
@@ -6786,6 +6865,7 @@ mod tests {
                     passive: false,
                     route_reflector: RouteReflectorConfig::default(),
                     multihop_ttl: None,
+                    ttl_security: None,
                     auth_password: None,
                     connect_retry_time: None,
                     families,
@@ -6820,6 +6900,175 @@ mod tests {
         assert!(has_gr_cap);
     }
 
+    // --- PeerGroup ttl_security tests ---
+
+    #[tokio::test]
+    async fn peer_group_grpc_ttl_security_roundtrip() {
+        let svc = make_grpc_service();
+        svc.add_peer_group(tonic::Request::new(api::AddPeerGroupRequest {
+            peer_group: Some(api::PeerGroup {
+                conf: Some(api::PeerGroupConf {
+                    peer_group_name: "ts-grp".to_string(),
+                    ..Default::default()
+                }),
+                ttl_security: Some(api::TtlSecurity {
+                    enabled: true,
+                    ttl_min: 200,
+                }),
+                ..Default::default()
+            }),
+        }))
+        .await
+        .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        svc.list_peer_group(tonic::Request::new(api::ListPeerGroupRequest {
+            peer_group_name: "ts-grp".to_string(),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .for_each(|r| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(r.unwrap().peer_group.unwrap()).await;
+            }
+        })
+        .await;
+
+        let got = rx.recv().await.unwrap();
+        let ts = got
+            .ttl_security
+            .as_ref()
+            .expect("ttl_security should be Some");
+        assert!(ts.enabled);
+        assert_eq!(ts.ttl_min, 200);
+    }
+
+    #[tokio::test]
+    async fn peer_group_grpc_ttl_security_default_min() {
+        // ttl_min == 0 with enabled=true should default to 255.
+        let svc = make_grpc_service();
+        svc.add_peer_group(tonic::Request::new(api::AddPeerGroupRequest {
+            peer_group: Some(api::PeerGroup {
+                conf: Some(api::PeerGroupConf {
+                    peer_group_name: "ts-default".to_string(),
+                    ..Default::default()
+                }),
+                ttl_security: Some(api::TtlSecurity {
+                    enabled: true,
+                    ttl_min: 0,
+                }),
+                ..Default::default()
+            }),
+        }))
+        .await
+        .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        svc.list_peer_group(tonic::Request::new(api::ListPeerGroupRequest {
+            peer_group_name: "ts-default".to_string(),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .for_each(|r| {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(r.unwrap().peer_group.unwrap()).await;
+            }
+        })
+        .await;
+
+        let got = rx.recv().await.unwrap();
+        let ts = got
+            .ttl_security
+            .as_ref()
+            .expect("ttl_security should be Some");
+        assert!(ts.enabled);
+        assert_eq!(ts.ttl_min, 255);
+    }
+
+    #[test]
+    fn peer_group_yaml_ttl_security_parsed() {
+        let yaml_pg = config::PeerGroup {
+            config: Some(config::PeerGroupConfig {
+                peer_group_name: Some("g".to_string()),
+                ..Default::default()
+            }),
+            ttl_security: Some(config::TtlSecurity {
+                config: Some(config::TtlSecurityConfig {
+                    enabled: Some(true),
+                    ttl_min: Some(200),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pg = PeerGroup::from_yaml(&yaml_pg);
+        assert_eq!(pg.ttl_security, Some(200u8));
+    }
+
+    #[test]
+    fn peer_group_yaml_ttl_security_default_min() {
+        let yaml_pg = config::PeerGroup {
+            config: Some(config::PeerGroupConfig {
+                peer_group_name: Some("g".to_string()),
+                ..Default::default()
+            }),
+            ttl_security: Some(config::TtlSecurity {
+                config: Some(config::TtlSecurityConfig {
+                    enabled: Some(true),
+                    ttl_min: None,
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pg = PeerGroup::from_yaml(&yaml_pg);
+        assert_eq!(pg.ttl_security, Some(255u8));
+    }
+
+    #[tokio::test]
+    async fn dynamic_peer_inherits_ttl_security_from_group() {
+        let global = make_global();
+        let tables = make_tables();
+        let (client, server) = loopback_pair().await;
+        let remote_addr = client.local_addr().unwrap().ip();
+
+        {
+            let mut g = global.write().await;
+            g.peer_group.insert(
+                "ts-group".to_string(),
+                PeerGroup {
+                    as_number: 65002,
+                    dynamic_peers: vec![DynamicPeer {
+                        prefix: packet::IpNet::new(remote_addr, 32),
+                    }],
+                    route_server_client: false,
+                    holdtime: None,
+                    local_asn: 0,
+                    passive: false,
+                    route_reflector: RouteReflectorConfig::default(),
+                    multihop_ttl: None,
+                    ttl_security: Some(200),
+                    auth_password: None,
+                    connect_retry_time: None,
+                    families: FnvHashMap::default(),
+                    send_max: FnvHashMap::default(),
+                    graceful_restart: None,
+                },
+            );
+        }
+
+        let h = accept_connection(&global, &tables, server, crate::fsm::Role::Passive).await;
+        assert!(h.is_some());
+
+        let g = global.read().await;
+        let peer = g.peers.get(&remote_addr).unwrap();
+        assert_eq!(peer.config.ttl_security, Some(200u8));
+    }
+
     #[tokio::test]
     async fn dynamic_peer_inherits_families_from_group() {
         let global = make_global();
@@ -6846,6 +7095,7 @@ mod tests {
                     passive: false,
                     route_reflector: RouteReflectorConfig::default(),
                     multihop_ttl: None,
+                    ttl_security: None,
                     auth_password: None,
                     connect_retry_time: None,
                     families,


### PR DESCRIPTION
PeerGroup previously held only 4 fields (as_number, route_server_client, holdtime, dynamic_peers). This left local_asn, passive, route_reflector, multihop_ttl, auth_password, and connect_retry_time silently ignored even when configured via gRPC or YAML.

Add all six fields to the PeerGroup struct, wire them through From<api::PeerGroup>, peer_group_to_api(), update_peer_group, and a new PeerGroup::from_yaml() helper (extracted from inline Global::serve code to make YAML parsing directly unit-testable). accept_connection now inherits all six fields into PeerParams when creating a dynamic peer, replacing the previous hard-coded defaults.

Tests added:
- dynamic_peer_inherits_all_group_fields: verifies every new field reaches PeerConfig after accept_connection
- peer_group_grpc_roundtrip_all_fields: AddPeerGroup -> ListPeerGroup round-trip for all fields
- peer_group_grpc_update_all_fields: UpdatePeerGroup changes reflected by ListPeerGroup
- peer_group_yaml_parses_all_fields: PeerGroup::from_yaml covers all fields
- peer_group_yaml_empty_password_becomes_none: empty string -> None
- peer_group_yaml_multihop_disabled_yields_none: disabled flag respected

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>