### PR TITLE
daemon,table: add BGP/MPLS IP VPN VRF gRPC API (RFC 4364)

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -124,6 +124,116 @@ fn mup_nlri_to_api(m: &mup::MupNlri) -> api::nlri::Nlri {
     }
 }
 
+/// Convert an `api::RouteTarget` to its 8-byte wire representation.
+///
+/// Rejects any RT whose sub_type is not 0x02 (Route Target) to prevent
+/// callers from silently injecting non-RT extended communities into VRFs.
+pub(crate) fn rt_from_api(rt: &api::RouteTarget) -> Result<[u8; 8], Error> {
+    use api::route_target::Rt;
+    let mut buf = [0u8; 8];
+    match rt
+        .rt
+        .as_ref()
+        .ok_or_else(|| Error::InvalidArgument("missing route target".to_string()))?
+    {
+        Rt::TwoOctetAsSpecific(r) => {
+            if r.sub_type != 2 {
+                return Err(Error::InvalidArgument(format!(
+                    "route target sub_type must be 2, got {}",
+                    r.sub_type
+                )));
+            }
+            if r.asn > u16::MAX as u32 {
+                return Err(Error::InvalidArgument(format!(
+                    "two-octet RT ASN out of range: {}",
+                    r.asn
+                )));
+            }
+            buf[0] = 0x00;
+            buf[1] = 0x02;
+            buf[2..4].copy_from_slice(&(r.asn as u16).to_be_bytes());
+            buf[4..8].copy_from_slice(&r.local_admin.to_be_bytes());
+        }
+        Rt::Ipv4AddressSpecific(r) => {
+            if r.sub_type != 2 {
+                return Err(Error::InvalidArgument(format!(
+                    "route target sub_type must be 2, got {}",
+                    r.sub_type
+                )));
+            }
+            if r.local_admin > u16::MAX as u32 {
+                return Err(Error::InvalidArgument(format!(
+                    "IPv4 RT local_admin out of range: {}",
+                    r.local_admin
+                )));
+            }
+            let addr: Ipv4Addr = r
+                .address
+                .parse()
+                .map_err(|e| Error::InvalidArgument(format!("invalid RT IPv4 address: {e}")))?;
+            buf[0] = 0x01;
+            buf[1] = 0x02;
+            buf[2..6].copy_from_slice(&addr.octets());
+            buf[6..8].copy_from_slice(&(r.local_admin as u16).to_be_bytes());
+        }
+        Rt::FourOctetAsSpecific(r) => {
+            if r.sub_type != 2 {
+                return Err(Error::InvalidArgument(format!(
+                    "route target sub_type must be 2, got {}",
+                    r.sub_type
+                )));
+            }
+            if r.local_admin > u16::MAX as u32 {
+                return Err(Error::InvalidArgument(format!(
+                    "four-octet RT local_admin out of range: {}",
+                    r.local_admin
+                )));
+            }
+            buf[0] = 0x02;
+            buf[1] = 0x02;
+            buf[2..6].copy_from_slice(&r.asn.to_be_bytes());
+            buf[6..8].copy_from_slice(&(r.local_admin as u16).to_be_bytes());
+        }
+    }
+    Ok(buf)
+}
+
+/// Convert an 8-byte RT wire value back to `api::RouteTarget`.
+pub(crate) fn rt_to_api(rt: &[u8; 8]) -> api::RouteTarget {
+    use api::route_target::Rt;
+    let rt_val = match rt[0] {
+        0x00 => Rt::TwoOctetAsSpecific(api::TwoOctetAsSpecificExtended {
+            is_transitive: true,
+            sub_type: rt[1] as u32,
+            asn: u16::from_be_bytes([rt[2], rt[3]]) as u32,
+            local_admin: u32::from_be_bytes([rt[4], rt[5], rt[6], rt[7]]),
+        }),
+        0x01 => Rt::Ipv4AddressSpecific(api::IPv4AddressSpecificExtended {
+            is_transitive: true,
+            sub_type: rt[1] as u32,
+            address: Ipv4Addr::new(rt[2], rt[3], rt[4], rt[5]).to_string(),
+            local_admin: u16::from_be_bytes([rt[6], rt[7]]) as u32,
+        }),
+        _ => Rt::FourOctetAsSpecific(api::FourOctetAsSpecificExtended {
+            is_transitive: true,
+            sub_type: rt[1] as u32,
+            asn: u32::from_be_bytes([rt[2], rt[3], rt[4], rt[5]]),
+            local_admin: u16::from_be_bytes([rt[6], rt[7]]) as u32,
+        }),
+    };
+    api::RouteTarget { rt: Some(rt_val) }
+}
+
+pub(crate) fn vrf_to_api(vrf: &rustybgp_table::Vrf) -> api::Vrf {
+    api::Vrf {
+        name: vrf.name.clone(),
+        rd: Some(rd_to_api(&vrf.rd)),
+        import_rt: vrf.import_rt.iter().map(rt_to_api).collect(),
+        export_rt: vrf.export_rt.iter().map(rt_to_api).collect(),
+        id: 0,
+    }
+}
+
 pub(crate) fn rd_to_api(rd: &RouteDistinguisher) -> api::RouteDistinguisher {
     let v = match *rd {
         RouteDistinguisher::TwoOctetAs { admin, assigned } => {
@@ -2508,6 +2618,125 @@ pub(crate) fn load_policy_from_config(
 mod tests {
     use super::*;
     use rustybgp_table::NexthopAction;
+
+    // --- RT conversion ---
+
+    fn two_octet_rt_api(asn: u32, local_admin: u32) -> api::RouteTarget {
+        api::RouteTarget {
+            rt: Some(api::route_target::Rt::TwoOctetAsSpecific(
+                api::TwoOctetAsSpecificExtended {
+                    is_transitive: true,
+                    sub_type: 2,
+                    asn,
+                    local_admin,
+                },
+            )),
+        }
+    }
+
+    fn ipv4_rt_api(addr: &str, local_admin: u32) -> api::RouteTarget {
+        api::RouteTarget {
+            rt: Some(api::route_target::Rt::Ipv4AddressSpecific(
+                api::IPv4AddressSpecificExtended {
+                    is_transitive: true,
+                    sub_type: 2,
+                    address: addr.to_string(),
+                    local_admin,
+                },
+            )),
+        }
+    }
+
+    fn four_octet_rt_api(asn: u32, local_admin: u32) -> api::RouteTarget {
+        api::RouteTarget {
+            rt: Some(api::route_target::Rt::FourOctetAsSpecific(
+                api::FourOctetAsSpecificExtended {
+                    is_transitive: true,
+                    sub_type: 2,
+                    asn,
+                    local_admin,
+                },
+            )),
+        }
+    }
+
+    #[test]
+    fn rt_from_api_two_octet_as() {
+        let rt = rt_from_api(&two_octet_rt_api(65000, 100)).unwrap();
+        assert_eq!(rt[0], 0x00);
+        assert_eq!(rt[1], 0x02);
+        assert_eq!(u16::from_be_bytes([rt[2], rt[3]]), 65000);
+        assert_eq!(u32::from_be_bytes([rt[4], rt[5], rt[6], rt[7]]), 100);
+    }
+
+    #[test]
+    fn rt_from_api_ipv4() {
+        let rt = rt_from_api(&ipv4_rt_api("192.0.2.1", 200)).unwrap();
+        assert_eq!(rt[0], 0x01);
+        assert_eq!(rt[1], 0x02);
+        assert_eq!(&rt[2..6], &[192, 0, 2, 1]);
+        assert_eq!(u16::from_be_bytes([rt[6], rt[7]]), 200);
+    }
+
+    #[test]
+    fn rt_from_api_four_octet_as() {
+        let rt = rt_from_api(&four_octet_rt_api(4_200_000_000, 7)).unwrap();
+        assert_eq!(rt[0], 0x02);
+        assert_eq!(rt[1], 0x02);
+        assert_eq!(
+            u32::from_be_bytes([rt[2], rt[3], rt[4], rt[5]]),
+            4_200_000_000
+        );
+        assert_eq!(u16::from_be_bytes([rt[6], rt[7]]), 7);
+    }
+
+    #[test]
+    fn rt_from_api_rejects_wrong_sub_type() {
+        let rt = api::RouteTarget {
+            rt: Some(api::route_target::Rt::TwoOctetAsSpecific(
+                api::TwoOctetAsSpecificExtended {
+                    is_transitive: true,
+                    sub_type: 3, // Route Origin, not Route Target
+                    asn: 65000,
+                    local_admin: 100,
+                },
+            )),
+        };
+        assert!(rt_from_api(&rt).is_err());
+    }
+
+    #[test]
+    fn rt_from_api_rejects_none() {
+        let rt = api::RouteTarget { rt: None };
+        assert!(rt_from_api(&rt).is_err());
+    }
+
+    #[test]
+    fn rt_roundtrip_two_octet() {
+        let original = two_octet_rt_api(65000, 100);
+        let bytes = rt_from_api(&original).unwrap();
+        let back = rt_to_api(&bytes);
+        let bytes2 = rt_from_api(&back).unwrap();
+        assert_eq!(bytes, bytes2);
+    }
+
+    #[test]
+    fn rt_roundtrip_ipv4() {
+        let original = ipv4_rt_api("10.0.0.1", 42);
+        let bytes = rt_from_api(&original).unwrap();
+        let back = rt_to_api(&bytes);
+        let bytes2 = rt_from_api(&back).unwrap();
+        assert_eq!(bytes, bytes2);
+    }
+
+    #[test]
+    fn rt_roundtrip_four_octet() {
+        let original = four_octet_rt_api(4_200_000_000, 7);
+        let bytes = rt_from_api(&original).unwrap();
+        let back = rt_to_api(&bytes);
+        let bytes2 = rt_from_api(&back).unwrap();
+        assert_eq!(bytes, bytes2);
+    }
 
     #[test]
     fn nexthop_action_self() {

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -2375,13 +2375,39 @@ impl GoBgpService for GrpcService {
         &self,
         request: tonic::Request<api::AddPathRequest>,
     ) -> Result<tonic::Response<api::AddPathResponse>, tonic::Status> {
-        let (family, nets, attrs, nexthop) =
-            self.local_path(request.into_inner().path.ok_or(Error::EmptyArgument)?)?;
-        let map_nets = nets.clone();
+        let inner = request.into_inner();
+        let table_type =
+            api::TableType::try_from(inner.table_type).unwrap_or(api::TableType::Global);
+        let (mut family, nets, attrs, nexthop) =
+            self.local_path(inner.path.ok_or(Error::EmptyArgument)?)?;
+        let mut insert_nets = nets.clone();
+        let mut insert_attrs = attrs;
+        if table_type == api::TableType::Vrf {
+            let vrf_id = inner.vrf_id;
+            if vrf_id.is_empty() {
+                return Err(Error::InvalidArgument(
+                    "vrf_id is required for VRF table type".to_string(),
+                )
+                .into());
+            }
+            let vrf = self
+                .tables
+                .list_vrfs(Some(&vrf_id))
+                .await
+                .into_iter()
+                .next()
+                .ok_or_else(|| tonic::Status::not_found(format!("VRF '{}' not found", vrf_id)))?;
+            let (vpn_family, vpn_nets, vpn_attrs) =
+                vrf_export_path(family, insert_nets, insert_attrs, &vrf)?;
+            family = vpn_family;
+            insert_nets = vpn_nets;
+            insert_attrs = vpn_attrs;
+        }
+        let map_nets = insert_nets.clone();
         let timestamp = std::time::SystemTime::now();
         let source = table::Source::local();
-        if let Some(attrs) = attrs {
-            for net in nets.clone() {
+        if let Some(attrs) = insert_attrs {
+            for net in insert_nets {
                 self.tables
                     .insert_route(
                         source.clone(),
@@ -2447,36 +2473,6 @@ impl GoBgpService for GrpcService {
             Some(family) => convert::family_from_api(&family),
             None => Family::IPV4,
         };
-        let query = if let Ok(t) = api::TableType::try_from(request.table_type) {
-            match t {
-                api::TableType::Unspecified => {
-                    return Err(tonic::Status::new(
-                        tonic::Code::InvalidArgument,
-                        "table type unspecified",
-                    ));
-                }
-                api::TableType::Global => table::TableQuery::Global,
-                api::TableType::Local | api::TableType::Vrf => {
-                    return Err(tonic::Status::unimplemented("Not yet implemented"));
-                }
-                api::TableType::AdjIn => IpAddr::from_str(&request.name)
-                    .map(table::TableQuery::AdjIn)
-                    .map_err(|_| {
-                        tonic::Status::new(tonic::Code::InvalidArgument, "invalid neighbor name")
-                    })?,
-                api::TableType::AdjOut => IpAddr::from_str(&request.name)
-                    .map(table::TableQuery::AdjOut)
-                    .map_err(|_| {
-                        tonic::Status::new(tonic::Code::InvalidArgument, "invalid neighbor name")
-                    })?,
-            }
-        } else {
-            return Err(tonic::Status::new(
-                tonic::Code::InvalidArgument,
-                "invalid table type",
-            ));
-        };
-
         let prefixes: Vec<table::PrefixFilter> = request
             .prefixes
             .iter()
@@ -2501,6 +2497,72 @@ impl GoBgpService for GrpcService {
             nlri_binary: request.enable_nlri_binary || request.enable_only_binary,
             attr_binary: request.enable_attribute_binary || request.enable_only_binary,
             only_binary: request.enable_only_binary,
+        };
+
+        let query = if let Ok(t) = api::TableType::try_from(request.table_type) {
+            match t {
+                api::TableType::Unspecified => {
+                    return Err(tonic::Status::new(
+                        tonic::Code::InvalidArgument,
+                        "table type unspecified",
+                    ));
+                }
+                api::TableType::Global => table::TableQuery::Global,
+                api::TableType::Local => {
+                    return Err(tonic::Status::unimplemented("Not yet implemented"));
+                }
+                api::TableType::Vrf => {
+                    let vrf_name = request.name.clone();
+                    if vrf_name.is_empty() {
+                        return Err(tonic::Status::new(
+                            tonic::Code::InvalidArgument,
+                            "name (vrf name) is required",
+                        ));
+                    }
+                    if !matches!(family, Family::IPV4 | Family::IPV6) {
+                        return Err(tonic::Status::new(
+                            tonic::Code::InvalidArgument,
+                            format!("unsupported VRF family: {:?}", family),
+                        ));
+                    }
+                    let entries = self
+                        .tables
+                        .collect_vrf_paths(&vrf_name, family, prefixes, enable_filtered)
+                        .await
+                        .ok_or_else(|| {
+                            tonic::Status::not_found(format!("VRF '{}' not found", vrf_name))
+                        })?;
+                    let (tx, rx) = mpsc::channel(1024);
+                    tokio::spawn(async move {
+                        for d in entries {
+                            let r = api::ListPathResponse {
+                                destination: Some(convert::destination_to_api(d, family, &binary)),
+                            };
+                            if tx.send(Ok(r)).await.is_err() {
+                                break;
+                            }
+                        }
+                    });
+                    return Ok(tonic::Response::new(Box::pin(
+                        tokio_stream::wrappers::ReceiverStream::new(rx),
+                    )));
+                }
+                api::TableType::AdjIn => IpAddr::from_str(&request.name)
+                    .map(table::TableQuery::AdjIn)
+                    .map_err(|_| {
+                        tonic::Status::new(tonic::Code::InvalidArgument, "invalid neighbor name")
+                    })?,
+                api::TableType::AdjOut => IpAddr::from_str(&request.name)
+                    .map(table::TableQuery::AdjOut)
+                    .map_err(|_| {
+                        tonic::Status::new(tonic::Code::InvalidArgument, "invalid neighbor name")
+                    })?,
+            }
+        } else {
+            return Err(tonic::Status::new(
+                tonic::Code::InvalidArgument,
+                "invalid table type",
+            ));
         };
         let mut path_count = 0u64;
         let v: Vec<_> = self
@@ -2578,24 +2640,84 @@ impl GoBgpService for GrpcService {
     }
     async fn add_vrf(
         &self,
-        _request: tonic::Request<api::AddVrfRequest>,
+        request: tonic::Request<api::AddVrfRequest>,
     ) -> Result<tonic::Response<api::AddVrfResponse>, tonic::Status> {
-        Err(tonic::Status::unimplemented("Not yet implemented"))
+        self.is_available(true).await?;
+        let vrf = request.into_inner().vrf.ok_or(Error::EmptyArgument)?;
+        let name = vrf.name.clone();
+        if name.is_empty() {
+            return Err(Error::InvalidArgument("vrf name is empty".to_string()).into());
+        }
+        let rd = convert::rd_from_api(
+            vrf.rd
+                .as_ref()
+                .ok_or_else(|| Error::InvalidArgument("missing rd".to_string()))?,
+        )?;
+        let import_rt = vrf
+            .import_rt
+            .iter()
+            .map(convert::rt_from_api)
+            .collect::<Result<std::collections::HashSet<_>, _>>()?;
+        let export_rt = vrf
+            .export_rt
+            .iter()
+            .map(convert::rt_from_api)
+            .collect::<Result<Vec<_>, _>>()?;
+        self.tables
+            .add_vrf(name, rd, import_rt, export_rt)
+            .await
+            .map_err(Error::Table)?;
+        Ok(tonic::Response::new(api::AddVrfResponse {}))
     }
+
     async fn delete_vrf(
         &self,
-        _request: tonic::Request<api::DeleteVrfRequest>,
+        request: tonic::Request<api::DeleteVrfRequest>,
     ) -> Result<tonic::Response<api::DeleteVrfResponse>, tonic::Status> {
-        Err(tonic::Status::unimplemented("Not yet implemented"))
+        self.is_available(true).await?;
+        let name = request.into_inner().name;
+        if name.is_empty() {
+            return Err(Error::InvalidArgument("vrf name is empty".to_string()).into());
+        }
+        self.tables.delete_vrf(&name).await.map_err(Error::Table)?;
+        Ok(tonic::Response::new(api::DeleteVrfResponse {}))
     }
+
     type ListVrfStream = Pin<
         Box<dyn Stream<Item = Result<api::ListVrfResponse, tonic::Status>> + Send + Sync + 'static>,
     >;
+
     async fn list_vrf(
         &self,
-        _request: tonic::Request<api::ListVrfRequest>,
+        request: tonic::Request<api::ListVrfRequest>,
     ) -> Result<tonic::Response<Self::ListVrfStream>, tonic::Status> {
-        Err(tonic::Status::unimplemented("Not yet implemented"))
+        self.is_available(false).await?;
+        let name_filter = request.into_inner().name;
+        let filter = if name_filter.is_empty() {
+            None
+        } else {
+            Some(name_filter.as_str())
+        };
+        let vrfs = self.tables.list_vrfs(filter).await;
+        let responses: Vec<_> = vrfs
+            .iter()
+            .map(|v| {
+                Ok(api::ListVrfResponse {
+                    vrf: Some(convert::vrf_to_api(v)),
+                })
+            })
+            .collect();
+        let (tx, rx) = mpsc::channel(32);
+        tokio::spawn(async move {
+            for r in responses {
+                if tx.send(r).await.is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(tonic::Response::new(Box::pin(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        )))
     }
     async fn add_policy(
         &self,
@@ -4355,6 +4477,93 @@ async fn process_restarting_outputs(
 
     // Flatten: None (no output) and Some(None) (disabled) both mean "don't start timer".
     start_timer.flatten()
+}
+
+/// Convert plain IPv4/IPv6 NLRIs to VPNv4/VPNv6 for VRF export.
+///
+/// Attaches the VRF's RD, label, and export RTs (as EXTENDED_COMMUNITY) to
+/// each path, then returns the translated family and updated NLRI/attrs.
+type ExportedPath = (
+    Family,
+    Vec<packet::PathNlri>,
+    Option<Arc<Vec<packet::Attribute>>>,
+);
+
+fn vrf_export_path(
+    family: Family,
+    nets: Vec<packet::PathNlri>,
+    attrs: Option<Arc<Vec<packet::Attribute>>>,
+    vrf: &table::Vrf,
+) -> Result<ExportedPath, tonic::Status> {
+    let vpn_family = match family {
+        Family::IPV4 => Family::IPV4_VPN,
+        Family::IPV6 => Family::IPV6_VPN,
+        _ => {
+            return Err(tonic::Status::new(
+                tonic::Code::InvalidArgument,
+                "VRF add_path only supports IPv4/IPv6 families",
+            ));
+        }
+    };
+
+    let vpn_nets: Vec<packet::PathNlri> = nets
+        .into_iter()
+        .map(|pn| {
+            let vpn_nlri = match pn.nlri {
+                packet::Nlri::V4(prefix) => packet::Nlri::VpnV4(packet::vpn::VpnV4Nlri {
+                    labels: packet::mpls::MplsLabelStack::new(vec![vrf.label]),
+                    rd: vrf.rd,
+                    prefix,
+                }),
+                packet::Nlri::V6(prefix) => packet::Nlri::VpnV6(packet::vpn::VpnV6Nlri {
+                    labels: packet::mpls::MplsLabelStack::new(vec![vrf.label]),
+                    rd: vrf.rd,
+                    prefix,
+                }),
+                other => {
+                    return Err(tonic::Status::new(
+                        tonic::Code::InvalidArgument,
+                        format!("unsupported NLRI type for VRF export: {:?}", other),
+                    ));
+                }
+            };
+            Ok(packet::PathNlri {
+                path_id: pn.path_id,
+                nlri: vpn_nlri,
+            })
+        })
+        .collect::<Result<_, _>>()?;
+
+    let vpn_attrs = if vrf.export_rt.is_empty() {
+        attrs
+    } else {
+        let rt_bytes: Vec<u8> = vrf
+            .export_rt
+            .iter()
+            .flat_map(|rt| rt.iter().copied())
+            .collect();
+        let mut new_attrs: Vec<packet::Attribute> =
+            attrs.as_deref().map_or_else(Vec::new, |v| v.to_vec());
+        if let Some(ec) = new_attrs
+            .iter_mut()
+            .find(|a| a.code() == packet::bgp::Attribute::EXTENDED_COMMUNITY)
+        {
+            let mut data = ec.binary().cloned().unwrap_or_default();
+            data.extend_from_slice(&rt_bytes);
+            *ec = packet::Attribute::new_with_bin(packet::bgp::Attribute::EXTENDED_COMMUNITY, data)
+                .unwrap();
+        } else {
+            if let Some(ec) = packet::Attribute::new_with_bin(
+                packet::bgp::Attribute::EXTENDED_COMMUNITY,
+                rt_bytes,
+            ) {
+                new_attrs.push(ec);
+            }
+        }
+        Some(Arc::new(new_attrs))
+    };
+
+    Ok((vpn_family, vpn_nets, vpn_attrs))
 }
 
 async fn gr_selection_deferral_timer_expired(global: GlobalHandle, tables: TableHandle) {
@@ -10516,5 +10725,401 @@ neighbor-address = "10.0.0.1"
         assert!(!exceeded, "loop detection must not trigger CEASE");
         let state = tables.table_state(Family::IPV4).await;
         assert_eq!(state.num_destination, 0, "route must not be inserted");
+    }
+
+    // --- VRF gRPC end-to-end ---
+
+    fn two_octet_rt(asn: u32, local_admin: u32) -> api::RouteTarget {
+        api::RouteTarget {
+            rt: Some(api::route_target::Rt::TwoOctetAsSpecific(
+                api::TwoOctetAsSpecificExtended {
+                    is_transitive: true,
+                    sub_type: 2,
+                    asn,
+                    local_admin,
+                },
+            )),
+        }
+    }
+
+    fn make_vrf_req(
+        name: &str,
+        rd_asn: u32,
+        rd_admin: u32,
+        rt_asn: u32,
+        rt_local: u32,
+    ) -> api::AddVrfRequest {
+        api::AddVrfRequest {
+            vrf: Some(api::Vrf {
+                name: name.to_string(),
+                rd: Some(api::RouteDistinguisher {
+                    rd: Some(api::route_distinguisher::Rd::TwoOctetAsn(
+                        api::RouteDistinguisherTwoOctetAsn {
+                            admin: rd_asn,
+                            assigned: rd_admin,
+                        },
+                    )),
+                }),
+                import_rt: vec![two_octet_rt(rt_asn, rt_local)],
+                export_rt: vec![two_octet_rt(rt_asn, rt_local)],
+                ..Default::default()
+            }),
+        }
+    }
+
+    async fn collect_list_vrf(svc: &GrpcService, name: &str) -> Vec<api::Vrf> {
+        let req = tonic::Request::new(api::ListVrfRequest {
+            name: name.to_string(),
+        });
+        let stream = svc.list_vrf(req).await.unwrap().into_inner();
+        stream
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .filter_map(|r| r.ok()?.vrf)
+            .collect()
+    }
+
+    async fn collect_list_path_vrf(
+        svc: &GrpcService,
+        vrf_name: &str,
+        afi: i32,
+        safi: i32,
+    ) -> Vec<api::Destination> {
+        let req = tonic::Request::new(api::ListPathRequest {
+            table_type: api::TableType::Vrf as i32,
+            name: vrf_name.to_string(),
+            family: Some(api::Family { afi, safi }),
+            ..Default::default()
+        });
+        let stream = svc.list_path(req).await.unwrap().into_inner();
+        stream
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .filter_map(|r| r.ok()?.destination)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn add_vrf_and_list_vrf() {
+        let svc = make_grpc_service();
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf1", 65000, 1, 65000, 1,
+        )))
+        .await
+        .unwrap();
+        let vrfs = collect_list_vrf(&svc, "vrf1").await;
+        assert_eq!(vrfs.len(), 1);
+        assert_eq!(vrfs[0].name, "vrf1");
+    }
+
+    #[tokio::test]
+    async fn add_vrf_duplicate_returns_error() {
+        let svc = make_grpc_service();
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf1", 65000, 1, 65000, 1,
+        )))
+        .await
+        .unwrap();
+        let err = svc
+            .add_vrf(tonic::Request::new(make_vrf_req(
+                "vrf1", 65000, 2, 65000, 2,
+            )))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::AlreadyExists);
+    }
+
+    #[tokio::test]
+    async fn delete_vrf_removes_it() {
+        let svc = make_grpc_service();
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf1", 65000, 1, 65000, 1,
+        )))
+        .await
+        .unwrap();
+        svc.delete_vrf(tonic::Request::new(api::DeleteVrfRequest {
+            name: "vrf1".to_string(),
+        }))
+        .await
+        .unwrap();
+        let vrfs = collect_list_vrf(&svc, "vrf1").await;
+        assert!(vrfs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_vrf_not_found_returns_error() {
+        let svc = make_grpc_service();
+        let err = svc
+            .delete_vrf(tonic::Request::new(api::DeleteVrfRequest {
+                name: "noexist".to_string(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn consecutive_vrfs_get_different_labels() {
+        let svc = make_grpc_service();
+        // Both VRFs use the same RT so both import the other's routes; they differ only by RD.
+        // Injecting the same prefix into each VRF produces two distinct VPN NLRI (different labels),
+        // which means the global IPV4_VPN table has two destinations.
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf1", 65000, 1, 65000, 100,
+        )))
+        .await
+        .unwrap();
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf2", 65000, 2, 65000, 100,
+        )))
+        .await
+        .unwrap();
+
+        for vrf in ["vrf1", "vrf2"] {
+            let req = tonic::Request::new(api::AddPathRequest {
+                table_type: api::TableType::Vrf as i32,
+                vrf_id: vrf.to_string(),
+                path: Some(ipv4_path("10.1.0.0", 24, "10.0.0.1")),
+            });
+            svc.add_path(req).await.unwrap();
+        }
+
+        let req = tonic::Request::new(api::ListPathRequest {
+            table_type: api::TableType::Global as i32,
+            family: Some(api::Family { afi: 1, safi: 128 }),
+            ..Default::default()
+        });
+        let stream = svc.list_path(req).await.unwrap().into_inner();
+        let dests: Vec<_> = stream
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .filter_map(|r| r.ok()?.destination)
+            .collect();
+        // Each VRF gets a unique label so they produce distinct VPN NLRI (two separate destinations)
+        assert_eq!(
+            dests.len(),
+            2,
+            "each VRF label yields a distinct VPN destination"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_path_vrf_appears_in_global_vpn_table() {
+        let svc = make_grpc_service();
+        // Create VRF with RT 65000:100
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf1", 65000, 100, 65000, 100,
+        )))
+        .await
+        .unwrap();
+
+        // Inject a plain IPv4 route via the VRF table type
+        let req = tonic::Request::new(api::AddPathRequest {
+            table_type: api::TableType::Vrf as i32,
+            vrf_id: "vrf1".to_string(),
+            path: Some(ipv4_path("10.1.0.0", 24, "10.0.0.1")),
+        });
+        svc.add_path(req).await.unwrap();
+
+        // The route must appear in the global IPV4_VPN table (AFI=1, SAFI=128)
+        let req = tonic::Request::new(api::ListPathRequest {
+            table_type: api::TableType::Global as i32,
+            family: Some(api::Family { afi: 1, safi: 128 }),
+            ..Default::default()
+        });
+        let stream = svc.list_path(req).await.unwrap().into_inner();
+        let dests: Vec<_> = stream
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .filter_map(|r| r.ok()?.destination)
+            .collect();
+        assert_eq!(dests.len(), 1, "VPN route must be in global VPN table");
+    }
+
+    #[tokio::test]
+    async fn list_path_vrf_shows_plain_prefix() {
+        let svc = make_grpc_service();
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf1", 65000, 100, 65000, 100,
+        )))
+        .await
+        .unwrap();
+
+        let req = tonic::Request::new(api::AddPathRequest {
+            table_type: api::TableType::Vrf as i32,
+            vrf_id: "vrf1".to_string(),
+            path: Some(ipv4_path("192.0.2.0", 24, "10.0.0.1")),
+        });
+        svc.add_path(req).await.unwrap();
+
+        // list_path with TABLE_TYPE_VRF applies ToLocal(): the destination prefix
+        // and the path NLRI are plain unicast (IPv4/IPv6), matching GoBGP behavior.
+        let dests = collect_list_path_vrf(&svc, "vrf1", 1, 1).await;
+        assert_eq!(dests.len(), 1);
+        // destination.prefix is a plain CIDR string ("192.0.2.0/24"), not VPN format.
+        assert_eq!(
+            dests[0].prefix, "192.0.2.0/24",
+            "expected plain CIDR, got: {}",
+            dests[0].prefix
+        );
+        // path.nlri must be IpAddressPrefix (plain), not LabeledVpnIpPrefix.
+        let path_nlri = dests[0].paths[0].nlri.as_ref().unwrap();
+        assert!(
+            matches!(path_nlri.nlri, Some(api::nlri::Nlri::Prefix(_))),
+            "expected plain IpAddressPrefix NLRI"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_path_vrf_to_local_family_and_no_ext_community() {
+        // ToLocal() must:
+        //   1. return paths with unicast family (afi=1/safi=1 for IPv4), not VPN family
+        //   2. remove EXTENDED_COMMUNITY attribute (export RTs) from each path
+        let svc = make_grpc_service();
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf1", 65000, 100, 65000, 100,
+        )))
+        .await
+        .unwrap();
+
+        let req = tonic::Request::new(api::AddPathRequest {
+            table_type: api::TableType::Vrf as i32,
+            vrf_id: "vrf1".to_string(),
+            path: Some(ipv4_path("10.0.1.0", 24, "10.0.0.1")),
+        });
+        svc.add_path(req).await.unwrap();
+
+        let dests = collect_list_path_vrf(&svc, "vrf1", 1, 1).await;
+        assert_eq!(dests.len(), 1);
+
+        let path = &dests[0].paths[0];
+
+        // family must be IPv4 unicast (afi=1, safi=1), not IPv4 VPN (afi=1, safi=128)
+        let fam = path.family.as_ref().expect("family must be set");
+        assert_eq!(fam.afi, 1, "expected AFI_IP (1), got {}", fam.afi);
+        assert_eq!(fam.safi, 1, "expected SAFI_UNICAST (1), got {}", fam.safi);
+
+        // EXTENDED_COMMUNITY must not appear in the path attributes
+        let has_ext_comm = path
+            .pattrs
+            .iter()
+            .any(|a| matches!(a.attr, Some(api::attribute::Attr::ExtendedCommunities(_))));
+        assert!(
+            !has_ext_comm,
+            "EXTENDED_COMMUNITY must be stripped from VRF list_path response"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_path_vrf_ipv6_to_local() {
+        // Verify ToLocal() works correctly for IPv6 VRF paths:
+        //   destination.prefix must be plain IPv6 CIDR parseable by net.ParseCIDR,
+        //   path NLRI must be IpAddressPrefix (not LabeledVpnIpPrefix),
+        //   path family must be IPv6 unicast (afi=2, safi=1).
+        let svc = make_grpc_service();
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf1", 65000, 100, 65000, 100,
+        )))
+        .await
+        .unwrap();
+
+        let ipv6_path = api::Path {
+            family: Some(api::Family { afi: 2, safi: 1 }),
+            nlri: Some(api::Nlri {
+                nlri: Some(api::nlri::Nlri::Prefix(api::IpAddressPrefix {
+                    prefix: "2001:db8::".to_string(),
+                    prefix_len: 32,
+                })),
+            }),
+            pattrs: vec![
+                api::Attribute {
+                    attr: Some(api::attribute::Attr::Origin(api::OriginAttribute {
+                        origin: 0,
+                    })),
+                },
+                api::Attribute {
+                    attr: Some(api::attribute::Attr::MpReach(api::MpReachNlriAttribute {
+                        family: Some(api::Family { afi: 2, safi: 1 }),
+                        next_hops: vec!["::1".to_string()],
+                        nlris: vec![],
+                    })),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let req = tonic::Request::new(api::AddPathRequest {
+            table_type: api::TableType::Vrf as i32,
+            vrf_id: "vrf1".to_string(),
+            path: Some(ipv6_path),
+        });
+        svc.add_path(req).await.unwrap();
+
+        // AFI=2 (IPv6), SAFI=1 (unicast) — VRF view
+        let dests = collect_list_path_vrf(&svc, "vrf1", 2, 1).await;
+        assert_eq!(dests.len(), 1, "IPv6 VRF path must appear");
+
+        // destination.prefix must be a plain IPv6 CIDR
+        assert_eq!(
+            dests[0].prefix, "2001:db8::/32",
+            "expected plain IPv6 CIDR, got: {}",
+            dests[0].prefix
+        );
+
+        let path = &dests[0].paths[0];
+
+        // path NLRI must be plain IpAddressPrefix
+        let nlri = path.nlri.as_ref().unwrap();
+        assert!(
+            matches!(nlri.nlri, Some(api::nlri::Nlri::Prefix(_))),
+            "expected IpAddressPrefix NLRI for IPv6 VRF path"
+        );
+
+        // family must be IPv6 unicast (afi=2, safi=1)
+        let fam = path.family.as_ref().unwrap();
+        assert_eq!(fam.afi, 2, "expected AFI_IP6 (2), got {}", fam.afi);
+        assert_eq!(fam.safi, 1, "expected SAFI_UNICAST (1), got {}", fam.safi);
+
+        // EXTENDED_COMMUNITY must be absent
+        assert!(
+            !path
+                .pattrs
+                .iter()
+                .any(|a| matches!(a.attr, Some(api::attribute::Attr::ExtendedCommunities(_)))),
+            "EXTENDED_COMMUNITY must be stripped"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_path_vrf_rt_isolation() {
+        let svc = make_grpc_service();
+        // vrf1 uses RT 65000:1; vrf2 uses RT 65000:2 — routes must not leak
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf1", 65000, 1, 65000, 1,
+        )))
+        .await
+        .unwrap();
+        svc.add_vrf(tonic::Request::new(make_vrf_req(
+            "vrf2", 65000, 2, 65000, 2,
+        )))
+        .await
+        .unwrap();
+
+        let req = tonic::Request::new(api::AddPathRequest {
+            table_type: api::TableType::Vrf as i32,
+            vrf_id: "vrf1".to_string(),
+            path: Some(ipv4_path("10.1.0.0", 24, "10.0.0.1")),
+        });
+        svc.add_path(req).await.unwrap();
+
+        let dests_vrf1 = collect_list_path_vrf(&svc, "vrf1", 1, 1).await;
+        let dests_vrf2 = collect_list_path_vrf(&svc, "vrf2", 1, 1).await;
+
+        assert_eq!(dests_vrf1.len(), 1, "vrf1 must see its own route");
+        assert_eq!(dests_vrf2.len(), 0, "vrf2 must not see vrf1's route");
     }
 }

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -83,9 +83,14 @@ pub(crate) struct TableManager {
     pub(crate) export_policy: ArcSwapOption<table::PolicyAssignment>,
     next_sub_id: std::sync::atomic::AtomicU64,
     subscribers: Mutex<FnvHashMap<SubscriptionId, mpsc::UnboundedSender<BgpEvent>>>,
+    vrfs: Mutex<FnvHashMap<String, table::Vrf>>,
+    next_label: std::sync::atomic::AtomicU32,
 }
 
 impl TableManager {
+    /// First available MPLS label (0-15 are reserved per RFC 3032).
+    const LABEL_BASE: u32 = 16;
+
     pub(crate) fn new(num_shards: usize) -> Self {
         TableManager {
             shards: (0..num_shards)
@@ -104,7 +109,103 @@ impl TableManager {
             export_policy: ArcSwapOption::const_empty(),
             next_sub_id: std::sync::atomic::AtomicU64::new(0),
             subscribers: Mutex::new(FnvHashMap::default()),
+            vrfs: Mutex::new(FnvHashMap::default()),
+            next_label: std::sync::atomic::AtomicU32::new(Self::LABEL_BASE),
         }
+    }
+
+    fn allocate_label(&self) -> packet::mpls::MplsLabel {
+        packet::mpls::MplsLabel::new(
+            self.next_label
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        )
+    }
+
+    pub(crate) async fn add_vrf(
+        &self,
+        name: String,
+        rd: packet::rd::RouteDistinguisher,
+        import_rt: std::collections::HashSet<[u8; 8]>,
+        export_rt: Vec<[u8; 8]>,
+    ) -> Result<packet::mpls::MplsLabel, table::TableError> {
+        let mut vrfs = self.vrfs.lock().await;
+        if vrfs.contains_key(&name) {
+            return Err(table::TableError::AlreadyExists(name));
+        }
+        let label = self.allocate_label();
+        vrfs.insert(
+            name.clone(),
+            table::Vrf {
+                name,
+                rd,
+                import_rt,
+                export_rt,
+                label,
+            },
+        );
+        Ok(label)
+    }
+
+    pub(crate) async fn delete_vrf(&self, name: &str) -> Result<(), table::TableError> {
+        let mut vrfs = self.vrfs.lock().await;
+        vrfs.remove(name).ok_or(table::TableError::NotFound)?;
+        Ok(())
+    }
+
+    pub(crate) async fn list_vrfs(&self, name: Option<&str>) -> Vec<table::Vrf> {
+        let vrfs = self.vrfs.lock().await;
+        match name {
+            Some(n) => vrfs.get(n).cloned().into_iter().collect(),
+            None => vrfs.values().cloned().collect(),
+        }
+    }
+
+    /// Collect paths from the global VPN table that can be imported into `vrf`.
+    /// Returns destinations with the VPN wrapper stripped (plain V4/V6 NLRI).
+    pub(crate) async fn collect_vrf_paths(
+        &self,
+        vrf_name: &str,
+        family: Family,
+        prefixes: Vec<table::PrefixFilter>,
+        enable_filtered: bool,
+    ) -> Option<Vec<table::DestinationEntry>> {
+        let vpn_family = match family {
+            Family::IPV4 => Family::IPV4_VPN,
+            Family::IPV6 => Family::IPV6_VPN,
+            _ => return None,
+        };
+        let vrf = self.vrfs.lock().await.get(vrf_name)?.clone();
+        let mut out = Vec::new();
+        for shard in &self.shards {
+            let t = shard.lock().await;
+            for mut dest in t.rtable.destinations(
+                table::TableQuery::Global,
+                vpn_family,
+                prefixes.clone(),
+                None,
+                enable_filtered,
+            ) {
+                if dest.paths.iter().any(|p| vrf.can_import(&p.attr)) {
+                    // ToLocal() equivalent: strip VPN envelope from NLRI,
+                    // remove EXTENDED_COMMUNITY (export RTs) from each path.
+                    let Some(local_nlri) = table::vpn_to_local_nlri(&dest.net) else {
+                        continue;
+                    };
+                    dest.net = local_nlri;
+                    for path in &mut dest.paths {
+                        let stripped: Vec<_> = path
+                            .attr
+                            .iter()
+                            .filter(|a| a.code() != packet::Attribute::EXTENDED_COMMUNITY)
+                            .cloned()
+                            .collect();
+                        path.attr = std::sync::Arc::new(stripped);
+                    }
+                    out.push(dest);
+                }
+            }
+        }
+        Some(out)
     }
 
     fn dealer<T: Hash>(&self, a: T) -> usize {

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -15,6 +15,7 @@
 
 use fnv::FnvHashMap;
 use patricia_tree::PatriciaMap;
+use std::collections::HashSet;
 use std::convert::Into;
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, Ipv4Addr};
@@ -35,6 +36,55 @@ pub enum TableError {
     NotFound,
     #[error("entity still in use")]
     StillInUse(String),
+}
+
+/// VRF (Virtual Routing and Forwarding) instance for BGP/MPLS IP VPN (RFC 4364).
+///
+/// Routes received from peers are imported when their extended communities
+/// contain at least one RT that matches `import_rt`.  Routes injected via
+/// the API are exported to the global VPN table with `rd`, `label`, and
+/// the `export_rt` set attached as extended communities.
+#[derive(Clone, Debug)]
+pub struct Vrf {
+    pub name: String,
+    pub rd: packet::rd::RouteDistinguisher,
+    /// Each entry is the 8-byte wire encoding of a Route Target extended
+    /// community (type/sub-type + value).  Stored as raw bytes for O(1)
+    /// lookup against the extended communities of incoming VPN routes.
+    pub import_rt: HashSet<[u8; 8]>,
+    pub export_rt: Vec<[u8; 8]>,
+    pub label: packet::mpls::MplsLabel,
+}
+
+impl Vrf {
+    /// Returns true when at least one RT in `attrs` extended communities
+    /// matches this VRF's import_rt set.
+    pub fn can_import(&self, attrs: &[Attribute]) -> bool {
+        for attr in attrs {
+            if attr.code() == Attribute::EXTENDED_COMMUNITY {
+                let Some(data) = attr.binary() else {
+                    continue;
+                };
+                for chunk in data.chunks_exact(8) {
+                    let bytes: [u8; 8] = chunk.try_into().unwrap();
+                    if self.import_rt.contains(&bytes) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
+/// Strip the VPN envelope from a VPNv4/VPNv6 NLRI, returning the plain
+/// IPv4/IPv6 prefix as seen inside the VRF.
+pub fn vpn_to_local_nlri(nlri: &packet::Nlri) -> Option<packet::Nlri> {
+    match nlri {
+        packet::Nlri::VpnV4(v) => Some(packet::Nlri::V4(v.prefix)),
+        packet::Nlri::VpnV6(v) => Some(packet::Nlri::V6(v.prefix)),
+        _ => None,
+    }
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -4937,5 +4987,100 @@ mod tests {
         let reaches: Vec<_> = rt.iter_reach(Family::IPV4).collect();
         assert_eq!(reaches.len(), 1);
         assert_eq!(reaches[0].attr, original);
+    }
+
+    // --- Vrf::can_import ---
+
+    fn make_vrf(import_rts: Vec<[u8; 8]>) -> Vrf {
+        Vrf {
+            name: "test".to_string(),
+            rd: packet::rd::RouteDistinguisher::TwoOctetAs {
+                admin: 65000,
+                assigned: 1,
+            },
+            import_rt: import_rts.into_iter().collect(),
+            export_rt: Vec::new(),
+            label: packet::mpls::MplsLabel::new(16),
+        }
+    }
+
+    fn ext_community_attr(rts: &[[u8; 8]]) -> packet::Attribute {
+        let mut data = Vec::with_capacity(rts.len() * 8);
+        for rt in rts {
+            data.extend_from_slice(rt);
+        }
+        packet::Attribute::new_with_bin(packet::Attribute::EXTENDED_COMMUNITY, data).unwrap()
+    }
+
+    #[test]
+    fn can_import_matching_rt() {
+        let rt: [u8; 8] = [0x00, 0x02, 0xfd, 0xe8, 0x00, 0x00, 0x00, 0x64];
+        let vrf = make_vrf(vec![rt]);
+        let attrs = vec![ext_community_attr(&[rt])];
+        assert!(vrf.can_import(&attrs));
+    }
+
+    #[test]
+    fn can_import_no_match() {
+        let rt_import: [u8; 8] = [0x00, 0x02, 0xfd, 0xe8, 0x00, 0x00, 0x00, 0x64];
+        let rt_other: [u8; 8] = [0x00, 0x02, 0xfd, 0xe8, 0x00, 0x00, 0x00, 0x65];
+        let vrf = make_vrf(vec![rt_import]);
+        let attrs = vec![ext_community_attr(&[rt_other])];
+        assert!(!vrf.can_import(&attrs));
+    }
+
+    #[test]
+    fn can_import_multiple_rts_one_matches() {
+        let rt_a: [u8; 8] = [0x00, 0x02, 0xfd, 0xe8, 0x00, 0x00, 0x00, 0x01];
+        let rt_b: [u8; 8] = [0x00, 0x02, 0xfd, 0xe8, 0x00, 0x00, 0x00, 0x02];
+        let vrf = make_vrf(vec![rt_b]);
+        // path carries both RT A and RT B; RT B matches
+        let attrs = vec![ext_community_attr(&[rt_a, rt_b])];
+        assert!(vrf.can_import(&attrs));
+    }
+
+    #[test]
+    fn can_import_empty_import_rt() {
+        let rt: [u8; 8] = [0x00, 0x02, 0xfd, 0xe8, 0x00, 0x00, 0x00, 0x64];
+        let vrf = make_vrf(vec![]);
+        let attrs = vec![ext_community_attr(&[rt])];
+        assert!(!vrf.can_import(&attrs));
+    }
+
+    #[test]
+    fn can_import_no_ext_community_attr() {
+        let rt: [u8; 8] = [0x00, 0x02, 0xfd, 0xe8, 0x00, 0x00, 0x00, 0x64];
+        let vrf = make_vrf(vec![rt]);
+        let attrs: Vec<packet::Attribute> = vec![];
+        assert!(!vrf.can_import(&attrs));
+    }
+
+    // --- vpn_to_local_nlri ---
+
+    #[test]
+    fn vpn_to_local_nlri_v4() {
+        use std::net::Ipv4Addr;
+        let prefix = packet::bgp::Ipv4Net {
+            addr: Ipv4Addr::new(10, 0, 1, 0),
+            mask: 24,
+        };
+        let rd = packet::rd::RouteDistinguisher::TwoOctetAs {
+            admin: 65000,
+            assigned: 100,
+        };
+        let labels = packet::mpls::MplsLabelStack::new(vec![packet::mpls::MplsLabel::new(16)]);
+        let vpn = packet::Nlri::VpnV4(packet::vpn::VpnV4Nlri { prefix, rd, labels });
+        let local = vpn_to_local_nlri(&vpn).unwrap();
+        assert_eq!(local, packet::Nlri::V4(prefix));
+    }
+
+    #[test]
+    fn vpn_to_local_nlri_non_vpn_returns_none() {
+        use std::net::Ipv4Addr;
+        let plain = packet::Nlri::V4(packet::bgp::Ipv4Net {
+            addr: Ipv4Addr::new(10, 0, 0, 0),
+            mask: 8,
+        });
+        assert!(vpn_to_local_nlri(&plain).is_none());
     }
 }


### PR DESCRIPTION
Implement add_vrf, delete_vrf, list_vrf, and add_path/list_path for TABLE_TYPE_VRF.  These were the last four unimplemented gRPC APIs.

Design follows GoBGP: no per-VRF RIB; all VPNv4/VPNv6 routes live in the global VPN table and the VRF view is built on-the-fly by RT filtering.

VRF storage and label allocation (table_manager.rs):
- Vrf struct with name, rd, import_rt (HashSet<[u8;8]>), export_rt, label
- Labels allocated from 16 (RFC 3032 reserved range 0-15) via AtomicU32
- vrfs: Mutex<FnvHashMap<String, Vrf>> alongside existing table shards

RT wire encoding (convert.rs):
- Stored as raw 8-byte wire encoding for O(1) import matching
- rt_from_api validates sub_type == 0x02 (Route Target) at API boundary
- rt_to_api reconstructs api::RouteTarget from raw bytes
- Three RT types: 2-octet AS (0x00), IPv4 (0x01), 4-octet AS (0x02)

add_path with TABLE_TYPE_VRF (event.rs):
- vrf_export_path converts plain V4/V6 NLRI to VpnV4/VpnV6, attaches VRF rd and label, adds export RTs to EXTENDED_COMMUNITY attribute
- Result inserted into global IPV4_VPN or IPV6_VPN table

list_path with TABLE_TYPE_VRF (table_manager.rs, event.rs):
- collect_vrf_paths walks global VPN table, filters by vrf.can_import() (checks path's EXTENDED_COMMUNITY against VRF's import_rt set)
- Applies ToLocal() equivalent matching GoBGP behavior:
    - Strips VPN envelope: VpnV4/VpnV6 NLRI -> V4/V6 NLRI
    - Removes EXTENDED_COMMUNITY (export RTs) from path attributes
- Returns plain unicast family (IPv4_UC / IPv6_UC) so GoBGP CLI's net.ParseCIDR(destination.prefix) succeeds without nil pointer panic

Tests:
- convert.rs: rt_from_api for all three RT types, sub_type rejection, None rejection, and roundtrip for each type (8 tests)
- table/src/lib.rs: can_import match/no-match/multiple-RTs/empty/no-attr, vpn_to_local_nlri v4 and non-VPN (7 tests)
- event.rs: add/duplicate/delete VRF, not-found deletion, consecutive label uniqueness, add_path in global VPN table, plain prefix string, plain NLRI type, unicast family, no EXTENDED_COMMUNITY in response, RT isolation between two VRFs, IPv6 ToLocal() (10 tests)

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>