### PR TITLE
daemon: remove unnecessary pub(crate) from module-internal items

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -199,7 +199,7 @@ pub(crate) fn rt_from_api(rt: &api::RouteTarget) -> Result<[u8; 8], Error> {
 }
 
 /// Convert an 8-byte RT wire value back to `api::RouteTarget`.
-pub(crate) fn rt_to_api(rt: &[u8; 8]) -> api::RouteTarget {
+fn rt_to_api(rt: &[u8; 8]) -> api::RouteTarget {
     use api::route_target::Rt;
     let rt_val = match rt[0] {
         0x00 => Rt::TwoOctetAsSpecific(api::TwoOctetAsSpecificExtended {
@@ -234,7 +234,7 @@ pub(crate) fn vrf_to_api(vrf: &rustybgp_table::Vrf) -> api::Vrf {
     }
 }
 
-pub(crate) fn rd_to_api(rd: &RouteDistinguisher) -> api::RouteDistinguisher {
+fn rd_to_api(rd: &RouteDistinguisher) -> api::RouteDistinguisher {
     let v = match *rd {
         RouteDistinguisher::TwoOctetAs { admin, assigned } => {
             api::route_distinguisher::Rd::TwoOctetAsn(api::RouteDistinguisherTwoOctetAsn {
@@ -997,7 +997,7 @@ pub(crate) fn attr_from_api(a: api::Attribute) -> Result<Attribute, Error> {
     }
 }
 
-pub(crate) fn prefix_sid_to_api(sid: &prefix_sid::PrefixSid) -> api::PrefixSid {
+fn prefix_sid_to_api(sid: &prefix_sid::PrefixSid) -> api::PrefixSid {
     let tlvs = sid
         .tlvs
         .iter()
@@ -1075,7 +1075,7 @@ fn srv6_service_sub_sub_tlvs_to_api(
     map
 }
 
-pub(crate) fn prefix_sid_from_api(p: api::PrefixSid) -> Result<prefix_sid::PrefixSid, Error> {
+fn prefix_sid_from_api(p: api::PrefixSid) -> Result<prefix_sid::PrefixSid, Error> {
     let mut tlvs = Vec::with_capacity(p.tlvs.len());
     for tlv in p.tlvs {
         let inner = tlv
@@ -2034,7 +2034,7 @@ pub(crate) fn roa_to_api(net: &IpNet, roa: &rustybgp_table::Roa) -> api::Roa {
     }
 }
 
-pub(crate) fn rpki_validation_to_api(v: rustybgp_table::RpkiValidation) -> api::Validation {
+fn rpki_validation_to_api(v: rustybgp_table::RpkiValidation) -> api::Validation {
     let mut result = api::Validation {
         state: match v.state {
             rustybgp_table::RpkiValidationState::NotFound => api::ValidationState::NotFound as i32,
@@ -2207,9 +2207,7 @@ fn bgp_defined_sets_to_api(sets: &config::BgpDefinedSets) -> Result<Vec<api::Def
     Ok(v)
 }
 
-pub(crate) fn defined_sets_to_api(
-    sets: &config::DefinedSets,
-) -> Result<Vec<api::DefinedSet>, Error> {
+fn defined_sets_to_api(sets: &config::DefinedSets) -> Result<Vec<api::DefinedSet>, Error> {
     let mut v = Vec::new();
     if let Some(sets) = &sets.prefix_sets {
         for s in sets {
@@ -2555,7 +2553,7 @@ fn actions_from_config(a: &config::Actions) -> Result<api::Actions, Error> {
     })
 }
 
-pub(crate) fn statement_from_config(s: &config::Statement) -> Result<api::Statement, Error> {
+fn statement_from_config(s: &config::Statement) -> Result<api::Statement, Error> {
     let u = Uuid::new_v4().to_string();
     let name = match s.name.as_ref() {
         Some(n) => n.to_string(),

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -151,7 +151,7 @@ pub(crate) struct Connection {
 }
 
 impl Connection {
-    pub(crate) fn new(
+    fn new(
         local_asn: u32,
         local_router_id: u32,
         local_cap: Vec<Capability>,
@@ -176,12 +176,12 @@ impl Connection {
         }
     }
 
-    pub(crate) fn state(&self) -> State {
+    fn state(&self) -> State {
         self.state
     }
 
     #[cfg(test)]
-    pub(crate) fn negotiated_holdtime(&self) -> u64 {
+    fn negotiated_holdtime(&self) -> u64 {
         self.negotiated_holdtime
     }
 
@@ -189,12 +189,12 @@ impl Connection {
         &self.send_max
     }
 
-    pub(crate) fn remote_id(&self) -> u32 {
+    fn remote_id(&self) -> u32 {
         self.remote_id
     }
 
     /// Process an input event and return actions for the I/O driver.
-    pub(crate) fn process(&mut self, input: Input) -> Vec<Output> {
+    fn process(&mut self, input: Input) -> Vec<Output> {
         match input {
             Input::Connected(_) => self.on_connected(),
             Input::MessageReceived(msg) => self.on_message(msg),
@@ -469,7 +469,7 @@ impl PeerFsm {
     }
 
     /// Close a connection, removing it from its slot.
-    pub(crate) fn close_connection(&mut self, role: Role) {
+    fn close_connection(&mut self, role: Role) {
         match role {
             Role::Active => self.active = None,
             Role::Passive => self.passive = None,
@@ -492,7 +492,7 @@ impl PeerFsm {
     }
 
     /// Mutable reference to the Connection for the given role.
-    pub(crate) fn connection_mut(&mut self, role: Role) -> Option<&mut Connection> {
+    fn connection_mut(&mut self, role: Role) -> Option<&mut Connection> {
         match role {
             Role::Active => self.active.as_mut(),
             Role::Passive => self.passive.as_mut(),

--- a/daemon/src/rpki.rs
+++ b/daemon/src/rpki.rs
@@ -33,7 +33,7 @@ pub(crate) struct RpkiState {
     pub(crate) uptime: AtomicU64,
     pub(crate) downtime: AtomicU64,
     pub(crate) up: AtomicBool,
-    pub(crate) session_id: AtomicU16,
+    session_id: AtomicU16,
     pub(crate) serial: AtomicU32,
     pub(crate) received_ipv4: AtomicI64,
     pub(crate) received_ipv6: AtomicI64,
@@ -47,7 +47,7 @@ pub(crate) struct RpkiState {
 }
 
 impl RpkiState {
-    pub(crate) fn update(&self, msg: &rpki::Message) {
+    fn update(&self, msg: &rpki::Message) {
         match msg {
             rpki::Message::SerialNotify { .. } => {
                 self.serial_notify.fetch_add(1, Ordering::Relaxed);

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -86,7 +86,7 @@ pub(crate) struct TableManager {
     pub(crate) export_policy: ArcSwapOption<table::PolicyAssignment>,
     /// Set of nexthop addresses currently considered unreachable by NHT.
     /// Written only from the event loop (serialized); read lock-free from any shard.
-    pub(crate) nexthop_invalid: ArcSwap<FnvHashSet<IpAddr>>,
+    nexthop_invalid: ArcSwap<FnvHashSet<IpAddr>>,
     next_sub_id: std::sync::atomic::AtomicU64,
     subscribers: Mutex<FnvHashMap<SubscriptionId, mpsc::UnboundedSender<BgpEvent>>>,
     vrfs: SharedVrfs,
@@ -748,7 +748,7 @@ impl TableManager {
 ///
 /// Returns `None` when the route has no usable nexthop or the family cannot
 /// be determined (e.g. MUP/VPN NLRIs).
-pub(crate) fn kernel_route_to_path(
+fn kernel_route_to_path(
     kr: &kernel::KernelRoute,
 ) -> Option<(
     Family,
@@ -868,18 +868,18 @@ fn nht_register(
 
 pub(crate) struct TableShard {
     pub(crate) rtable: table::Table,
-    pub(crate) peer_event_tx: FnvHashMap<IpAddr, mpsc::UnboundedSender<ToPeerEvent>>,
-    pub(crate) subscribers: FnvHashMap<SubscriptionId, mpsc::UnboundedSender<BgpEvent>>,
+    peer_event_tx: FnvHashMap<IpAddr, mpsc::UnboundedSender<ToPeerEvent>>,
+    subscribers: FnvHashMap<SubscriptionId, mpsc::UnboundedSender<BgpEvent>>,
     pub(crate) addpath: FnvHashMap<IpAddr, FnvHashSet<Family>>,
     vrfs: SharedVrfs,
 }
 
 impl TableShard {
-    pub(crate) fn has_addpath(&self, addr: &IpAddr, family: &Family) -> bool {
+    fn has_addpath(&self, addr: &IpAddr, family: &Family) -> bool {
         self.addpath.get(addr).is_some_and(|e| e.contains(family))
     }
 
-    pub(crate) fn disconnected(
+    fn disconnected(
         &mut self,
         addr: IpAddr,
         family: Family,
@@ -896,7 +896,7 @@ impl TableShard {
         }
     }
 
-    pub(crate) fn mark_stale(
+    fn mark_stale(
         &mut self,
         addr: IpAddr,
         family: Family,
@@ -907,7 +907,7 @@ impl TableShard {
         }
     }
 
-    pub(crate) fn notify_adj_rib_in(
+    fn notify_adj_rib_in(
         &self,
         source: Arc<table::Source>,
         family: Family,
@@ -1008,7 +1008,7 @@ impl TableShard {
     ///
     /// Stale paths (GR helper mode) are skipped; see
     /// [`table::Table::collect_adj_in_paths`] for the rationale.
-    pub(crate) fn soft_reset_in(
+    fn soft_reset_in(
         &mut self,
         peer: std::net::IpAddr,
         import_policy: Option<&table::PolicyAssignment>,
@@ -1057,7 +1057,7 @@ impl TableShard {
         }
     }
 
-    pub(crate) fn drop_stale(
+    fn drop_stale(
         &mut self,
         addr: IpAddr,
         family: Family,
@@ -1074,11 +1074,7 @@ impl TableShard {
         }
     }
 
-    pub(crate) fn end_deferral(
-        &mut self,
-        family: Family,
-        kernel_handle: Option<&kernel::KernelHandle>,
-    ) {
+    fn end_deferral(&mut self, family: Family, kernel_handle: Option<&kernel::KernelHandle>) {
         for change in self.rtable.end_deferral(family) {
             self.distribute_update(change, kernel_handle);
         }


### PR DESCRIPTION
24 items were marked pub(crate) but never accessed outside their own source file, making private visibility sufficient.  Identified by grepping each candidate across all daemon source files and confirming no cross-file usage; verified by cargo build with all visibility modifiers removed.

Changed items:
- table_manager: nexthop_invalid field, kernel_route_to_path fn, TableShard fields peer_event_tx/subscribers, TableShard methods has_addpath/disconnected/mark_stale/notify_adj_rib_in/soft_reset_in/ drop_stale/end_deferral
- convert: rt_to_api, rd_to_api, prefix_sid_to_api, prefix_sid_from_api, rpki_validation_to_api, defined_sets_to_api, statement_from_config
- rpki: RpkiState.session_id field, RpkiState::update method
- fsm: Connection methods new/state/negotiated_holdtime/remote_id/process, PeerFsm methods close_connection/connection_mut

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>