### PR TITLE
packet,daemon: refactor message types to separate parsing from routin…

### DIFF
--- a/daemon/src/bmp.rs
+++ b/daemon/src/bmp.rs
@@ -72,16 +72,14 @@ fn flush_peer_snapshot(
         for ((family, _), change) in &peer_routes {
             families_seen.insert(*family);
             let attrs = change.attrs.as_ref().unwrap();
-            let update = bgp::Message::Update(bgp::Update {
-                reach: Some(packet::bgp::NlriSet {
+            let update = bgp::Message::Update(bgp::Update::Routes {
+                reach: Some(packet::bgp::ReachNlri {
                     family: *family,
                     entries: change.nlris.clone(),
+                    nexthop: change.nexthop,
                 }),
-                mp_reach: None,
                 attr: attrs.clone(),
                 unreach: None,
-                mp_unreach: None,
-                nexthop: change.nexthop,
             });
             messages.push(bmp::Message::RouteMonitoring {
                 header: bmp::PerPeerHeader::new(
@@ -115,28 +113,23 @@ fn flush_peer_snapshot(
 /// Convert a live `AdjRibInChange` to the BGP UPDATE used in RouteMonitoring.
 fn adj_rib_in_to_bmp_update(change: &AdjRibInChange) -> bgp::Message {
     if let Some(ref attrs) = change.attrs {
-        bgp::Message::Update(bgp::Update {
-            reach: Some(packet::bgp::NlriSet {
+        bgp::Message::Update(bgp::Update::Routes {
+            reach: Some(packet::bgp::ReachNlri {
                 family: change.family,
                 entries: change.nlris.clone(),
+                nexthop: change.nexthop,
             }),
-            mp_reach: None,
             attr: attrs.clone(),
             unreach: None,
-            mp_unreach: None,
-            nexthop: change.nexthop,
         })
     } else {
-        bgp::Message::Update(bgp::Update {
+        bgp::Message::Update(bgp::Update::Routes {
             reach: None,
-            mp_reach: None,
             attr: Arc::new(Vec::new()),
-            unreach: None,
-            mp_unreach: Some(packet::bgp::NlriSet {
+            unreach: Some(packet::bgp::UnreachNlri {
                 family: change.family,
                 entries: change.nlris.clone(),
             }),
-            nexthop: None,
         })
     }
 }
@@ -705,7 +698,7 @@ mod tests {
 
     #[test]
     fn session_down_to_bmp_remote_notification_preserved() {
-        let msg = bgp::Message::Notification(rustybgp_packet::error::BgpError::Other {
+        let msg = bgp::Message::Notification(rustybgp_packet::error::Notification::Other {
             code: 6,
             subcode: 0,
             data: vec![],
@@ -718,7 +711,7 @@ mod tests {
 
     #[test]
     fn session_down_to_bmp_local_notification_preserved() {
-        let msg = bgp::Message::Notification(rustybgp_packet::error::BgpError::Other {
+        let msg = bgp::Message::Notification(rustybgp_packet::error::Notification::Other {
             code: 6,
             subcode: 0,
             data: vec![],

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -83,23 +83,20 @@ impl MessageCounter {
     fn sync(&self, msg: &bgp::Message) -> bool {
         let mut ret = false;
         match msg {
-            bgp::Message::Open(bgp::Open { .. }) => {
+            bgp::Message::Open(_) => {
                 let _ = self.open.fetch_add(1, Ordering::Relaxed);
             }
-            bgp::Message::Update(bgp::Update {
-                unreach,
-                mp_unreach,
-                ..
-            }) => {
+            bgp::Message::Update(bgp::Update::Routes { unreach, .. }) => {
                 self.update.fetch_add(1, Ordering::Relaxed);
-
-                let unreach_count = unreach.as_ref().map_or(0, |s| s.entries.len())
-                    + mp_unreach.as_ref().map_or(0, |s| s.entries.len());
+                let unreach_count = unreach.as_ref().map_or(0, |s| s.entries.len());
                 if unreach_count > 0 {
                     self.withdraw_update.fetch_add(1, Ordering::Relaxed);
                     self.withdraw_prefix
                         .fetch_add(unreach_count as u64, Ordering::Relaxed);
                 }
+            }
+            bgp::Message::Update(bgp::Update::EndOfRib(_)) => {
+                self.update.fetch_add(1, Ordering::Relaxed);
             }
             bgp::Message::Notification(_) => {
                 ret = true;
@@ -1582,7 +1579,7 @@ impl GoBgpService for GrpcService {
         request: tonic::Request<api::StopBgpRequest>,
     ) -> Result<tonic::Response<api::StopBgpResponse>, tonic::Status> {
         let allow_gr = request.into_inner().allow_graceful_restart;
-        let cease = bgp::Message::Notification(rustybgp_packet::BgpError::Other {
+        let cease = bgp::Message::Notification(rustybgp_packet::Notification::Other {
             code: 6,
             subcode: 3,
             data: vec![],
@@ -1694,7 +1691,7 @@ impl GoBgpService for GrpcService {
                     let mut ctx = p.context.lock().unwrap();
                     ctx.force_down(
                         CloseReason::SendMessage(bgp::Message::Notification(
-                            rustybgp_packet::BgpError::Other {
+                            rustybgp_packet::Notification::Other {
                                 code: 6,
                                 subcode: 3,
                                 data: vec![],
@@ -1873,7 +1870,7 @@ impl GoBgpService for GrpcService {
                 let mut ctx = peer.context.lock().unwrap();
                 ctx.force_down(
                     CloseReason::SendMessage(bgp::Message::Notification(
-                        rustybgp_packet::BgpError::Other {
+                        rustybgp_packet::Notification::Other {
                             code: 6,
                             subcode: 3,
                             data: vec![],
@@ -1927,7 +1924,7 @@ impl GoBgpService for GrpcService {
             let mut ctx = peer.context.lock().unwrap();
             ctx.force_down(
                 CloseReason::SendMessage(bgp::Message::Notification(
-                    rustybgp_packet::BgpError::Other {
+                    rustybgp_packet::Notification::Other {
                         code: 6,
                         subcode: 3,
                         data: vec![],
@@ -5607,10 +5604,9 @@ impl PeerSession {
     /// The caller must send a CEASE NOTIFICATION and close the session.
     async fn rx_update(
         &mut self,
-        reach: Option<packet::NlriSet>,
-        unreach: Option<packet::NlriSet>,
+        reach: Option<bgp::ReachNlri>,
+        unreach: Option<packet::UnreachNlri>,
         attr: Arc<Vec<packet::Attribute>>,
-        nexthop: Option<bgp::Nexthop>,
         timestamp: std::time::SystemTime,
     ) -> bool {
         // RFC 4456 §8 loop detection: discard UPDATE if ORIGINATOR_ID equals
@@ -5636,6 +5632,7 @@ impl PeerSession {
         }
         if let Some(s) = reach {
             let family = s.family;
+            let nexthop = s.nexthop;
             let source = self.source[&family].clone();
             let prefix_limit = self
                 .prefix_counters
@@ -5719,16 +5716,19 @@ impl PeerSession {
         remote_sockaddr: SocketAddr,
         msg: bgp::Message,
     ) -> std::result::Result<(), Error> {
-        // Extract UPDATE fields before passing to FSM (FSM doesn't process routes).
-        let update_fields = if let bgp::Message::Update(ref u) = msg {
-            Some((
-                u.reach.clone(),
-                u.mp_reach.clone(),
-                u.attr.clone(),
-                u.unreach.clone(),
-                u.mp_unreach.clone(),
-                u.nexthop,
-            ))
+        // Extract UPDATE fields before consuming msg into the FSM.
+        let route_fields = if let bgp::Message::Update(bgp::Update::Routes {
+            reach,
+            unreach,
+            attr,
+        }) = &msg
+        {
+            Some((reach.clone(), unreach.clone(), attr.clone()))
+        } else {
+            None
+        };
+        let eor_family = if let bgp::Message::Update(bgp::Update::EndOfRib(f)) = &msg {
+            Some(*f)
         } else {
             None
         };
@@ -5749,25 +5749,19 @@ impl PeerSession {
             .await;
         self.process_effects(effects, global).await;
 
-        // For UPDATE messages: if FSM didn't reject (no SessionDown), process routes.
-        if let Some((reach, mp_reach, attr, unreach, mp_unreach, nexthop)) = update_fields {
+        // For UPDATE Routes: if FSM didn't reject (no SessionDown), process routes.
+        if let Some((reach, unreach, attr)) = route_fields {
             if has_session_down {
                 return Err(Error::Packet(
-                    rustybgp_packet::BgpError::FsmUnexpectedState {
+                    rustybgp_packet::Notification::FsmUnexpectedState {
                         state: u8::from(self.conn_arbiter.lock().unwrap().state(self.role)),
                     }
                     .into(),
                 ));
             }
             let rx_timestamp = std::time::SystemTime::now();
-            let prefix_limit_exceeded = self
-                .rx_update(reach.clone(), unreach, attr.clone(), nexthop, rx_timestamp)
-                .await
-                || self
-                    .rx_update(mp_reach, mp_unreach.clone(), attr, nexthop, rx_timestamp)
-                    .await;
-            if prefix_limit_exceeded {
-                let cease = bgp::Message::Notification(rustybgp_packet::BgpError::Other {
+            if self.rx_update(reach, unreach, attr, rx_timestamp).await {
+                let cease = bgp::Message::Notification(rustybgp_packet::Notification::Other {
                     code: 6,
                     subcode: 1,
                     data: vec![],
@@ -5776,25 +5770,15 @@ impl PeerSession {
                 self.shutdown = Some(crate::fsm::SessionDownReason::LocalNotification(cease));
                 return Ok(());
             }
+        }
 
-            // Detect End-of-RIB: empty NlriSet with no attributes.
-            // IPv4 EOR: reach has empty entries; other families: mp_unreach has empty entries.
-            if self.negotiated_gr.is_some() {
-                let mut eor_effects = Vec::new();
-                if let Some(r) = &reach
-                    && r.entries.is_empty()
-                {
-                    eor_effects.push(GlobalEffect::GrEorReceived { family: r.family });
-                }
-                if let Some(u) = &mp_unreach
-                    && u.entries.is_empty()
-                {
-                    eor_effects.push(GlobalEffect::GrEorReceived { family: u.family });
-                }
-                if !eor_effects.is_empty() {
-                    self.process_effects(eor_effects, global).await;
-                }
-            }
+        // For UPDATE EndOfRib: signal GR if negotiated.
+        if let Some(family) = eor_family
+            && !has_session_down
+            && self.negotiated_gr.is_some()
+        {
+            self.process_effects(vec![GlobalEffect::GrEorReceived { family }], global)
+                .await;
         }
         Ok(())
     }
@@ -5923,9 +5907,20 @@ impl PeerSession {
                             Ok(_) => loop {
                                     match self.framer.try_parse(&mut rxbuf) {
                                     Ok(msg) => match msg {
-                                        Some(msg) => {
-                                            (*self.counter_rx).sync(&msg);
-                                            let _ = self.rx_msg(global, local_sockaddr, remote_sockaddr, msg).await;
+                                        Some(parsed) => {
+                                            match bgp::validate_message(parsed) {
+                                                Err(notif) => {
+                                                    self.urgent.insert(0, bgp::Message::Notification(notif.clone()));
+                                                    self.shutdown = Some(crate::fsm::SessionDownReason::LocalNotification(bgp::Message::Notification(notif)));
+                                                    break;
+                                                }
+                                                Ok(iter) => {
+                                                    for msg in iter {
+                                                        (*self.counter_rx).sync(&msg);
+                                                        let _ = self.rx_msg(global, local_sockaddr, remote_sockaddr, msg).await;
+                                                    }
+                                                }
+                                            }
                                         }
                                         None => {
                                             // partial read
@@ -5933,7 +5928,7 @@ impl PeerSession {
                                         },
                                     }
                                     Err(e) => {
-                                        // Bypass FSM: BgpError already encodes the
+                                        // Bypass FSM: Notification already encodes the
                                         // correct NOTIFICATION; the FSM has no
                                         // decision to make here.
                                         if let rustybgp_packet::Error::Bgp(ref bgp_err) = e {
@@ -7626,7 +7621,7 @@ mod tests {
     }
 
     fn cease_notification() -> bgp::Message {
-        bgp::Message::Notification(packet::BgpError::Other {
+        bgp::Message::Notification(packet::Notification::Other {
             code: 6,    // Cease
             subcode: 7, // Connection Collision Resolution
             data: vec![],
@@ -8498,7 +8493,7 @@ mod tests {
 
     fn cease(subcode: u8) -> crate::fsm::SessionDownReason {
         crate::fsm::SessionDownReason::RemoteNotification(bgp::Message::Notification(
-            rustybgp_packet::error::BgpError::Other {
+            rustybgp_packet::error::Notification::Other {
                 code: 6,
                 subcode,
                 data: vec![],
@@ -8508,7 +8503,7 @@ mod tests {
 
     fn local_cease(subcode: u8) -> crate::fsm::SessionDownReason {
         crate::fsm::SessionDownReason::LocalNotification(bgp::Message::Notification(
-            rustybgp_packet::error::BgpError::Other {
+            rustybgp_packet::error::Notification::Other {
                 code: 6,
                 subcode,
                 data: vec![],
@@ -8637,13 +8632,8 @@ mod tests {
         fn reach_entries(msgs: &[bgp::Message]) -> Vec<(packet::Nlri, u32)> {
             let mut out = Vec::new();
             for msg in msgs {
-                if let bgp::Message::Update(u) = msg {
-                    for e in u
-                        .reach
-                        .iter()
-                        .chain(u.mp_reach.iter())
-                        .flat_map(|s| &s.entries)
-                    {
+                if let bgp::Message::Update(bgp::Update::Routes { reach, .. }) = msg {
+                    for e in reach.iter().flat_map(|s| &s.entries) {
                         out.push((e.nlri.clone(), e.path_id));
                     }
                 }
@@ -8655,13 +8645,8 @@ mod tests {
         fn unreach_entries(msgs: &[bgp::Message]) -> Vec<(packet::Nlri, u32)> {
             let mut out = Vec::new();
             for msg in msgs {
-                if let bgp::Message::Update(u) = msg {
-                    for e in u
-                        .unreach
-                        .iter()
-                        .chain(u.mp_unreach.iter())
-                        .flat_map(|s| &s.entries)
-                    {
+                if let bgp::Message::Update(bgp::Update::Routes { unreach, .. }) = msg {
+                    for e in unreach.iter().flat_map(|s| &s.entries) {
                         out.push((e.nlri.clone(), e.path_id));
                     }
                 }
@@ -9575,9 +9560,9 @@ mod tests {
         ) -> Arc<Vec<packet::Attribute>> {
             let msgs = pending.drain_messages(Family::IPV4, false);
             for msg in msgs {
-                if let bgp::Message::Update(u) = msg {
-                    if u.reach.as_ref().is_some_and(|r| !r.entries.is_empty()) {
-                        return u.attr;
+                if let bgp::Message::Update(bgp::Update::Routes { reach, attr, .. }) = msg {
+                    if reach.as_ref().is_some_and(|r| !r.entries.is_empty()) {
+                        return attr;
                     }
                 }
             }
@@ -10684,10 +10669,11 @@ neighbor-address = "10.0.0.1"
     // source lookup, so no source setup is required; the absence of an inserted
     // route is verified via table_state().
 
-    fn reach_set(prefix: &str) -> Option<packet::NlriSet> {
-        Some(packet::NlriSet {
+    fn reach_set(prefix: &str) -> Option<bgp::ReachNlri> {
+        Some(bgp::ReachNlri {
             family: Family::IPV4,
             entries: vec![packet::PathNlri::new(prefix.parse().unwrap())],
+            nexthop: None,
         })
     }
 
@@ -10711,7 +10697,6 @@ neighbor-address = "10.0.0.1"
                 reach_set("10.0.0.0/24"),
                 None,
                 attrs,
-                None,
                 std::time::SystemTime::now(),
             )
             .await;
@@ -10739,7 +10724,6 @@ neighbor-address = "10.0.0.1"
                 reach_set("10.0.0.0/24"),
                 None,
                 attrs,
-                None,
                 std::time::SystemTime::now(),
             )
             .await;
@@ -10772,7 +10756,6 @@ neighbor-address = "10.0.0.1"
                 reach_set("10.0.0.0/24"),
                 None,
                 attrs,
-                None,
                 std::time::SystemTime::now(),
             )
             .await;

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -65,12 +65,16 @@ impl TryFrom<u8> for State {
 }
 
 /// Events fed into the session FSM.
+// MessageReceived carries ReceivedMessage (216 bytes) while other variants are at most 1 byte.
+// The ReceivedMessage data (NlriSets, Vecs) is already heap-allocated; boxing here would only
+// add an extra allocation per received message.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum Input {
     /// TCP connection established; start the OPEN exchange.
     /// The bool indicates whether the local speaker is currently the restarting
     /// speaker (R-bit in the GR capability of the OPEN).
     Connected(bool),
-    /// A complete BGP message was received from the peer.
+    /// A complete BGP message was received from the peer (post-validation).
     MessageReceived(bgp::Message),
     /// The keepalive timer fired (send direction: we may need to send KEEPALIVE).
     KeepaliveTimerExpired,
@@ -239,7 +243,7 @@ impl Connection {
         if self.state != State::OpenSent {
             return vec![
                 Output::SendMessage(bgp::Message::Notification(
-                    rustybgp_packet::BgpError::FsmUnexpectedState {
+                    rustybgp_packet::Notification::FsmUnexpectedState {
                         state: u8::from(self.state),
                     },
                 )),
@@ -252,7 +256,7 @@ impl Connection {
         // Validate ASN if pre-configured
         if self.expected_remote_asn != 0 && self.expected_remote_asn != open.as_number {
             out.push(Output::SendMessage(bgp::Message::Notification(
-                rustybgp_packet::BgpError::Other {
+                rustybgp_packet::Notification::Other {
                     code: 2,
                     subcode: 2,
                     data: vec![],
@@ -316,7 +320,7 @@ impl Connection {
             }
             _ => vec![
                 Output::SendMessage(bgp::Message::Notification(
-                    rustybgp_packet::BgpError::FsmUnexpectedState {
+                    rustybgp_packet::Notification::FsmUnexpectedState {
                         state: u8::from(self.state),
                     },
                 )),
@@ -329,7 +333,7 @@ impl Connection {
         if self.state != State::Established {
             return vec![
                 Output::SendMessage(bgp::Message::Notification(
-                    rustybgp_packet::BgpError::FsmUnexpectedState {
+                    rustybgp_packet::Notification::FsmUnexpectedState {
                         state: u8::from(self.state),
                     },
                 )),
@@ -339,7 +343,7 @@ impl Connection {
         vec![Output::SetHoldTimer(self.negotiated_holdtime)]
     }
 
-    fn on_notification(&mut self, err: rustybgp_packet::BgpError) -> Vec<Output> {
+    fn on_notification(&mut self, err: rustybgp_packet::Notification) -> Vec<Output> {
         vec![Output::SessionDown(SessionDownReason::RemoteNotification(
             bgp::Message::Notification(err),
         ))]
@@ -349,7 +353,7 @@ impl Connection {
         if self.state != State::Established {
             return vec![
                 Output::SendMessage(bgp::Message::Notification(
-                    rustybgp_packet::BgpError::FsmUnexpectedState {
+                    rustybgp_packet::Notification::FsmUnexpectedState {
                         state: u8::from(self.state),
                     },
                 )),
@@ -393,7 +397,7 @@ impl Connection {
     fn on_admin_shutdown(&mut self) -> Vec<Output> {
         vec![
             Output::SendMessage(bgp::Message::Notification(
-                rustybgp_packet::BgpError::Other {
+                rustybgp_packet::Notification::Other {
                     code: 6,
                     subcode: 2,
                     data: vec![],
@@ -630,7 +634,7 @@ impl PeerFsm {
         let outputs = vec![PeerFsmOutput::Connection(
             loser,
             Output::SendMessage(bgp::Message::Notification(
-                rustybgp_packet::BgpError::Other {
+                rustybgp_packet::Notification::Other {
                     code: 6,    // Cease
                     subcode: 7, // Connection Collision Resolution
                     data: vec![],
@@ -1041,13 +1045,10 @@ mod tests {
         assert_eq!(s.state(), State::Established);
 
         // UPDATE received → reset hold timer to full negotiated_holdtime
-        let update = bgp::Message::Update(bgp::Update {
+        let update = bgp::Message::Update(bgp::Update::Routes {
             reach: None,
-            mp_reach: None,
             unreach: None,
-            mp_unreach: None,
             attr: std::sync::Arc::new(Vec::new()),
-            nexthop: None,
         });
         let out = s.process(Input::MessageReceived(update));
         assert!(has_output(&out, |o| matches!(o, Output::SetHoldTimer(60))));
@@ -1125,7 +1126,7 @@ mod tests {
         let mut s = basic_connection();
         let _ = s.process(Input::Connected(false));
 
-        let notif = bgp::Message::Notification(rustybgp_packet::BgpError::Other {
+        let notif = bgp::Message::Notification(rustybgp_packet::Notification::Other {
             code: 6,
             subcode: 4,
             data: vec![],
@@ -1143,13 +1144,10 @@ mod tests {
         let _ = s.process(Input::Connected(false));
         assert_eq!(s.state(), State::OpenSent);
 
-        let update = bgp::Message::Update(bgp::Update {
+        let update = bgp::Message::Update(bgp::Update::Routes {
             reach: None,
-            mp_reach: None,
             unreach: None,
-            mp_unreach: None,
             attr: std::sync::Arc::new(Vec::new()),
-            nexthop: None,
         });
         let out = s.process(Input::MessageReceived(update));
         assert!(has_output(&out, |o| matches!(o, Output::SessionDown(_))));

--- a/daemon/src/mrt.rs
+++ b/daemon/src/mrt.rs
@@ -36,28 +36,23 @@ fn adj_rib_in_to_mrt(change: &AdjRibInChange) -> mrt::Message {
         true,
     );
     let body = if let Some(attrs) = &change.attrs {
-        bgp::Message::Update(bgp::Update {
-            reach: Some(packet::bgp::NlriSet {
+        bgp::Message::Update(bgp::Update::Routes {
+            reach: Some(packet::bgp::ReachNlri {
                 family: change.family,
                 entries: change.nlris.clone(),
+                nexthop: change.nexthop,
             }),
-            mp_reach: None,
             attr: attrs.clone(),
             unreach: None,
-            mp_unreach: None,
-            nexthop: change.nexthop,
         })
     } else {
-        bgp::Message::Update(bgp::Update {
+        bgp::Message::Update(bgp::Update::Routes {
             reach: None,
-            mp_reach: None,
             attr: Arc::new(Vec::new()),
-            unreach: None,
-            mp_unreach: Some(packet::bgp::NlriSet {
+            unreach: Some(packet::bgp::UnreachNlri {
                 family: change.family,
                 entries: change.nlris.clone(),
             }),
-            nexthop: None,
         })
     };
     mrt::Message::Mp {

--- a/daemon/src/peer_tx.rs
+++ b/daemon/src/peer_tx.rs
@@ -108,12 +108,12 @@ impl PendingTx {
     ///
     /// Returns a list of UPDATE messages ready for encoding. The caller is
     /// responsible for encoding and writing them to the wire.
-    pub(crate) fn drain_messages(&mut self, family: Family, use_mp: bool) -> Vec<bgp::Message> {
+    pub(crate) fn drain_messages(&mut self, family: Family, _use_mp: bool) -> Vec<bgp::Message> {
         let mut messages = Vec::new();
 
         // 1. Withdrawals
         if !self.unreach.is_empty() {
-            let unreach: Vec<packet::PathNlri> = self
+            let entries: Vec<packet::PathNlri> = self
                 .unreach
                 .drain()
                 .map(|(nlri, pid)| packet::PathNlri {
@@ -121,16 +121,10 @@ impl PendingTx {
                     nlri,
                 })
                 .collect();
-            messages.push(bgp::Message::Update(bgp::Update {
+            messages.push(bgp::Message::Update(bgp::Update::Routes {
                 reach: None,
-                mp_reach: None,
                 attr: Arc::new(Vec::new()),
-                unreach: None,
-                mp_unreach: Some(packet::NlriSet {
-                    family,
-                    entries: unreach,
-                }),
-                nexthop: None,
+                unreach: Some(packet::UnreachNlri { family, entries }),
             }));
         }
 
@@ -139,35 +133,28 @@ impl PendingTx {
         let mut count = 0;
 
         for (attr, keys) in self.bucket.iter() {
-            let nlri_set = packet::NlriSet {
-                family,
-                entries: keys
-                    .iter()
-                    .cloned()
-                    .map(|(nlri, pid)| packet::PathNlri {
-                        path_id: if self.addpath_tx { pid } else { 0 },
-                        nlri,
-                    })
-                    .collect(),
-            };
+            let entries = keys
+                .iter()
+                .cloned()
+                .map(|(nlri, pid)| packet::PathNlri {
+                    path_id: if self.addpath_tx { pid } else { 0 },
+                    nlri,
+                })
+                .collect();
             // Look up nexthop from the first entry in this bucket
             let nexthop = keys
                 .iter()
                 .next()
                 .and_then(|k| self.reach.get(k).map(|(_, nh)| *nh));
 
-            let (reach, mp_reach) = if use_mp {
-                (None, Some(nlri_set))
-            } else {
-                (Some(nlri_set), None)
-            };
-            messages.push(bgp::Message::Update(bgp::Update {
-                reach,
-                mp_reach,
+            messages.push(bgp::Message::Update(bgp::Update::Routes {
+                reach: Some(packet::ReachNlri {
+                    family,
+                    entries,
+                    nexthop,
+                }),
                 attr: attr.clone(),
                 unreach: None,
-                mp_unreach: None,
-                nexthop,
             }));
             sent_attrs.push(attr.clone());
 
@@ -239,9 +226,9 @@ mod tests {
         let msgs = p.drain_messages(Family::IPV4, false);
         // Same attributes → batched into 1 UPDATE + EOR
         assert_eq!(msgs.len(), 2);
-        if let bgp::Message::Update(u) = &msgs[0] {
-            assert!(u.reach.is_some());
-            assert_eq!(u.reach.as_ref().unwrap().entries.len(), 2);
+        if let bgp::Message::Update(bgp::Update::Routes { reach, .. }) = &msgs[0] {
+            assert!(reach.is_some());
+            assert_eq!(reach.as_ref().unwrap().entries.len(), 2);
         } else {
             panic!("expected Update");
         }
@@ -256,8 +243,8 @@ mod tests {
         let msgs = p.drain_messages(Family::IPV4, false);
         // withdrawal + EOR
         assert_eq!(msgs.len(), 2);
-        if let bgp::Message::Update(u) = &msgs[0] {
-            assert!(u.mp_unreach.is_some());
+        if let bgp::Message::Update(bgp::Update::Routes { unreach, .. }) = &msgs[0] {
+            assert!(unreach.is_some());
         } else {
             panic!("expected Update");
         }
@@ -273,9 +260,9 @@ mod tests {
         let msgs = p.drain_messages(Family::IPV4, false);
         // withdrawal + EOR
         assert_eq!(msgs.len(), 2);
-        if let bgp::Message::Update(u) = &msgs[0] {
-            assert!(u.mp_unreach.is_some());
-            assert!(u.reach.is_none());
+        if let bgp::Message::Update(bgp::Update::Routes { reach, unreach, .. }) = &msgs[0] {
+            assert!(unreach.is_some());
+            assert!(reach.is_none());
         } else {
             panic!("expected Update");
         }
@@ -328,11 +315,10 @@ mod tests {
         let msgs = p.drain_messages(Family::IPV4, false);
         let mut origins: Vec<u32> = Vec::new();
         for msg in &msgs {
-            if let bgp::Message::Update(u) = msg {
-                if let Some(reach) = &u.reach {
+            if let bgp::Message::Update(bgp::Update::Routes { reach, attr, .. }) = msg {
+                if let Some(reach) = reach {
                     if !reach.entries.is_empty() {
-                        let origin = u
-                            .attr
+                        let origin = attr
                             .iter()
                             .find(|a| a.code() == packet::Attribute::ORIGIN)
                             .and_then(|a| a.value())
@@ -356,13 +342,13 @@ mod tests {
         // The final state is a reach (withdrawal was cancelled by re-advertisement)
         let msgs = p.drain_messages(Family::IPV4, false);
         assert!(msgs.iter().any(|m| {
-            matches!(m, bgp::Message::Update(u) if u.reach.as_ref().is_some_and(|r| !r.entries.is_empty()))
+            matches!(m, bgp::Message::Update(bgp::Update::Routes { reach, .. })
+                if reach.as_ref().is_some_and(|r| !r.entries.is_empty()))
         }));
-        assert!(
-            !msgs
-                .iter()
-                .any(|m| { matches!(m, bgp::Message::Update(u) if u.mp_unreach.is_some()) })
-        );
+        assert!(!msgs.iter().any(|m| {
+            matches!(m, bgp::Message::Update(bgp::Update::Routes { unreach, .. })
+                if unreach.is_some())
+        }));
     }
 
     #[test]
@@ -370,12 +356,13 @@ mod tests {
         let mut p = PendingTx::new(false);
         let msgs = p.drain_messages(Family::IPV4, false);
         assert_eq!(msgs.len(), 1);
-        // Should be an EOR (empty UPDATE with reach for IPv4)
-        if let bgp::Message::Update(u) = &msgs[0] {
-            assert!(u.reach.as_ref().is_some_and(|r| r.entries.is_empty()));
-        } else {
-            panic!("expected EOR Update");
-        }
+        assert!(
+            matches!(
+                &msgs[0],
+                bgp::Message::Update(bgp::Update::EndOfRib(Family::IPV4))
+            ),
+            "expected EndOfRib(IPV4)"
+        );
 
         // Not generated again
         let msgs = p.drain_messages(Family::IPV4, false);
@@ -390,30 +377,32 @@ mod tests {
         let msgs = p.drain_messages(Family::IPV4, false);
         assert_eq!(msgs.len(), 2);
         // First: reach
-        if let bgp::Message::Update(u) = &msgs[0] {
-            assert!(u.reach.as_ref().is_some_and(|r| !r.entries.is_empty()));
+        if let bgp::Message::Update(bgp::Update::Routes { reach, .. }) = &msgs[0] {
+            assert!(reach.as_ref().is_some_and(|r| !r.entries.is_empty()));
         } else {
             panic!("expected reach Update");
         }
         // Second: EOR
-        if let bgp::Message::Update(u) = &msgs[1] {
-            assert!(u.reach.as_ref().is_some_and(|r| r.entries.is_empty()));
-        } else {
-            panic!("expected EOR Update");
-        }
+        assert!(
+            matches!(
+                &msgs[1],
+                bgp::Message::Update(bgp::Update::EndOfRib(Family::IPV4))
+            ),
+            "expected EndOfRib(IPV4)"
+        );
     }
 
     #[test]
-    fn use_mp_routes_through_mp_reach() {
+    fn use_mp_routes_through_reach() {
+        // _use_mp is a hint to PeerCodec for RFC 8950 extended nexthop; drain_messages
+        // always puts NLRIs in reach regardless.
         let mut p = PendingTx::new(false);
         p.reach(nlri("10.0.0.0/24"), 0, nh(), attr(0));
 
         let msgs = p.drain_messages(Family::IPV4, true);
-        // reach via MP_REACH + EOR
         assert_eq!(msgs.len(), 2);
-        if let bgp::Message::Update(u) = &msgs[0] {
-            assert!(u.reach.is_none());
-            assert!(u.mp_reach.is_some());
+        if let bgp::Message::Update(bgp::Update::Routes { reach, .. }) = &msgs[0] {
+            assert!(reach.as_ref().is_some_and(|r| !r.entries.is_empty()));
         } else {
             panic!("expected Update");
         }
@@ -425,8 +414,8 @@ mod tests {
         p.reach(nlri("10.0.0.0/24"), 42, nh(), attr(0));
 
         let msgs = p.drain_messages(Family::IPV4, false);
-        if let bgp::Message::Update(u) = &msgs[0] {
-            assert_eq!(u.reach.as_ref().unwrap().entries[0].path_id, 42);
+        if let bgp::Message::Update(bgp::Update::Routes { reach, .. }) = &msgs[0] {
+            assert_eq!(reach.as_ref().unwrap().entries[0].path_id, 42);
         } else {
             panic!("expected Update");
         }

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::{BgpError, Error};
+use crate::error::{Error, Notification};
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use bytes::BufMut;
 use fnv::FnvHashMap;
@@ -216,7 +216,7 @@ impl Nlri {
             }
             Family::IPV4_VPN => crate::vpn::VpnV4Nlri::decode(c, len).map(Nlri::VpnV4),
             Family::IPV6_VPN => crate::vpn::VpnV6Nlri::decode(c, len).map(Nlri::VpnV6),
-            _ => Err(BgpError::UpdateMalformedAttributeList.into()),
+            _ => Err(Notification::UpdateMalformedAttributeList.into()),
         }
     }
 }
@@ -261,16 +261,16 @@ impl PathNlri {
     }
 }
 
-/// A set of NLRI entries sharing a common address family (AFI+SAFI).
+/// Withdrawn (unreachable) NLRIs sharing a common address family (AFI+SAFI).
 #[derive(Clone, Debug)]
-pub struct NlriSet {
+pub struct UnreachNlri {
     pub family: Family,
     pub entries: Vec<PathNlri>,
 }
 
-impl NlriSet {
+impl UnreachNlri {
     pub fn new(family: Family) -> Self {
-        NlriSet {
+        UnreachNlri {
             family,
             entries: Vec::new(),
         }
@@ -353,7 +353,7 @@ impl Ipv4Net {
     fn decode<T: io::Read>(c: &mut T, len: usize) -> Result<Ipv4Net, Error> {
         let bit_len = c.read_u8()?;
         if len < (bit_len as usize).div_ceil(8) || bit_len > 32 {
-            return Err(BgpError::UpdateMalformedAttributeList.into());
+            return Err(Notification::UpdateMalformedAttributeList.into());
         }
         let mut addr = [0_u8; 4];
         for i in 0..bit_len.div_ceil(8) {
@@ -401,7 +401,7 @@ impl Ipv6Net {
     fn decode<T: io::Read>(c: &mut T, len: usize) -> Result<Ipv6Net, Error> {
         let bit_len = c.read_u8()?;
         if len < (bit_len as usize).div_ceil(8) || bit_len > 128 {
-            return Err(BgpError::UpdateMalformedAttributeList.into());
+            return Err(Notification::UpdateMalformedAttributeList.into());
         }
         let mut addr = [0_u8; 16];
         for i in 0..bit_len.div_ceil(8) {
@@ -1186,34 +1186,190 @@ pub struct Open {
     pub capability: Vec<Capability>,
 }
 
-/// BGP UPDATE message body (RFC 4271 §4.3, RFC 4760 §3).
+/// BGP UPDATE message body (RFC 4271 §4.3, RFC 4760 §3) — send path.
+///
+/// `Routes.reach.family` determines encoding: `IPV4` -> traditional NLRI + NEXTHOP attribute
+/// (unless RFC 8950 extended nexthop is negotiated); any other family -> MP_REACH_NLRI.
+/// Same rule applies for `unreach`.
 #[derive(Clone)]
-pub struct Update {
-    /// Traditional BGP NLRI field (IPv4 unicast via legacy encoding).
-    pub reach: Option<NlriSet>,
-    /// MP_REACH_NLRI attribute (non-IPv4, or IPv4 via RFC 8950 Extended Nexthop).
-    pub mp_reach: Option<NlriSet>,
-    /// Traditional Withdrawn Routes field (IPv4 unicast via legacy encoding).
-    pub unreach: Option<NlriSet>,
-    /// MP_UNREACH_NLRI attribute (non-IPv4, or IPv4 via RFC 8950 Extended Nexthop).
-    pub mp_unreach: Option<NlriSet>,
-    pub attr: Arc<Vec<Attribute>>,
-    /// Parsed nexthop from NEXT_HOP attribute (type 3) or MP_REACH_NLRI.
-    /// `None` for withdrawal-only UPDATE messages.
-    pub nexthop: Option<Nexthop>,
+pub enum Update {
+    /// Route announcements and/or withdrawals.
+    Routes {
+        /// Reachable NLRIs with nexthop.
+        reach: Option<ReachNlri>,
+        /// Withdrawn NLRIs.
+        unreach: Option<UnreachNlri>,
+        attr: Arc<Vec<Attribute>>,
+    },
+    /// End-of-RIB marker for `family` (RFC 4724 §2).
+    EndOfRib(Family),
 }
 
+/// A BGP message (unified send/receive type after validation).
 #[derive(Clone)]
 pub enum Message {
     Open(Open),
     Update(Update),
-    /// BGP NOTIFICATION message (RFC 4271 §4.5).
-    /// Uses the typed `BgpError` to represent the error code/subcode.
-    Notification(BgpError),
+    Notification(Notification),
     Keepalive,
-    RouteRefresh {
-        family: Family,
+    RouteRefresh { family: Family },
+}
+
+/// A set of reachable NLRIs together with the nexthop used to reach them.
+/// Used for both traditional IPv4 NLRI (nexthop from NEXTHOP attribute)
+/// and MP_REACH_NLRI (nexthop embedded in the attribute).
+#[derive(Clone, Debug)]
+pub struct ReachNlri {
+    pub family: Family,
+    pub entries: Vec<PathNlri>,
+    /// `None` only for AFIs that carry no nexthop (e.g. Flowspec, RFC 5575 §4).
+    pub nexthop: Option<Nexthop>,
+}
+
+/// One attribute that could not be parsed (RFC 7606).
+/// The caller uses `attr_flags` to determine the RFC 7606 action:
+/// optional + transitive -> discard; otherwise -> treat-as-withdraw.
+#[derive(Clone, Debug)]
+pub struct AttributeError {
+    pub attr_code: u8,
+    pub attr_flags: u8,
+}
+
+/// A parsed BGP UPDATE message (receive path).
+// Routes carries 6 Options/Vecs whose metadata is on the stack (209 bytes), while EndOfRib is 4
+// bytes.  The Vec/UnreachNlri contents are already heap-allocated, so boxing Routes would only add
+// one extra heap allocation per UPDATE without reducing heap pressure.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
+pub enum ParsedUpdate {
+    /// Route announcements and/or withdrawals with optional attribute errors.
+    Routes {
+        /// Traditional IPv4 NLRI with nexthop from NEXTHOP attribute (legacy encoding).
+        reach: Option<ReachNlri>,
+        /// MP_REACH_NLRI with embedded nexthop (non-IPv4 or RFC 8950 IPv4).
+        mp_reach: Option<ReachNlri>,
+        /// Traditional IPv4 Withdrawn Routes (legacy encoding).
+        unreach: Option<UnreachNlri>,
+        /// MP_UNREACH_NLRI (non-IPv4 or RFC 8950 IPv4).
+        mp_unreach: Option<UnreachNlri>,
+        attrs: Vec<Attribute>,
+        /// Attributes that failed to parse; see RFC 7606 for handling.
+        error_attrs: Vec<AttributeError>,
     },
+    /// End-of-RIB marker for `family` (RFC 4724).
+    EndOfRib(Family),
+}
+
+/// Fatal parse error: the session must send this NOTIFICATION and close.
+#[derive(Debug)]
+pub struct ParseError {
+    pub notification: Notification,
+}
+
+impl From<Notification> for ParseError {
+    fn from(n: Notification) -> Self {
+        ParseError { notification: n }
+    }
+}
+
+/// A received BGP message (decode path).  Pass to `validate_message` to obtain
+/// normalized send-path `Message`s with RFC 7606 error handling applied.
+#[derive(Clone)]
+pub enum ParsedMessage {
+    Open(Open),
+    Update(ParsedUpdate),
+    Notification(Notification),
+    Keepalive,
+    RouteRefresh { family: Family },
+}
+
+/// Validate a parsed BGP message and normalize it into send-path `Message`s.
+///
+/// Returns `Err(Notification)` when the session must send that `Notification`
+/// and close.  Returns `Ok(iter)` otherwise; the iterator yields the resulting
+/// `Message`s (normally 1, 2 for a multi-family UPDATE, 0 for discard-only
+/// attribute errors with no NLRIs).
+pub fn validate_message(msg: ParsedMessage) -> Result<impl Iterator<Item = Message>, Notification> {
+    let msgs: Vec<Message> = match msg {
+        ParsedMessage::Open(open) => vec![Message::Open(open)],
+        ParsedMessage::Update(update) => validate_update(update)?,
+        ParsedMessage::Notification(n) => vec![Message::Notification(n)],
+        ParsedMessage::Keepalive => vec![Message::Keepalive],
+        ParsedMessage::RouteRefresh { family } => vec![Message::RouteRefresh { family }],
+    };
+    Ok(msgs.into_iter())
+}
+
+fn validate_update(update: ParsedUpdate) -> Result<Vec<Message>, Notification> {
+    match update {
+        ParsedUpdate::EndOfRib(family) => Ok(vec![Message::Update(Update::EndOfRib(family))]),
+        ParsedUpdate::Routes {
+            reach,
+            mp_reach,
+            unreach,
+            mp_unreach,
+            attrs,
+            error_attrs,
+        } => {
+            // RFC 7606: classify each attribute error.
+            // Optional non-transitive: attribute discard (already absent from attrs).
+            // Well-known or optional transitive: treat-as-withdraw.
+            let treat_as_withdraw = error_attrs.iter().any(|e| {
+                let optional = e.attr_flags & Attribute::FLAG_OPTIONAL != 0;
+                let transitive = e.attr_flags & Attribute::FLAG_TRANSITIVE != 0;
+                !optional || transitive
+            });
+
+            if treat_as_withdraw {
+                let empty = Arc::new(Vec::new());
+                let mut msgs: Vec<Message> = Vec::new();
+                // Convert announced NLRIs to withdrawals.
+                for r in reach.into_iter().chain(mp_reach) {
+                    msgs.push(Message::Update(Update::Routes {
+                        reach: None,
+                        unreach: Some(UnreachNlri {
+                            family: r.family,
+                            entries: r.entries,
+                        }),
+                        attr: empty.clone(),
+                    }));
+                }
+                // Pass through any withdrawals already in the UPDATE.
+                for u in unreach.into_iter().chain(mp_unreach) {
+                    msgs.push(Message::Update(Update::Routes {
+                        reach: None,
+                        unreach: Some(u),
+                        attr: empty.clone(),
+                    }));
+                }
+                return Ok(msgs);
+            }
+
+            // Normal path: attribute-discard errors are already absent from attrs.
+            let attr = Arc::new(attrs);
+            let mut msgs: Vec<Message> = Vec::new();
+
+            // Traditional IPv4 reach/unreach.
+            if reach.is_some() || unreach.is_some() {
+                msgs.push(Message::Update(Update::Routes {
+                    reach,
+                    unreach,
+                    attr: attr.clone(),
+                }));
+            }
+
+            // MP_REACH/MP_UNREACH: non-IPv4 or RFC 8950 IPv4.
+            if mp_reach.is_some() || mp_unreach.is_some() {
+                msgs.push(Message::Update(Update::Routes {
+                    reach: mp_reach,
+                    unreach: mp_unreach,
+                    attr,
+                }));
+            }
+
+            Ok(msgs)
+        }
+    }
 }
 
 impl Message {
@@ -1229,25 +1385,7 @@ impl Message {
     const ROUTE_REFRESH: u8 = 5;
 
     pub fn eor(family: Family) -> Message {
-        if family == Family::IPV4 {
-            Message::Update(Update {
-                reach: Some(NlriSet::new(Family::IPV4)),
-                mp_reach: None,
-                attr: Arc::new(Vec::new()),
-                unreach: None,
-                mp_unreach: None,
-                nexthop: None,
-            })
-        } else {
-            Message::Update(Update {
-                reach: None,
-                mp_reach: None,
-                attr: Arc::new(Vec::new()),
-                unreach: None,
-                mp_unreach: Some(NlriSet::new(family)),
-                nexthop: None,
-            })
-        }
+        Message::Update(Update::EndOfRib(family))
     }
 }
 
@@ -1440,9 +1578,8 @@ impl PeerCodec {
         &self,
         buf_head: usize,
         dst: &mut B,
-        reach: &NlriSet,
+        reach: &ReachNlri,
         reach_idx: &mut usize,
-        nexthop: Option<&Nexthop>,
     ) -> Result<u16, ()> {
         let family = &reach.family;
         let nets = &reach.entries;
@@ -1460,7 +1597,7 @@ impl PeerCodec {
         // before routes enter PendingTx, so the nexthop here is already the export
         // nexthop.  VPN families prefix the nexthop with an 8-byte zero RD (RFC 4364
         // §4.3.2); other families pad IPv4 to 16 bytes for MP_REACH.
-        let nh_bytes = nexthop.map(|nh| nh.to_bytes()).unwrap_or_default();
+        let nh_bytes = reach.nexthop.map(|nh| nh.to_bytes()).unwrap_or_default();
         let padded = if matches!(family, &Family::IPV4_VPN | &Family::IPV6_VPN) {
             let mut v = vec![0u8; 8];
             v.extend_from_slice(&nh_bytes);
@@ -1506,7 +1643,7 @@ impl PeerCodec {
         buf_head: usize,
         _: Arc<Vec<Attribute>>,
         dst: &mut B,
-        unreach: &NlriSet,
+        unreach: &UnreachNlri,
         unreach_idx: &mut usize,
     ) -> Result<u16, ()> {
         let family = &unreach.family;
@@ -1593,116 +1730,142 @@ impl PeerCodec {
                     .write_u8(cap_len + 2_u8)
                     .unwrap();
             }
-            Message::Update(Update {
-                reach,
-                mp_reach,
-                attr,
-                unreach,
-                mp_unreach,
-                nexthop: _nexthop,
-            }) => {
-                let attrs = attr.clone();
-                // Use family from whichever NlriSet is present for addpath lookup
-                let family = reach
-                    .as_ref()
-                    .or(unreach.as_ref())
-                    .map_or(Family::IPV4, |s| s.family);
-                let addpath = self.channel.get(&family).is_some_and(|c| c.addpath_tx());
-                dst.put_u8(Message::UPDATE);
-                let pos_withdrawn_len = dst.as_mut().len();
-                dst.put_u16(0);
-                let mut withdrawn_len = 0;
-                // Traditional IPv4 withdrawn routes
-                if let Some(unreach) = unreach {
-                    let max_len = 5 + if addpath { 4 } else { 0 };
-                    for (i, item) in unreach.entries.iter().enumerate().skip(*reach_idx) {
-                        if pos_head + self.max_message_length() > dst.as_mut().len() + max_len {
-                            if addpath {
-                                dst.put_u32(item.path_id);
+            Message::Update(update) => match update {
+                Update::Routes {
+                    reach,
+                    unreach,
+                    attr,
+                } => {
+                    let attrs = attr.clone();
+                    let family = reach
+                        .as_ref()
+                        .map(|r| r.family)
+                        .or_else(|| unreach.as_ref().map(|u| u.family))
+                        .unwrap_or(Family::IPV4);
+                    let addpath = self.channel.get(&family).is_some_and(|c| c.addpath_tx());
+                    // RFC 8950: IPv4 uses MP_REACH_NLRI when extended nexthop is negotiated.
+                    let ipv4_via_mp = self
+                        .channel
+                        .get(&Family::IPV4)
+                        .is_some_and(|c| c.extended_nexthop());
+                    dst.put_u8(Message::UPDATE);
+                    let pos_withdrawn_len = dst.as_mut().len();
+                    dst.put_u16(0);
+                    let mut withdrawn_len = 0;
+                    // Traditional IPv4 withdrawn routes (only when not using MP for IPv4)
+                    if let Some(unreach) = &unreach
+                        && unreach.family == Family::IPV4
+                        && !ipv4_via_mp
+                    {
+                        let max_len = 5 + if addpath { 4 } else { 0 };
+                        for (i, item) in unreach.entries.iter().enumerate().skip(*reach_idx) {
+                            if pos_head + self.max_message_length() > dst.as_mut().len() + max_len {
+                                if addpath {
+                                    dst.put_u32(item.path_id);
+                                }
+                                withdrawn_len += item.nlri.encode(dst).unwrap();
+                                *reach_idx = i;
+                            } else {
+                                break;
                             }
-                            withdrawn_len += item.nlri.encode(dst).unwrap();
-                            *reach_idx = i;
-                        } else {
-                            break;
                         }
                     }
-                }
-                if withdrawn_len != 0 {
-                    (&mut dst.as_mut()[pos_withdrawn_len..])
-                        .write_u16::<NetworkEndian>(withdrawn_len)
-                        .unwrap();
-                }
-                let pos_attr_len = dst.as_mut().len();
-                dst.put_u16(0);
-                // Like BIRD, for simplicity, MP_REACH/MP_UNREACH attribute isn't ordered.
-                // BIRD encodes MP_REACH/MP_UNREACH first and then the rest.
-                // RustyBGP encode MP_REACH/MP_UNREACH last.
-                let mut attr_len = 0;
-                let mut has_as_path = false;
-                // Attribute transformation (AS-path prepend, LOCAL_PREF strip) is applied
-                // by PeerExportContext before routes enter PendingTx; attrs here are already
-                // export-ready.  Encode every transitive attribute as-is.
-                for a in &*attrs {
-                    if a.flags & Attribute::FLAG_TRANSITIVE > 0 {
-                        if a.code() == Attribute::AS_PATH {
-                            has_as_path = true;
-                        }
-                        attr_len += a.encode_wire(dst);
+                    if withdrawn_len != 0 {
+                        (&mut dst.as_mut()[pos_withdrawn_len..])
+                            .write_u16::<NetworkEndian>(withdrawn_len)
+                            .unwrap();
                     }
-                }
-                // Encode NEXTHOP attribute for traditional IPv4 reach (not MP_REACH).
-                // The nexthop in the Update struct is the export nexthop, already set
-                // by PeerExportContext::export_nexthop().
-                if reach.as_ref().is_some_and(|r| !r.entries.is_empty())
-                    && mp_reach.is_none()
-                    && let Some(nh) = _nexthop
-                    && let IpAddr::V4(v4) = nh.addr()
-                {
-                    let nh_attr =
-                        Attribute::new_with_bin(Attribute::NEXTHOP, v4.octets().to_vec()).unwrap();
-                    attr_len += nh_attr.encode_wire(dst);
-                }
-                // Safety net: ensure AS_PATH is present for UPDATEs with NLRI.
-                // PeerExportContext::export_attrs() adds it for all non-RS sessions,
-                // so this branch fires only as a last resort.
-                let has_nlri =
-                    reach.as_ref().is_some_and(|r| !r.entries.is_empty()) || mp_reach.is_some();
-                if !has_as_path && has_nlri {
-                    attr_len += Attribute::empty_as_path().encode_wire(dst);
-                }
-                // MP_REACH_NLRI attribute
-                if let Some(mp_reach) = mp_reach {
-                    attr_len += self
-                        .mp_reach_encode(pos_head, dst, mp_reach, reach_idx, _nexthop.as_ref())
-                        .unwrap();
-                }
-                // MP_UNREACH_NLRI attribute
-                if let Some(mp_unreach) = mp_unreach {
-                    attr_len += self
-                        .mp_unreach_encode(pos_head, attr.clone(), dst, mp_unreach, reach_idx)
-                        .unwrap();
-                }
-
-                (&mut dst.as_mut()[pos_attr_len..])
-                    .write_u16::<NetworkEndian>(attr_len)
-                    .unwrap();
-
-                // Traditional IPv4 NLRI
-                if let Some(reach) = reach {
-                    let max_len = 5 + if addpath { 4 } else { 0 };
-                    for (i, item) in reach.entries.iter().enumerate().skip(*reach_idx) {
-                        if pos_head + self.max_message_length() > dst.as_mut().len() + max_len {
-                            if addpath {
-                                dst.put_u32(item.path_id);
+                    let pos_attr_len = dst.as_mut().len();
+                    dst.put_u16(0);
+                    let mut attr_len = 0;
+                    let mut has_as_path = false;
+                    for a in &*attrs {
+                        if a.flags & Attribute::FLAG_TRANSITIVE > 0 {
+                            if a.code() == Attribute::AS_PATH {
+                                has_as_path = true;
                             }
-                            let _ = item.nlri.encode(dst);
-                            *reach_idx = i;
-                        } else {
-                            break;
+                            attr_len += a.encode_wire(dst);
+                        }
+                    }
+                    // NEXTHOP attribute for traditional IPv4 reach (not used when RFC 8950 active).
+                    if let Some(r) = &reach
+                        && r.family == Family::IPV4
+                        && !ipv4_via_mp
+                        && !r.entries.is_empty()
+                        && let Some(nh) = r.nexthop
+                        && let IpAddr::V4(v4) = nh.addr()
+                    {
+                        let nh_attr =
+                            Attribute::new_with_bin(Attribute::NEXTHOP, v4.octets().to_vec())
+                                .unwrap();
+                        attr_len += nh_attr.encode_wire(dst);
+                    }
+                    let has_nlri = reach.as_ref().is_some_and(|r| !r.entries.is_empty());
+                    if !has_as_path && has_nlri {
+                        attr_len += Attribute::empty_as_path().encode_wire(dst);
+                    }
+                    // MP_REACH_NLRI (non-IPv4, or IPv4 with RFC 8950 extended nexthop)
+                    if let Some(r) = &reach
+                        && (r.family != Family::IPV4 || ipv4_via_mp)
+                    {
+                        attr_len += self.mp_reach_encode(pos_head, dst, r, reach_idx).unwrap();
+                    }
+                    // MP_UNREACH_NLRI (non-IPv4, or IPv4 with RFC 8950 extended nexthop)
+                    if let Some(u) = &unreach
+                        && (u.family != Family::IPV4 || ipv4_via_mp)
+                    {
+                        attr_len += self
+                            .mp_unreach_encode(pos_head, attr.clone(), dst, u, reach_idx)
+                            .unwrap();
+                    }
+                    (&mut dst.as_mut()[pos_attr_len..])
+                        .write_u16::<NetworkEndian>(attr_len)
+                        .unwrap();
+                    // Traditional IPv4 NLRI (not used when RFC 8950 active)
+                    if let Some(r) = reach
+                        && r.family == Family::IPV4
+                        && !ipv4_via_mp
+                    {
+                        let max_len = 5 + if addpath { 4 } else { 0 };
+                        for (i, item) in r.entries.iter().enumerate().skip(*reach_idx) {
+                            if pos_head + self.max_message_length() > dst.as_mut().len() + max_len {
+                                if addpath {
+                                    dst.put_u32(item.path_id);
+                                }
+                                let _ = item.nlri.encode(dst);
+                                *reach_idx = i;
+                            } else {
+                                break;
+                            }
                         }
                     }
                 }
-            }
+                Update::EndOfRib(family) => {
+                    dst.put_u8(Message::UPDATE);
+                    // No withdrawn routes
+                    dst.put_u16(0);
+                    let pos_attr_len = dst.as_mut().len();
+                    dst.put_u16(0);
+                    let mut attr_len = 0u16;
+                    if *family != Family::IPV4 {
+                        // Non-IPv4 EOR: empty MP_UNREACH_NLRI (RFC 4724 §2).
+                        let empty = UnreachNlri::new(*family);
+                        attr_len += self
+                            .mp_unreach_encode(
+                                pos_head,
+                                Arc::new(Vec::new()),
+                                dst,
+                                &empty,
+                                reach_idx,
+                            )
+                            .unwrap();
+                    }
+                    // IPv4 EOR: all-zero length fields, no attributes, no NLRI.
+                    (&mut dst.as_mut()[pos_attr_len..])
+                        .write_u16::<NetworkEndian>(attr_len)
+                        .unwrap();
+                }
+            },
             Message::Notification(err) => {
                 dst.put_u8(Message::NOTIFICATION);
                 dst.put_u8(err.notification_code());
@@ -1733,7 +1896,7 @@ impl PeerCodec {
         c: &mut T,
         mut len: usize,
     ) -> Result<PathNlri, Error> {
-        let malformed: Error = BgpError::UpdateMalformedAttributeList.into();
+        let malformed: Error = Notification::UpdateMalformedAttributeList.into();
         let id = if chan.addpath_rx() {
             if len < 4 {
                 return Err(malformed);
@@ -1749,12 +1912,12 @@ impl PeerCodec {
         };
         Nlri::decode(chan.family, c, len).map(|nlri| PathNlri { path_id: id, nlri })
     }
-    pub fn parse_message(&mut self, buf: &[u8]) -> Result<Message, Error> {
+    pub fn parse_message(&mut self, buf: &[u8]) -> Result<ParsedMessage, Error> {
         if buf.len() < Message::HEADER_LENGTH as usize {
-            return Err(BgpError::BadMessageLength { data: vec![] }.into());
+            return Err(Notification::BadMessageLength { data: vec![] }.into());
         }
         let code = buf[18];
-        let header_len_error: Error = BgpError::BadMessageLength {
+        let header_len_error: Error = Notification::BadMessageLength {
             data: (buf[16..18]).to_vec(),
         }
         .into();
@@ -1762,7 +1925,7 @@ impl PeerCodec {
         match code {
             Message::OPEN => {
                 const MINIMUM_OPEN_LENGTH: usize = 29;
-                let malformed: Error = BgpError::OpenMalformed.into();
+                let malformed: Error = Notification::OpenMalformed.into();
                 if buf.len() < MINIMUM_OPEN_LENGTH {
                     return Err(header_len_error);
                 }
@@ -1771,12 +1934,12 @@ impl PeerCodec {
                 let version = c.read_u8().unwrap();
                 // BGP version must be 4 (RFC 4271 §4.2)
                 if version != 4 {
-                    return Err(BgpError::OpenMalformed.into());
+                    return Err(Notification::OpenMalformed.into());
                 }
                 let mut as_number = c.read_u16::<NetworkEndian>().unwrap() as u32;
                 let raw_holdtime = c.read_u16::<NetworkEndian>().unwrap();
                 let holdtime =
-                    HoldTime::new(raw_holdtime).ok_or(BgpError::OpenUnacceptableHoldTime {
+                    HoldTime::new(raw_holdtime).ok_or(Notification::OpenUnacceptableHoldTime {
                         data: raw_holdtime.to_be_bytes().to_vec(),
                     })?;
                 let router_id = c.read_u32::<NetworkEndian>().unwrap();
@@ -1820,7 +1983,7 @@ impl PeerCodec {
                             }
                         }
                     } else {
-                        return Err(BgpError::OpenUnsupportedOptionalParameter {
+                        return Err(Notification::OpenUnsupportedOptionalParameter {
                             data: buf[c.position() as usize - 2
                                 ..c.position() as usize + op_len as usize]
                                 .to_vec(),
@@ -1834,7 +1997,7 @@ impl PeerCodec {
                     self.remote_asn = as_number;
                 }
 
-                Ok(Message::Open(Open {
+                Ok(ParsedMessage::Open(Open {
                     as_number,
                     holdtime,
                     router_id,
@@ -1843,7 +2006,7 @@ impl PeerCodec {
             }
             Message::UPDATE => {
                 const MINIMUM_UPDATE_LENGTH: usize = 23;
-                let malformed = || Error::from(BgpError::UpdateMalformedAttributeList);
+                let malformed = || Error::from(Notification::UpdateMalformedAttributeList);
                 let reach_family = Family::IPV4;
                 let unreach_family = Family::IPV4;
                 let mut mp_reach_family = Family::IPV4;
@@ -1855,6 +2018,7 @@ impl PeerCodec {
                 let mut mp_unreach_entries: Vec<PathNlri> = Vec::new();
                 let mut mp_reach_attr = None;
                 let mut mp_unreach_attr = None;
+                let mut reach_nexthop: Option<Nexthop> = None;
                 let mut mp_nexthop: Option<Nexthop> = None;
                 if buf.len() < MINIMUM_UPDATE_LENGTH {
                     return Err(header_len_error);
@@ -1874,7 +2038,7 @@ impl PeerCodec {
                 let attr_end = c.position() + attr_len as u64;
                 let mut pre_code = 0;
                 let mut unsorted = false;
-                let mut error_withdraw = false;
+                let mut error_attrs: Vec<AttributeError> = Vec::new();
                 let mut attr_idx = 0;
                 let reach_len = buf.len() as u64 - attr_end;
                 while c.position() < attr_end {
@@ -1922,7 +2086,10 @@ impl PeerCodec {
                             {
                                 // FIXME: handle aigp case
                                 c.set_position(c.position() + alen as u64);
-                                error_withdraw = true;
+                                error_attrs.push(AttributeError {
+                                    attr_code: code,
+                                    attr_flags: flags,
+                                });
                                 continue;
                             } else {
                                 let cur = c.position();
@@ -1933,7 +2100,7 @@ impl PeerCodec {
                                         } else if code == Attribute::MP_UNREACH {
                                             mp_unreach_attr = Some(a);
                                         } else if code == Attribute::NEXTHOP {
-                                            mp_nexthop =
+                                            reach_nexthop =
                                                 a.binary().and_then(|b| Nexthop::from_bytes(b));
                                         } else {
                                             attr.push(a);
@@ -1941,7 +2108,10 @@ impl PeerCodec {
                                         }
                                     }
                                     Err(_) => {
-                                        error_withdraw = true;
+                                        error_attrs.push(AttributeError {
+                                            attr_code: code,
+                                            attr_flags: flags,
+                                        });
                                         c.set_position(cur + alen as u64);
                                         continue;
                                     }
@@ -1950,7 +2120,10 @@ impl PeerCodec {
                         }
                         None => {
                             if flags & Attribute::FLAG_OPTIONAL == 0 {
-                                error_withdraw = true;
+                                error_attrs.push(AttributeError {
+                                    attr_code: code,
+                                    attr_flags: flags,
+                                });
                             }
                             c.set_position(c.position() + alen as u64);
                         }
@@ -1959,55 +2132,69 @@ impl PeerCodec {
 
                 // v4 eor
                 if reach_len == 0 && attr_len == 0 && withdrawn_len == 0 {
-                    return Ok(Message::Update(Update {
-                        reach: Some(NlriSet::new(Family::IPV4)),
-                        mp_reach: None,
-                        attr: Arc::new(Vec::new()),
-                        unreach: None,
-                        mp_unreach: None,
-                        nexthop: None,
-                    }));
+                    return Ok(ParsedMessage::Update(ParsedUpdate::EndOfRib(Family::IPV4)));
                 }
 
                 if reach_len != 0 || mp_reach_attr.is_some() {
                     if !seen.contains_key(&Attribute::ORIGIN)
                         || !seen.contains_key(&Attribute::AS_PATH)
                     {
-                        error_withdraw = true;
+                        error_attrs.push(AttributeError {
+                            attr_code: Attribute::ORIGIN,
+                            attr_flags: Attribute::FLAG_TRANSITIVE,
+                        });
                     }
 
-                    if !error_withdraw && mp_nexthop.is_none() && reach_len != 0 {
-                        error_withdraw = true;
+                    if error_attrs.is_empty() && reach_nexthop.is_none() && reach_len != 0 {
+                        error_attrs.push(AttributeError {
+                            attr_code: Attribute::NEXTHOP,
+                            attr_flags: Attribute::FLAG_TRANSITIVE,
+                        });
                     }
 
-                    if !error_withdraw {
+                    if error_attrs.is_empty() {
                         let as_path = &attr[*seen.get(&Attribute::AS_PATH).unwrap()];
                         match as_path.as_path_count(self.local_asn) {
                             Ok(v) => {
                                 if v > 0 {
-                                    error_withdraw = true
+                                    error_attrs.push(AttributeError {
+                                        attr_code: Attribute::AS_PATH,
+                                        attr_flags: Attribute::FLAG_TRANSITIVE,
+                                    });
                                 }
                             }
-                            Err(_) => error_withdraw = true,
+                            Err(_) => error_attrs.push(AttributeError {
+                                attr_code: Attribute::AS_PATH,
+                                attr_flags: Attribute::FLAG_TRANSITIVE,
+                            }),
                         }
-                        if !error_withdraw
+                        if error_attrs.is_empty()
                             && self.confederation_id != 0
                             && self.confederation_id != self.local_asn
                         {
                             match as_path.as_path_count(self.confederation_id) {
                                 Ok(v) => {
                                     if v > 0 {
-                                        error_withdraw = true
+                                        error_attrs.push(AttributeError {
+                                            attr_code: Attribute::AS_PATH,
+                                            attr_flags: Attribute::FLAG_TRANSITIVE,
+                                        });
                                     }
                                 }
-                                Err(_) => error_withdraw = true,
+                                Err(_) => error_attrs.push(AttributeError {
+                                    attr_code: Attribute::AS_PATH,
+                                    attr_flags: Attribute::FLAG_TRANSITIVE,
+                                }),
                             }
                         }
                     }
                 }
 
                 if c.position() != attr_end {
-                    error_withdraw = true;
+                    error_attrs.push(AttributeError {
+                        attr_code: 0,
+                        attr_flags: 0,
+                    });
                     c.set_position(attr_end);
                 }
 
@@ -2051,12 +2238,8 @@ impl PeerCodec {
                     attr.sort_unstable_by_key(|a| a.code());
                 }
 
-                if error_withdraw {
-                    unreach.append(&mut reach);
-                }
-
                 if let Some(a) = mp_reach_attr {
-                    let err: Error = BgpError::UpdateOptionalAttributeError.into();
+                    let err: Error = Notification::UpdateOptionalAttributeError.into();
                     let buf = a.binary().unwrap();
                     if buf.len() < 5 {
                         return Err(err);
@@ -2076,6 +2259,8 @@ impl PeerCodec {
                     }
                     let mut data = Vec::with_capacity(nexthop_len as usize);
                     match nexthop_len {
+                        // Flowspec and similar AFIs carry no nexthop (RFC 5575 §4).
+                        0 => {}
                         4 | 16 | 32 => {
                             for _ in 0..nexthop_len {
                                 data.push(c.read_u8().unwrap());
@@ -2104,8 +2289,9 @@ impl PeerCodec {
                     }
                 }
 
+                let mp_unreach_present = mp_unreach_attr.is_some();
                 if let Some(a) = mp_unreach_attr {
-                    let err: Error = BgpError::UpdateOptionalAttributeError.into();
+                    let err: Error = Notification::UpdateOptionalAttributeError.into();
                     let buf = a.binary().unwrap();
                     if buf.len() < 3 {
                         return Err(err);
@@ -2128,28 +2314,44 @@ impl PeerCodec {
                     }
                 }
 
-                Ok(Message::Update(Update {
+                // non-IPv4 EOR: MP_UNREACH_NLRI with no NLRIs and no other content (RFC 4724 §2)
+                if mp_unreach_entries.is_empty()
+                    && mp_unreach_present
+                    && reach.is_empty()
+                    && mp_reach_entries.is_empty()
+                    && unreach.is_empty()
+                    && attr.is_empty()
+                    && error_attrs.is_empty()
+                {
+                    return Ok(ParsedMessage::Update(ParsedUpdate::EndOfRib(
+                        mp_unreach_family,
+                    )));
+                }
+
+                Ok(ParsedMessage::Update(ParsedUpdate::Routes {
                     reach: if reach.is_empty() {
                         None
                     } else {
-                        Some(NlriSet {
+                        Some(ReachNlri {
                             family: reach_family,
                             entries: reach,
+                            nexthop: reach_nexthop,
                         })
                     },
                     mp_reach: if mp_reach_entries.is_empty() {
                         None
                     } else {
-                        Some(NlriSet {
+                        Some(ReachNlri {
                             family: mp_reach_family,
                             entries: mp_reach_entries,
+                            nexthop: mp_nexthop,
                         })
                     },
-                    attr: Arc::new(attr),
+                    attrs: attr,
                     unreach: if unreach.is_empty() {
                         None
                     } else {
-                        Some(NlriSet {
+                        Some(UnreachNlri {
                             family: unreach_family,
                             entries: unreach,
                         })
@@ -2157,12 +2359,12 @@ impl PeerCodec {
                     mp_unreach: if mp_unreach_entries.is_empty() {
                         None
                     } else {
-                        Some(NlriSet {
+                        Some(UnreachNlri {
                             family: mp_unreach_family,
                             entries: mp_unreach_entries,
                         })
                     },
-                    nexthop: mp_nexthop,
+                    error_attrs,
                 }))
             }
             Message::NOTIFICATION => {
@@ -2175,28 +2377,32 @@ impl PeerCodec {
                 let code = c.read_u8().unwrap();
                 let subcode = c.read_u8().unwrap();
 
-                Ok(Message::Notification(BgpError::from_notification(
-                    code,
-                    subcode,
-                    buf[c.position() as usize..].to_vec(),
-                )))
+                Ok(ParsedMessage::Notification(
+                    Notification::from_notification(
+                        code,
+                        subcode,
+                        buf[c.position() as usize..].to_vec(),
+                    ),
+                ))
             }
-            Message::KEEPALIVE => Ok(Message::Keepalive),
+            Message::KEEPALIVE => Ok(ParsedMessage::Keepalive),
             Message::ROUTE_REFRESH => {
                 const ROUTE_REFRESH_LENGTH: usize = Message::HEADER_LENGTH as usize + 4;
                 if buf.len() < ROUTE_REFRESH_LENGTH {
                     return Err(header_len_error);
                 }
                 if ROUTE_REFRESH_LENGTH < buf.len() {
-                    return Err(BgpError::RouteRefreshInvalidLength { data: buf.to_vec() }.into());
+                    return Err(
+                        Notification::RouteRefreshInvalidLength { data: buf.to_vec() }.into(),
+                    );
                 }
                 let mut c = Cursor::new(&buf);
                 c.set_position(Message::HEADER_LENGTH.into());
-                Ok(Message::RouteRefresh {
+                Ok(ParsedMessage::RouteRefresh {
                     family: Family(c.read_u32::<NetworkEndian>().unwrap()),
                 })
             }
-            _ => Err(BgpError::BadMessageType { data: vec![code] }.into()),
+            _ => Err(Notification::BadMessageType { data: vec![code] }.into()),
         }
     }
 
@@ -2207,25 +2413,12 @@ impl PeerCodec {
     ) -> Result<(), Error> {
         let mut done_idx = 0;
         match msg {
-            Message::Update(Update {
-                reach,
-                mp_reach,
-                unreach,
-                mp_unreach,
-                ..
-            }) => {
+            Message::Update(Update::Routes { reach, unreach, .. }) => {
                 // Determine the number of iterations needed for splitting large route sets.
-                // reach and unreach use the traditional IPv4 field and may need splitting.
-                // mp_reach and mp_unreach go into path attributes and are encoded as a whole.
-                let n = std::cmp::max(
-                    reach.as_ref().map_or(0, |s| s.entries.len()),
-                    unreach.as_ref().map_or(0, |s| s.entries.len()),
+                let total = std::cmp::max(
+                    reach.as_ref().map_or(0, |s| s.entries.len()).max(1),
+                    unreach.as_ref().map_or(0, |s| s.entries.len()).max(1),
                 );
-                let mp_n = std::cmp::max(
-                    mp_reach.as_ref().map_or(0, |s| s.entries.len()),
-                    mp_unreach.as_ref().map_or(0, |s| s.entries.len()),
-                );
-                let total = std::cmp::max(n.max(1), mp_n.max(1));
                 loop {
                     self.do_encode(msg, dst, &mut done_idx)?;
                     done_idx += 1;
@@ -2358,13 +2551,13 @@ mod confed_as_path_tests {
 
         let msg = update_msg_with_asn_in_path(confederation_id);
         let result = codec.parse_message(&msg).unwrap();
-        if let Message::Update(update) = result {
+        if let ParsedMessage::Update(ParsedUpdate::Routes { error_attrs, .. }) = result {
             assert!(
-                update.reach.is_none(),
-                "route with confederation_id in AS_PATH must be treated as withdrawn"
+                !error_attrs.is_empty(),
+                "route with confederation_id in AS_PATH must have error"
             );
         } else {
-            panic!("expected UPDATE message");
+            panic!("expected UPDATE Routes message");
         }
     }
 }

--- a/packet/src/bmp.rs
+++ b/packet/src/bmp.rs
@@ -212,13 +212,7 @@ impl Encoder<&Message> for BmpCodec {
             } => {
                 header.encode(c).unwrap();
                 let mut buf = bytes::BytesMut::with_capacity(4096);
-                if let bgp::Message::Update(bgp::Update {
-                    reach,
-                    unreach,
-                    attr: _,
-                    ..
-                }) = update
-                {
+                if let bgp::Message::Update(bgp::Update::Routes { reach, unreach, .. }) = update {
                     let family = if let Some(s) = reach {
                         s.family
                     } else {

--- a/packet/src/error.rs
+++ b/packet/src/error.rs
@@ -18,16 +18,17 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("BGP: {0}")]
-    Bgp(#[from] BgpError),
+    Bgp(#[from] Notification),
     #[error("parse error: {0}")]
     InvalidArgument(String),
     #[error("io error: {0}")]
     StdIoErr(#[from] std::io::Error),
 }
 
-/// Typed BGP NOTIFICATION error (RFC 4271 §4.5, RFC 6608 §3, RFC 7313 §5)
+/// Typed BGP NOTIFICATION content (RFC 4271 §4.5, RFC 6608 §3, RFC 7313 §5).
+/// Represents the error code, subcode, and data of a BGP NOTIFICATION message.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum BgpError {
+pub enum Notification {
     // Code 1: Message Header Error
     #[error("header error: bad message length")]
     BadMessageLength { data: Vec<u8> },
@@ -65,7 +66,7 @@ pub enum BgpError {
     },
 }
 
-impl BgpError {
+impl Notification {
     /// Returns the BGP NOTIFICATION error code.
     pub fn notification_code(&self) -> u8 {
         match self {
@@ -122,7 +123,7 @@ impl BgpError {
         )
     }
 
-    /// Constructs a `BgpError` from a received NOTIFICATION message.
+    /// Constructs a `Notification` from a received NOTIFICATION message.
     pub fn from_notification(code: u8, subcode: u8, data: Vec<u8>) -> Self {
         match (code, subcode) {
             (1, 2) => Self::BadMessageLength { data },
@@ -149,7 +150,7 @@ mod tests {
 
     #[test]
     fn hard_reset_is_cease_subcode_9() {
-        let err = BgpError::Other {
+        let err = Notification::Other {
             code: 6,
             subcode: 9,
             data: vec![],
@@ -160,7 +161,7 @@ mod tests {
     #[test]
     fn cease_other_subcodes_are_not_hard_reset() {
         for subcode in [0u8, 1, 2, 3, 4, 5, 6, 7, 8] {
-            let err = BgpError::Other {
+            let err = Notification::Other {
                 code: 6,
                 subcode,
                 data: vec![],
@@ -175,7 +176,7 @@ mod tests {
     #[test]
     fn non_cease_codes_are_not_hard_reset() {
         for code in [1u8, 2, 3, 5, 7] {
-            let err = BgpError::Other {
+            let err = Notification::Other {
                 code,
                 subcode: 9,
                 data: vec![],

--- a/packet/src/frame.rs
+++ b/packet/src/frame.rs
@@ -17,7 +17,7 @@ use byteorder::{NetworkEndian, ReadBytesExt};
 use bytes::{BufMut, BytesMut};
 
 use crate::bgp;
-use crate::error::{BgpError, Error};
+use crate::error::{Error, Notification};
 
 /// BGP framing layer: detects message boundaries in a `BytesMut` stream
 /// and delegates parsing to the inner `PeerCodec`.
@@ -38,7 +38,7 @@ impl BgpFramer {
 
     /// Try to parse one complete BGP message from `src`.
     /// Returns `Ok(None)` if there are not enough bytes yet.
-    pub fn try_parse(&mut self, src: &mut BytesMut) -> Result<Option<bgp::Message>, Error> {
+    pub fn try_parse(&mut self, src: &mut BytesMut) -> Result<Option<bgp::ParsedMessage>, Error> {
         let buffer_len = src.len();
         if buffer_len < bgp::Message::HEADER_LENGTH as usize {
             return Ok(None);
@@ -47,7 +47,7 @@ impl BgpFramer {
         if message_len < bgp::Message::HEADER_LENGTH as usize
             || message_len > self.0.max_message_length()
         {
-            return Err(BgpError::BadMessageLength {
+            return Err(Notification::BadMessageLength {
                 data: src[16..18].to_vec(),
             }
             .into());

--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -14,10 +14,12 @@
 // limitations under the License.
 
 pub mod bgp;
+pub use self::bgp::validate_message;
 pub use self::bgp::{
-    Attribute, Capability, Family, HoldTime, IpNet, Nlri, NlriSet, Open, PathNlri, Update,
+    Attribute, Capability, Family, HoldTime, IpNet, Nlri, Open, ParsedMessage, PathNlri, ReachNlri,
+    UnreachNlri, Update,
 };
-pub use self::error::{BgpError, Error};
+pub use self::error::{Error, Notification};
 pub use self::frame::BgpFramer;
 
 pub mod bmp;

--- a/packet/src/mpls.rs
+++ b/packet/src/mpls.rs
@@ -12,7 +12,7 @@
 // implied.  See the License for the specific language governing
 // permissions and limitations under the License.
 
-use crate::error::{BgpError, Error};
+use crate::error::{Error, Notification};
 use bytes::BufMut;
 use std::io;
 
@@ -77,7 +77,7 @@ impl MplsLabelStack {
         loop {
             let mut buf = [0u8; 3];
             c.read_exact(&mut buf)
-                .map_err(|_| Error::from(BgpError::UpdateMalformedAttributeList))?;
+                .map_err(|_| Error::from(Notification::UpdateMalformedAttributeList))?;
             let bos = (buf[2] & 1) != 0;
             labels.push(MplsLabel::decode(&buf));
             if bos {

--- a/packet/src/mrt.rs
+++ b/packet/src/mrt.rs
@@ -142,13 +142,7 @@ impl Encoder<&Message> for MrtCodec {
                 body,
                 addpath,
             } => {
-                if let bgp::Message::Update(bgp::Update {
-                    reach,
-                    unreach,
-                    attr: _,
-                    ..
-                }) = body
-                {
+                if let bgp::Message::Update(bgp::Update::Routes { reach, unreach, .. }) = body {
                     let family = if let Some(s) = reach {
                         s.family
                     } else {

--- a/packet/src/mup.rs
+++ b/packet/src/mup.rs
@@ -17,7 +17,7 @@
 //! Implements Architecture Type 1 (3GPP-5G) and route types 1..4.
 
 use crate::bgp::Family;
-use crate::error::{BgpError, Error};
+use crate::error::{Error, Notification};
 use crate::rd::RouteDistinguisher;
 use byteorder::{ByteOrder, NetworkEndian};
 use bytes::BufMut;
@@ -38,7 +38,7 @@ pub const EC_TYPE_MUP: u8 = 0x0c;
 pub const EC_SUBTYPE_MUP_DIRECT_SEG: u8 = 0x00;
 
 fn malformed() -> Error {
-    BgpError::UpdateMalformedAttributeList.into()
+    Notification::UpdateMalformedAttributeList.into()
 }
 
 fn addr_bit_len(family: Family) -> Result<u8, Error> {

--- a/packet/src/prefix_sid.rs
+++ b/packet/src/prefix_sid.rs
@@ -20,14 +20,14 @@
 //! so the attribute round-trips byte-for-byte regardless of the
 //! specific TLV mix an originator chose.
 
-use crate::error::{BgpError, Error};
+use crate::error::{Error, Notification};
 use byteorder::{NetworkEndian, ReadBytesExt};
 use bytes::BufMut;
 use std::io::{self, Cursor, Read};
 use std::net::Ipv6Addr;
 
 fn malformed() -> Error {
-    BgpError::UpdateMalformedAttributeList.into()
+    Notification::UpdateMalformedAttributeList.into()
 }
 
 /// Read a `[type: 1][length: 2 BE]` header plus `length` bytes of value.

--- a/packet/src/rd.rs
+++ b/packet/src/rd.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::{BgpError, Error};
+use crate::error::{Error, Notification};
 use byteorder::{ByteOrder, NetworkEndian};
 use bytes::BufMut;
 use std::fmt;
@@ -40,7 +40,7 @@ impl RouteDistinguisher {
     const TYPE_FOUR_OCTET_AS: u16 = 2;
 
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        let malformed: Error = BgpError::UpdateMalformedAttributeList.into();
+        let malformed: Error = Notification::UpdateMalformedAttributeList.into();
         if data.len() != Self::LEN {
             return Err(malformed);
         }
@@ -101,7 +101,7 @@ impl FromStr for RouteDistinguisher {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Error> {
-        let malformed = || -> Error { BgpError::UpdateMalformedAttributeList.into() };
+        let malformed = || -> Error { Notification::UpdateMalformedAttributeList.into() };
         let (admin_str, assigned_str) = s.rsplit_once(':').ok_or_else(malformed)?;
         if let Ok(addr) = admin_str.parse::<Ipv4Addr>() {
             let assigned: u16 = assigned_str.parse().map_err(|_| malformed())?;

--- a/packet/src/vpn.rs
+++ b/packet/src/vpn.rs
@@ -21,7 +21,7 @@
 //!   ceil(prefix_bits/8) bytes IP prefix (significant octets only)
 
 use crate::bgp::{Ipv4Net, Ipv6Net};
-use crate::error::{BgpError, Error};
+use crate::error::{Error, Notification};
 use crate::mpls::MplsLabelStack;
 use crate::rd::RouteDistinguisher;
 use byteorder::ReadBytesExt;
@@ -34,7 +34,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 const VPN_RD_BITS: u8 = 64;
 
 fn malformed() -> Error {
-    BgpError::UpdateMalformedAttributeList.into()
+    Notification::UpdateMalformedAttributeList.into()
 }
 
 /// VPNv4 NLRI (AFI=1, SAFI=128).

--- a/packet/tests/bgp_attribute.rs
+++ b/packet/tests/bgp_attribute.rs
@@ -14,7 +14,9 @@
 // limitations under the License.
 
 use rustybgp_packet::bgp::Ipv4Net;
-use rustybgp_packet::bgp::{Attribute, Message, NlriSet, PeerCodecBuilder, Update};
+use rustybgp_packet::bgp::{
+    Attribute, Message, ParsedMessage, ParsedUpdate, PeerCodecBuilder, ReachNlri, Update,
+};
 use rustybgp_packet::{BgpFramer, Family, Nlri, PathNlri};
 use std::net::Ipv4Addr;
 use std::sync::Arc;
@@ -48,7 +50,7 @@ fn base_attrs(nexthop: Ipv4Addr) -> Vec<Attribute> {
     ]
 }
 
-fn round_trip(msg: &Message) -> Message {
+fn round_trip(msg: &Message) -> ParsedMessage {
     let mut framer = BgpFramer::new(ipv4_codec());
     let mut buf = Vec::new();
     framer.encode_to(msg, &mut buf).unwrap();
@@ -56,16 +58,14 @@ fn round_trip(msg: &Message) -> Message {
 }
 
 fn update_with_attrs(attrs: Vec<Attribute>) -> Message {
-    Message::Update(Update {
-        reach: Some(NlriSet {
+    Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4,
             entries: vec![ipv4_prefix("10.0.0.0", 8)],
+            nexthop: None,
         }),
-        mp_reach: None,
         attr: Arc::new(attrs),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     })
 }
 
@@ -190,8 +190,8 @@ fn attribute_local_pref_round_trip() {
     attrs.push(Attribute::new_with_value(Attribute::LOCAL_PREF, 200).unwrap());
 
     match round_trip(&update_with_attrs(attrs)) {
-        Message::Update(Update { attr, .. }) => {
-            let lp = attr
+        ParsedMessage::Update(ParsedUpdate::Routes { attrs, .. }) => {
+            let lp = attrs
                 .iter()
                 .find(|a| a.code() == Attribute::LOCAL_PREF)
                 .expect("LOCAL_PREF must be present");
@@ -227,8 +227,8 @@ fn attribute_as_path_round_trip() {
     attrs.push(Attribute::new_with_value(Attribute::LOCAL_PREF, 100).unwrap());
 
     match round_trip(&update_with_attrs(attrs)) {
-        Message::Update(Update { attr, .. }) => {
-            let ap = attr
+        ParsedMessage::Update(ParsedUpdate::Routes { attrs, .. }) => {
+            let ap = attrs
                 .iter()
                 .find(|a| a.code() == Attribute::AS_PATH)
                 .expect("AS_PATH must be present");
@@ -249,8 +249,8 @@ fn attribute_large_community_round_trip() {
     attrs.push(Attribute::new_with_bin(Attribute::LARGE_COMMUNITY, lc.clone()).unwrap());
 
     match round_trip(&update_with_attrs(attrs)) {
-        Message::Update(Update { attr, .. }) => {
-            let lc_attr = attr
+        ParsedMessage::Update(ParsedUpdate::Routes { attrs, .. }) => {
+            let lc_attr = attrs
                 .iter()
                 .find(|a| a.code() == Attribute::LARGE_COMMUNITY)
                 .expect("LARGE_COMMUNITY must be present");
@@ -268,8 +268,8 @@ fn attribute_extended_community_round_trip() {
     attrs.push(Attribute::new_with_bin(Attribute::EXTENDED_COMMUNITY, ec.clone()).unwrap());
 
     match round_trip(&update_with_attrs(attrs)) {
-        Message::Update(Update { attr, .. }) => {
-            let ec_attr = attr
+        ParsedMessage::Update(ParsedUpdate::Routes { attrs, .. }) => {
+            let ec_attr = attrs
                 .iter()
                 .find(|a| a.code() == Attribute::EXTENDED_COMMUNITY)
                 .expect("EXTENDED_COMMUNITY must be present");

--- a/packet/tests/bgp_capability.rs
+++ b/packet/tests/bgp_capability.rs
@@ -13,8 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustybgp_packet::bgp::{Capability, Message, Open, PeerCodecBuilder, create_channel};
-use rustybgp_packet::{BgpError, BgpFramer, Family, HoldTime};
+use rustybgp_packet::bgp::{
+    Capability, Message, Open, ParsedMessage, PeerCodecBuilder, create_channel,
+};
+use rustybgp_packet::{BgpFramer, Family, HoldTime, Notification};
 use std::net::Ipv4Addr;
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -51,12 +53,12 @@ fn parse_open_caps(cap_bytes: &[u8]) -> Vec<Capability> {
         &open_body(65001, 90, "192.0.2.1".parse().unwrap(), &params),
     );
     match PeerCodecBuilder::new().build().parse_message(&buf).unwrap() {
-        Message::Open(Open { capability, .. }) => capability,
+        ParsedMessage::Open(Open { capability, .. }) => capability,
         _ => panic!("expected OPEN"),
     }
 }
 
-fn round_trip(msg: &Message) -> Message {
+fn round_trip(msg: &Message) -> ParsedMessage {
     let mut framer = BgpFramer::new(PeerCodecBuilder::new().build());
     let mut buf = Vec::new();
     framer.encode_to(msg, &mut buf).unwrap();
@@ -129,7 +131,7 @@ fn capability_graceful_restart_round_trip() {
         families: vec![(Family::IPV4, 0x80), (Family::IPV6, 0x00)],
     }]);
     match round_trip(&original) {
-        Message::Open(Open { capability, .. }) => {
+        ParsedMessage::Open(Open { capability, .. }) => {
             assert_eq!(capability.len(), 1);
             match &capability[0] {
                 Capability::GracefulRestart {
@@ -160,7 +162,7 @@ fn capability_graceful_restart_invalid_len() {
         &open_body(65001, 90, "192.0.2.1".parse().unwrap(), &params),
     );
     match PeerCodecBuilder::new().build().parse_message(&buf) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::OpenMalformed)) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::OpenMalformed)) => {}
         Ok(_) => panic!("expected error"),
         Err(e) => panic!("unexpected error: {}", e),
     }
@@ -173,7 +175,7 @@ fn capability_add_path_round_trip() {
     // mode=3: send+receive
     let original = open_with(vec![Capability::AddPath(vec![(Family::IPV4, 3)])]);
     match round_trip(&original) {
-        Message::Open(Open { capability, .. }) => {
+        ParsedMessage::Open(Open { capability, .. }) => {
             assert_eq!(capability.len(), 1);
             assert!(matches!(
                 &capability[0],
@@ -191,7 +193,7 @@ fn capability_add_path_multiple_families() {
         (Family::IPV6, 2), // send only
     ])]);
     match round_trip(&original) {
-        Message::Open(Open { capability, .. }) => {
+        ParsedMessage::Open(Open { capability, .. }) => {
             assert_eq!(capability.len(), 1);
             match &capability[0] {
                 Capability::AddPath(v) => {
@@ -216,7 +218,7 @@ fn capability_add_path_invalid_len() {
         &open_body(65001, 90, "192.0.2.1".parse().unwrap(), &params),
     );
     match PeerCodecBuilder::new().build().parse_message(&buf) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::OpenMalformed)) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::OpenMalformed)) => {}
         Ok(_) => panic!("expected error"),
         Err(e) => panic!("unexpected error: {}", e),
     }
@@ -228,7 +230,7 @@ fn capability_add_path_invalid_len() {
 fn capability_enhanced_route_refresh_round_trip() {
     let original = open_with(vec![Capability::EnhancedRouteRefresh]);
     match round_trip(&original) {
-        Message::Open(Open { capability, .. }) => {
+        ParsedMessage::Open(Open { capability, .. }) => {
             assert!(
                 capability
                     .iter()
@@ -270,7 +272,7 @@ fn capability_fqdn_round_trip() {
         domain: "example.com".to_string(),
     }]);
     match round_trip(&original) {
-        Message::Open(Open { capability, .. }) => {
+        ParsedMessage::Open(Open { capability, .. }) => {
             assert_eq!(capability.len(), 1);
             assert!(matches!(
                 &capability[0],
@@ -292,7 +294,7 @@ fn capability_llgr_round_trip() {
         3600, // stale time in seconds
     )])]);
     match round_trip(&original) {
-        Message::Open(Open { capability, .. }) => {
+        ParsedMessage::Open(Open { capability, .. }) => {
             assert_eq!(capability.len(), 1);
             assert!(matches!(
                 &capability[0],
@@ -424,7 +426,7 @@ fn capability_extended_nexthop_round_trip() {
         Family::AFI_IP6,
     )])]);
     match round_trip(&original) {
-        Message::Open(Open { capability, .. }) => {
+        ParsedMessage::Open(Open { capability, .. }) => {
             assert_eq!(capability.len(), 1);
             match &capability[0] {
                 Capability::ExtendedNexthop(v) => {

--- a/packet/tests/bgp_framer.rs
+++ b/packet/tests/bgp_framer.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 use bytes::BytesMut;
-use rustybgp_packet::bgp::{Message, PeerCodecBuilder};
-use rustybgp_packet::{BgpError, BgpFramer};
+use rustybgp_packet::bgp::{Message, ParsedMessage, PeerCodecBuilder};
+use rustybgp_packet::{BgpFramer, Notification};
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -67,7 +67,7 @@ fn framer_complete_keepalive() {
     let mut framer = default_framer();
     let mut buf = BytesMut::from(keepalive_bytes().as_slice());
     let result = framer.try_parse(&mut buf).unwrap();
-    assert!(matches!(result, Some(Message::Keepalive)));
+    assert!(matches!(result, Some(ParsedMessage::Keepalive)));
     assert_eq!(buf.len(), 0); // consumed
 }
 
@@ -83,7 +83,7 @@ fn framer_partial_message() {
     // Second chunk: add the remaining 9 bytes
     buf.extend_from_slice(&bytes[10..]);
     let result = framer.try_parse(&mut buf).unwrap();
-    assert!(matches!(result, Some(Message::Keepalive)));
+    assert!(matches!(result, Some(ParsedMessage::Keepalive)));
     assert_eq!(buf.len(), 0);
 }
 
@@ -98,12 +98,12 @@ fn framer_two_messages_in_buffer() {
 
     // First parse: consumes one message
     let r1 = framer.try_parse(&mut buf).unwrap();
-    assert!(matches!(r1, Some(Message::Keepalive)));
+    assert!(matches!(r1, Some(ParsedMessage::Keepalive)));
     assert_eq!(buf.len(), 19); // one message remains
 
     // Second parse: consumes second message
     let r2 = framer.try_parse(&mut buf).unwrap();
-    assert!(matches!(r2, Some(Message::Keepalive)));
+    assert!(matches!(r2, Some(ParsedMessage::Keepalive)));
     assert_eq!(buf.len(), 0);
 
     // Third parse: empty
@@ -121,7 +121,7 @@ fn framer_message_then_partial() {
 
     // First parse: succeeds
     let r1 = framer.try_parse(&mut buf).unwrap();
-    assert!(matches!(r1, Some(Message::Keepalive)));
+    assert!(matches!(r1, Some(ParsedMessage::Keepalive)));
     assert_eq!(buf.len(), 5);
 
     // Second parse: partial → None
@@ -141,7 +141,7 @@ fn framer_header_length_below_minimum() {
     let mut framer = default_framer();
     let mut bmut = BytesMut::from(buf.as_slice());
     match framer.try_parse(&mut bmut) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::BadMessageLength { .. })) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::BadMessageLength { .. })) => {}
         other => panic!("expected BadMessageLength, got {:?}", other.map(|_| "ok")),
     }
 }
@@ -156,7 +156,7 @@ fn framer_header_length_exceeds_max() {
     let mut framer = default_framer();
     let mut bmut = BytesMut::from(buf.as_slice());
     match framer.try_parse(&mut bmut) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::BadMessageLength { .. })) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::BadMessageLength { .. })) => {}
         other => panic!("expected BadMessageLength, got {:?}", other.map(|_| "ok")),
     }
 }
@@ -168,7 +168,7 @@ fn framer_unknown_message_type() {
     let mut framer = default_framer();
     let mut bmut = BytesMut::from(buf.as_slice());
     match framer.try_parse(&mut bmut) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::BadMessageType { .. })) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::BadMessageType { .. })) => {}
         other => panic!("expected BadMessageType, got {:?}", other.map(|_| "ok")),
     }
 }
@@ -191,12 +191,12 @@ fn framer_mixed_message_types() {
     buf.extend_from_slice(&bgp_msg(5, &[0x00, 0x01, 0x00, 0x01]));
 
     let m1 = framer.try_parse(&mut buf).unwrap();
-    assert!(matches!(m1, Some(Message::Keepalive)));
+    assert!(matches!(m1, Some(ParsedMessage::Keepalive)));
 
     let m2 = framer.try_parse(&mut buf).unwrap();
     assert!(matches!(
         m2,
-        Some(Message::RouteRefresh { family })
+        Some(ParsedMessage::RouteRefresh { family })
         if family == rustybgp_packet::Family::IPV4
     ));
 

--- a/packet/tests/bgp_message.rs
+++ b/packet/tests/bgp_message.rs
@@ -15,7 +15,8 @@
 
 use bytes::BytesMut;
 use rustybgp_packet::bgp::{
-    Attribute, Ipv4Net, Ipv6Net, Message, NlriSet, PeerCodecBuilder, Update,
+    Attribute, Ipv4Net, Ipv6Net, Message, ParsedMessage, ParsedUpdate, PeerCodecBuilder, ReachNlri,
+    UnreachNlri, Update,
 };
 use rustybgp_packet::{BgpFramer, Family, Nlri, PathNlri};
 use std::collections::HashSet;
@@ -69,7 +70,7 @@ fn parse_ipv6_update() {
     let mut codec = PeerCodecBuilder::new().families(vec![Family::IPV6]).build();
     let msg = codec.parse_message(&buf).unwrap();
     match msg {
-        Message::Update(Update { mp_reach, .. }) => {
+        ParsedMessage::Update(ParsedUpdate::Routes { mp_reach, .. }) => {
             // IPv6 NLRI arrives via MP_REACH_NLRI attribute
             let s = mp_reach.unwrap();
             assert_eq!(s.family, Family::IPV6);
@@ -95,20 +96,18 @@ fn build_many_v4_route() {
 
     let mut set: HashSet<PathNlri> = net.iter().cloned().map(PathNlri::new).collect();
 
-    let mut msg = Message::Update(Update {
-        reach: Some(NlriSet {
+    let mut msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4,
             entries: net.iter().cloned().map(PathNlri::new).collect(),
+            nexthop: None,
         }),
-        mp_reach: None,
         attr: Arc::new(vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
             Attribute::new_with_bin(Attribute::AS_PATH, vec![2, 1, 1, 0, 0, 0]).unwrap(),
             Attribute::new_with_bin(Attribute::NEXTHOP, vec![0, 0, 0, 0]).unwrap(),
         ]),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     let codec = PeerCodecBuilder::new().families(vec![Family::IPV4]).build();
@@ -119,7 +118,9 @@ fn build_many_v4_route() {
     let mut recv = Vec::new();
     loop {
         match framer.try_parse(&mut txbuf).expect("failed to decode") {
-            Some(Message::Update(Update { reach, .. })) => recv.append(&mut reach.unwrap().entries),
+            Some(ParsedMessage::Update(ParsedUpdate::Routes { reach, .. })) => {
+                recv.append(&mut reach.unwrap().entries)
+            }
             Some(_) => {}
             None => break,
         }
@@ -130,16 +131,13 @@ fn build_many_v4_route() {
     }
     assert_eq!(set.len(), 0);
 
-    msg = Message::Update(Update {
+    msg = Message::Update(Update::Routes {
         reach: None,
-        mp_reach: None,
         attr: Arc::new(Vec::new()),
-        unreach: Some(NlriSet {
+        unreach: Some(UnreachNlri {
             family: Family::IPV4,
             entries: net.iter().cloned().map(PathNlri::new).collect(),
         }),
-        mp_unreach: None,
-        nexthop: None,
     });
     for n in &net {
         set.insert(PathNlri::new(n.clone()));
@@ -149,7 +147,7 @@ fn build_many_v4_route() {
     let mut withdrawn = Vec::new();
     loop {
         match framer.try_parse(&mut txbuf).expect("failed to decode") {
-            Some(Message::Update(Update { unreach, .. })) => {
+            Some(ParsedMessage::Update(ParsedUpdate::Routes { unreach, .. })) => {
                 withdrawn.append(&mut unreach.unwrap().entries)
             }
             Some(_) => {}
@@ -176,11 +174,11 @@ fn many_mp_reach() {
 
     let mut set: HashSet<PathNlri> = net.iter().cloned().map(PathNlri::new).collect();
 
-    let msg = Message::Update(Update {
-        reach: None,
-        mp_reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV6,
             entries: net.iter().cloned().map(PathNlri::new).collect(),
+            nexthop: None,
         }),
         attr: Arc::new(vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
@@ -188,8 +186,6 @@ fn many_mp_reach() {
             Attribute::new_with_bin(Attribute::NEXTHOP, (0..31).collect::<Vec<u8>>()).unwrap(),
         ]),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     let codec = PeerCodecBuilder::new().families(vec![Family::IPV6]).build();
@@ -200,7 +196,7 @@ fn many_mp_reach() {
     let mut recv = Vec::new();
     loop {
         match framer.try_parse(&mut txbuf).expect("failed to decode") {
-            Some(Message::Update(Update { mp_reach, .. })) => {
+            Some(ParsedMessage::Update(ParsedUpdate::Routes { mp_reach, .. })) => {
                 recv.append(&mut mp_reach.unwrap().entries)
             }
             Some(_) => {}
@@ -227,16 +223,13 @@ fn many_mp_unreach() {
 
     let mut set: HashSet<PathNlri> = net.iter().cloned().map(PathNlri::new).collect();
 
-    let msg = Message::Update(Update {
+    let msg = Message::Update(Update::Routes {
         reach: None,
-        mp_reach: None,
         attr: Arc::new(Vec::new()),
-        unreach: None,
-        mp_unreach: Some(NlriSet {
+        unreach: Some(UnreachNlri {
             family: Family::IPV6,
             entries: net.iter().cloned().map(PathNlri::new).collect(),
         }),
-        nexthop: None,
     });
 
     let codec = PeerCodecBuilder::new().families(vec![Family::IPV6]).build();
@@ -247,7 +240,7 @@ fn many_mp_unreach() {
     let mut recv = Vec::new();
     loop {
         match framer.try_parse(&mut txbuf).expect("failed to decode") {
-            Some(Message::Update(Update { mp_unreach, .. })) => {
+            Some(ParsedMessage::Update(ParsedUpdate::Routes { mp_unreach, .. })) => {
                 recv.append(&mut mp_unreach.unwrap().entries)
             }
             Some(_) => {}

--- a/packet/tests/bgp_misc.rs
+++ b/packet/tests/bgp_misc.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 use bytes::{BufMut, BytesMut};
-use rustybgp_packet::bgp::{Message, PeerCodecBuilder};
-use rustybgp_packet::{BgpError, BgpFramer, Family};
+use rustybgp_packet::bgp::{Message, ParsedMessage, PeerCodecBuilder};
+use rustybgp_packet::{BgpFramer, Family, Notification};
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -32,7 +32,7 @@ fn default_codec() -> rustybgp_packet::bgp::PeerCodec {
     PeerCodecBuilder::new().build()
 }
 
-fn round_trip(msg: &Message) -> Message {
+fn round_trip(msg: &Message) -> ParsedMessage {
     let mut framer = BgpFramer::new(default_codec());
     let mut buf = BytesMut::new();
     framer.encode_to(msg, &mut buf).unwrap();
@@ -48,14 +48,14 @@ fn keepalive_parse() {
     let mut codec = default_codec();
     assert!(matches!(
         codec.parse_message(&buf).unwrap(),
-        Message::Keepalive
+        ParsedMessage::Keepalive
     ));
 }
 
 #[test]
 fn keepalive_round_trip() {
     match round_trip(&Message::Keepalive) {
-        Message::Keepalive => {}
+        ParsedMessage::Keepalive => {}
         _ => panic!("expected Keepalive"),
     }
 }
@@ -69,7 +69,7 @@ fn notification_parse() {
     let buf = bgp_msg(3, body);
     let mut codec = default_codec();
     match codec.parse_message(&buf).unwrap() {
-        Message::Notification(err) => {
+        ParsedMessage::Notification(err) => {
             assert_eq!(err.notification_code(), 1);
             assert_eq!(err.notification_subcode(), 2);
             assert_eq!(err.notification_data(), &[0x00u8, 0x13]);
@@ -85,7 +85,7 @@ fn notification_parse_no_data() {
     let buf = bgp_msg(3, body);
     let mut codec = default_codec();
     match codec.parse_message(&buf).unwrap() {
-        Message::Notification(err) => {
+        ParsedMessage::Notification(err) => {
             assert_eq!(err.notification_code(), 4);
             assert_eq!(err.notification_subcode(), 0);
             assert!(err.notification_data().is_empty());
@@ -96,12 +96,12 @@ fn notification_parse_no_data() {
 
 #[test]
 fn notification_round_trip() {
-    // Use BadMessageLength (code=1, subcode=2) which preserves data in BgpError
-    let original = Message::Notification(BgpError::BadMessageLength {
+    // Use BadMessageLength (code=1, subcode=2) which preserves data in Notification
+    let original = Message::Notification(Notification::BadMessageLength {
         data: vec![0xDE, 0xAD, 0xBE, 0xEF],
     });
     match round_trip(&original) {
-        Message::Notification(err) => {
+        ParsedMessage::Notification(err) => {
             assert_eq!(err.notification_code(), 1);
             assert_eq!(err.notification_subcode(), 2);
             assert_eq!(err.notification_data(), &[0xDEu8, 0xAD, 0xBE, 0xEF]);
@@ -110,47 +110,47 @@ fn notification_round_trip() {
     }
 }
 
-// ─── BgpError ↔ Notification mapping ─────────────────────────────────────────
+// ─── Notification ↔ Notification mapping ─────────────────────────────────────────
 
 #[test]
 fn bgerror_from_notification_known_codes() {
-    // Verify BgpError::from_notification maps known codes correctly
+    // Verify Notification::from_notification maps known codes correctly
     assert!(matches!(
-        BgpError::from_notification(1, 2, vec![]),
-        BgpError::BadMessageLength { .. }
+        Notification::from_notification(1, 2, vec![]),
+        Notification::BadMessageLength { .. }
     ));
     assert!(matches!(
-        BgpError::from_notification(1, 3, vec![]),
-        BgpError::BadMessageType { .. }
+        Notification::from_notification(1, 3, vec![]),
+        Notification::BadMessageType { .. }
     ));
     assert!(matches!(
-        BgpError::from_notification(2, 0, vec![]),
-        BgpError::OpenMalformed
+        Notification::from_notification(2, 0, vec![]),
+        Notification::OpenMalformed
     ));
     assert!(matches!(
-        BgpError::from_notification(2, 4, vec![]),
-        BgpError::OpenUnsupportedOptionalParameter { .. }
+        Notification::from_notification(2, 4, vec![]),
+        Notification::OpenUnsupportedOptionalParameter { .. }
     ));
     assert!(matches!(
-        BgpError::from_notification(2, 6, vec![]),
-        BgpError::OpenUnacceptableHoldTime { .. }
+        Notification::from_notification(2, 6, vec![]),
+        Notification::OpenUnacceptableHoldTime { .. }
     ));
     assert!(matches!(
-        BgpError::from_notification(3, 1, vec![]),
-        BgpError::UpdateMalformedAttributeList
+        Notification::from_notification(3, 1, vec![]),
+        Notification::UpdateMalformedAttributeList
     ));
     assert!(matches!(
-        BgpError::from_notification(7, 1, vec![]),
-        BgpError::RouteRefreshInvalidLength { .. }
+        Notification::from_notification(7, 1, vec![]),
+        Notification::RouteRefreshInvalidLength { .. }
     ));
 }
 
 #[test]
 fn bgerror_from_notification_unknown_code() {
-    let err = BgpError::from_notification(99, 0, vec![0xAB]);
+    let err = Notification::from_notification(99, 0, vec![0xAB]);
     assert!(matches!(
         err,
-        BgpError::Other {
+        Notification::Other {
             code: 99,
             subcode: 0,
             ..
@@ -161,14 +161,14 @@ fn bgerror_from_notification_unknown_code() {
 #[test]
 fn bgerror_notification_code_round_trip() {
     // notification_code/subcode/data round-trips correctly
-    let err = BgpError::BadMessageLength {
+    let err = Notification::BadMessageLength {
         data: vec![0x10, 0x00],
     };
     assert_eq!(err.notification_code(), 1);
     assert_eq!(err.notification_subcode(), 2);
     assert_eq!(err.notification_data(), &[0x10, 0x00]);
 
-    let err = BgpError::FsmUnexpectedState { state: 3 };
+    let err = Notification::FsmUnexpectedState { state: 3 };
     assert_eq!(err.notification_code(), 5);
     assert_eq!(err.notification_subcode(), 3);
 }
@@ -182,7 +182,7 @@ fn route_refresh_ipv4() {
     let buf = bgp_msg(5, body);
     let mut codec = default_codec();
     match codec.parse_message(&buf).unwrap() {
-        Message::RouteRefresh { family } => {
+        ParsedMessage::RouteRefresh { family } => {
             assert_eq!(family, Family::IPV4);
         }
         _ => panic!("expected RouteRefresh"),
@@ -196,7 +196,7 @@ fn route_refresh_ipv6() {
     let buf = bgp_msg(5, body);
     let mut codec = default_codec();
     match codec.parse_message(&buf).unwrap() {
-        Message::RouteRefresh { family } => {
+        ParsedMessage::RouteRefresh { family } => {
             assert_eq!(family, Family::IPV6);
         }
         _ => panic!("expected RouteRefresh"),
@@ -209,7 +209,7 @@ fn route_refresh_round_trip() {
         family: Family::IPV4,
     };
     match round_trip(&original) {
-        Message::RouteRefresh { family } => {
+        ParsedMessage::RouteRefresh { family } => {
             assert_eq!(family, Family::IPV4);
         }
         _ => panic!("expected RouteRefresh"),
@@ -223,7 +223,7 @@ fn route_refresh_too_long() {
     let buf = bgp_msg(5, body);
     let mut codec = default_codec();
     match codec.parse_message(&buf) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::RouteRefreshInvalidLength { .. })) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::RouteRefreshInvalidLength { .. })) => {}
         Ok(_) => panic!("expected error"),
         Err(e) => panic!("unexpected error: {}", e),
     }
@@ -237,7 +237,7 @@ fn bad_message_type() {
     let buf = bgp_msg(99, &[]);
     let mut codec = default_codec();
     match codec.parse_message(&buf) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::BadMessageType { .. })) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::BadMessageType { .. })) => {}
         Ok(_) => panic!("expected error"),
         Err(e) => panic!("unexpected error: {}", e),
     }
@@ -250,7 +250,7 @@ fn parse_message_too_short_buffer() {
     let buf: Vec<u8> = vec![0xff; 10]; // 10 bytes < HEADER_LENGTH=19
     let mut codec = default_codec();
     match codec.parse_message(&buf) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::BadMessageLength { .. })) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::BadMessageLength { .. })) => {}
         Ok(_) => panic!("expected error"),
         Err(e) => panic!("unexpected error: {}", e),
     }
@@ -266,7 +266,7 @@ fn framer_bad_header_length() {
     buf.put_u8(4); // KEEPALIVE
     let mut framer = BgpFramer::new(PeerCodecBuilder::new().build());
     match framer.try_parse(&mut buf) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::BadMessageLength { .. })) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::BadMessageLength { .. })) => {}
         Ok(_) => panic!("expected error"),
         Err(e) => panic!("unexpected error: {}", e),
     }

--- a/packet/tests/bgp_open.rs
+++ b/packet/tests/bgp_open.rs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustybgp_packet::bgp::{Capability, Message, Open, PeerCodecBuilder};
-use rustybgp_packet::{BgpError, BgpFramer, Family, HoldTime};
+use rustybgp_packet::bgp::{Capability, Message, Open, ParsedMessage, PeerCodecBuilder};
+use rustybgp_packet::{BgpFramer, Family, HoldTime, Notification};
 use std::net::Ipv4Addr;
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -59,7 +59,7 @@ fn open_minimal_parse() {
     let buf = bgp_msg(1, &open_body(65001, 90, "192.0.2.1".parse().unwrap(), &[]));
     let mut codec = default_codec().build();
     match codec.parse_message(&buf).unwrap() {
-        Message::Open(Open {
+        ParsedMessage::Open(Open {
             as_number,
             holdtime,
             router_id,
@@ -89,7 +89,7 @@ fn open_with_multiprotocol_ipv4() {
 
     let mut codec = default_codec().build();
     match codec.parse_message(&buf).unwrap() {
-        Message::Open(Open { capability, .. }) => {
+        ParsedMessage::Open(Open { capability, .. }) => {
             assert_eq!(capability.len(), 1);
             assert!(matches!(
                 &capability[0],
@@ -112,7 +112,7 @@ fn open_with_multiprotocol_ipv6() {
 
     let mut codec = default_codec().build();
     match codec.parse_message(&buf).unwrap() {
-        Message::Open(Open { capability, .. }) => {
+        ParsedMessage::Open(Open { capability, .. }) => {
             assert_eq!(capability.len(), 1);
             assert!(matches!(
                 &capability[0],
@@ -138,7 +138,7 @@ fn open_with_four_octet_asn() {
 
     let mut codec = default_codec().build();
     match codec.parse_message(&buf).unwrap() {
-        Message::Open(Open {
+        ParsedMessage::Open(Open {
             as_number,
             capability,
             ..
@@ -167,7 +167,7 @@ fn open_with_route_refresh() {
 
     let mut codec = default_codec().build();
     match codec.parse_message(&buf).unwrap() {
-        Message::Open(Open { capability, .. }) => {
+        ParsedMessage::Open(Open { capability, .. }) => {
             assert!(
                 capability
                     .iter()
@@ -195,7 +195,7 @@ fn open_round_trip_minimal() {
     let parsed = framer.inner_mut().parse_message(&buf).unwrap();
 
     match parsed {
-        Message::Open(Open {
+        ParsedMessage::Open(Open {
             as_number,
             holdtime,
             router_id,
@@ -233,7 +233,7 @@ fn open_round_trip_with_capabilities() {
     let parsed = framer.inner_mut().parse_message(&buf).unwrap();
 
     match parsed {
-        Message::Open(Open {
+        ParsedMessage::Open(Open {
             as_number,
             holdtime,
             capability,
@@ -275,7 +275,7 @@ fn open_too_short() {
     let buf = bgp_msg(1, body);
     let mut codec = default_codec().build();
     match codec.parse_message(&buf) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::BadMessageLength { .. })) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::BadMessageLength { .. })) => {}
         Ok(_) => panic!("expected error"),
         Err(e) => panic!("unexpected error: {}", e),
     }
@@ -291,7 +291,7 @@ fn open_unacceptable_holdtime() {
         );
         let mut codec = default_codec().build();
         match codec.parse_message(&buf) {
-            Err(rustybgp_packet::Error::Bgp(BgpError::OpenUnacceptableHoldTime { .. })) => {}
+            Err(rustybgp_packet::Error::Bgp(Notification::OpenUnacceptableHoldTime { .. })) => {}
             Ok(_) => panic!("expected error for holdtime={}", bad_holdtime),
             Err(e) => panic!("unexpected error for holdtime={}: {}", bad_holdtime, e),
         }
@@ -308,7 +308,9 @@ fn open_unsupported_optional_parameter() {
     );
     let mut codec = default_codec().build();
     match codec.parse_message(&buf) {
-        Err(rustybgp_packet::Error::Bgp(BgpError::OpenUnsupportedOptionalParameter { .. })) => {}
+        Err(rustybgp_packet::Error::Bgp(Notification::OpenUnsupportedOptionalParameter {
+            ..
+        })) => {}
         Ok(_) => panic!("expected error"),
         Err(e) => panic!("unexpected error: {}", e),
     }

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -14,7 +14,8 @@
 // limitations under the License.
 
 use rustybgp_packet::bgp::{
-    Attribute, Ipv4Net, Ipv6Net, Message, Nexthop, NlriSet, PeerCodec, PeerCodecBuilder, Update,
+    Attribute, Ipv4Net, Ipv6Net, Message, Nexthop, ParsedMessage, ParsedUpdate, PeerCodec,
+    PeerCodecBuilder, ReachNlri, UnreachNlri, Update,
 };
 use rustybgp_packet::mup;
 use rustybgp_packet::prefix_sid;
@@ -71,7 +72,7 @@ fn ipv6_prefix(addr: &str, mask: u8) -> PathNlri {
 }
 
 /// Encode + parse a message and return the parsed result.
-fn round_trip(msg: &Message, codec: rustybgp_packet::bgp::PeerCodec) -> Message {
+fn round_trip(msg: &Message, codec: rustybgp_packet::bgp::PeerCodec) -> ParsedMessage {
     let mut framer = BgpFramer::new(codec);
     let mut buf = Vec::new();
     framer.encode_to(msg, &mut buf).unwrap();
@@ -83,20 +84,18 @@ fn round_trip(msg: &Message, codec: rustybgp_packet::bgp::PeerCodec) -> Message 
 #[test]
 fn update_ipv4_announce() {
     let prefix = ipv4_prefix("10.0.0.0", 8);
-    let msg = Message::Update(Update {
-        reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4,
             entries: vec![prefix.clone()],
+            nexthop: None,
         }),
-        mp_reach: None,
         attr: ipv4_attrs("192.0.2.254".parse().unwrap()),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_codec()) {
-        Message::Update(Update { reach, unreach, .. }) => {
+        ParsedMessage::Update(ParsedUpdate::Routes { reach, unreach, .. }) => {
             assert!(unreach.is_none());
             let s = reach.unwrap();
             assert_eq!(s.family, Family::IPV4);
@@ -116,20 +115,18 @@ fn update_ipv4_announce_multiple() {
         })
         .collect();
 
-    let msg = Message::Update(Update {
-        reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4,
             entries: prefixes.clone(),
+            nexthop: None,
         }),
-        mp_reach: None,
         attr: ipv4_attrs("192.0.2.254".parse().unwrap()),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_codec()) {
-        Message::Update(Update { reach, .. }) => {
+        ParsedMessage::Update(ParsedUpdate::Routes { reach, .. }) => {
             let s = reach.unwrap();
             assert_eq!(s.entries.len(), 3);
             // All prefixes should be present (order may differ for large tables,
@@ -145,20 +142,17 @@ fn update_ipv4_announce_multiple() {
 #[test]
 fn update_ipv4_withdraw() {
     let prefix = ipv4_prefix("10.0.0.0", 8);
-    let msg = Message::Update(Update {
+    let msg = Message::Update(Update::Routes {
         reach: None,
-        mp_reach: None,
         attr: Arc::new(Vec::new()),
-        unreach: Some(NlriSet {
+        unreach: Some(UnreachNlri {
             family: Family::IPV4,
             entries: vec![prefix.clone()],
         }),
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_codec()) {
-        Message::Update(Update { reach, unreach, .. }) => {
+        ParsedMessage::Update(ParsedUpdate::Routes { reach, unreach, .. }) => {
             assert!(reach.is_none());
             let s = unreach.unwrap();
             assert_eq!(s.family, Family::IPV4);
@@ -175,11 +169,11 @@ fn update_ipv6_announce() {
     let prefix = ipv6_prefix("2001:db8::", 32);
     let nexthop_bytes: Vec<u8> = "2001:db8::1".parse::<Ipv6Addr>().unwrap().octets().to_vec();
 
-    let msg = Message::Update(Update {
-        reach: None,
-        mp_reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV6,
             entries: vec![prefix.clone()],
+            nexthop: None,
         }),
         attr: Arc::new(vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
@@ -191,12 +185,10 @@ fn update_ipv6_announce() {
             Attribute::new_with_bin(Attribute::NEXTHOP, nexthop_bytes).unwrap(),
         ]),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv6_codec()) {
-        Message::Update(Update {
+        ParsedMessage::Update(ParsedUpdate::Routes {
             mp_reach,
             mp_unreach,
             ..
@@ -213,20 +205,17 @@ fn update_ipv6_announce() {
 #[test]
 fn update_ipv6_withdraw() {
     let prefix = ipv6_prefix("2001:db8::", 32);
-    let msg = Message::Update(Update {
+    let msg = Message::Update(Update::Routes {
         reach: None,
-        mp_reach: None,
         attr: Arc::new(Vec::new()),
-        unreach: None,
-        mp_unreach: Some(NlriSet {
+        unreach: Some(UnreachNlri {
             family: Family::IPV6,
             entries: vec![prefix.clone()],
         }),
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv6_codec()) {
-        Message::Update(Update {
+        ParsedMessage::Update(ParsedUpdate::Routes {
             mp_reach,
             mp_unreach,
             ..
@@ -246,44 +235,21 @@ fn update_ipv6_withdraw() {
 fn update_eor_ipv4() {
     let msg = Message::eor(Family::IPV4);
     match round_trip(&msg, ipv4_codec()) {
-        Message::Update(Update {
-            reach,
-            unreach,
-            attr,
-            ..
-        }) => {
-            let s = reach.unwrap();
-            assert_eq!(s.family, Family::IPV4);
-            assert!(s.entries.is_empty(), "IPv4 EOR must have empty NLRI");
-            assert!(unreach.is_none());
-            assert!(attr.is_empty());
+        ParsedMessage::Update(ParsedUpdate::EndOfRib(family)) => {
+            assert_eq!(family, Family::IPV4);
         }
-        _ => panic!("expected Update"),
+        _ => panic!("expected EndOfRib(IPV4)"),
     }
 }
 
 #[test]
 fn update_eor_ipv6() {
     let msg = Message::eor(Family::IPV6);
-    // IPv6 EOR: MP_UNREACH with empty prefix list.
-    // After round-trip, the empty unreach list is normalized to None.
     match round_trip(&msg, ipv6_codec()) {
-        Message::Update(Update {
-            reach,
-            unreach,
-            mp_unreach,
-            attr,
-            ..
-        }) => {
-            assert!(reach.is_none());
-            // IPv6 EOR: mp_unreach is present but empty after parsing
-            assert!(unreach.is_none());
-            assert!(
-                mp_unreach.is_none() || mp_unreach.as_ref().map_or(true, |s| s.entries.is_empty())
-            );
-            assert!(attr.is_empty());
+        ParsedMessage::Update(ParsedUpdate::EndOfRib(family)) => {
+            assert_eq!(family, Family::IPV6);
         }
-        _ => panic!("expected Update"),
+        _ => panic!("expected EndOfRib(IPV6)"),
     }
 }
 
@@ -291,22 +257,20 @@ fn update_eor_ipv6() {
 
 #[test]
 fn update_attr_origin_igp() {
-    let msg = Message::Update(Update {
-        reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4,
             entries: vec![ipv4_prefix("10.0.0.0", 8)],
+            nexthop: None,
         }),
-        mp_reach: None,
         attr: ipv4_attrs("192.0.2.254".parse().unwrap()),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_codec()) {
-        Message::Update(Update { attr, reach, .. }) => {
+        ParsedMessage::Update(ParsedUpdate::Routes { attrs, reach, .. }) => {
             assert!(!reach.unwrap().entries.is_empty());
-            let origin = attr
+            let origin = attrs
                 .iter()
                 .find(|a| a.code() == Attribute::ORIGIN)
                 .expect("ORIGIN attribute must be present");
@@ -325,25 +289,24 @@ fn update_attr_med_dropped_on_encode() {
     let mut attrs = (*ipv4_attrs("192.0.2.254".parse().unwrap())).clone();
     attrs.push(Attribute::new_with_value(Attribute::MULTI_EXIT_DESC, med_value).unwrap());
 
-    let msg = Message::Update(Update {
-        reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4,
             entries: vec![ipv4_prefix("10.0.0.0", 8)],
+            nexthop: None,
         }),
-        mp_reach: None,
         attr: Arc::new(attrs),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_codec()) {
-        Message::Update(Update { attr, reach, .. }) => {
+        ParsedMessage::Update(ParsedUpdate::Routes { attrs, reach, .. }) => {
             // Routes should be present (not withdrawn)
             assert!(!reach.unwrap().entries.is_empty());
             // MED is dropped because it's optional non-transitive
             assert!(
-                attr.iter()
+                attrs
+                    .iter()
                     .find(|a| a.code() == Attribute::MULTI_EXIT_DESC)
                     .is_none(),
                 "MED must be dropped on encode (non-transitive optional attribute)"
@@ -372,11 +335,11 @@ fn update_ipv4_with_ipv6_nexthop() {
     let prefix = ipv4_prefix("10.0.0.0", 8);
     let nexthop_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
 
-    let msg = Message::Update(Update {
-        reach: None,
-        mp_reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4,
             entries: vec![prefix.clone()],
+            nexthop: Some(Nexthop::V6(nexthop_v6)),
         }),
         attr: Arc::new(vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
@@ -387,16 +350,11 @@ fn update_ipv4_with_ipv6_nexthop() {
             .unwrap(),
         ]),
         unreach: None,
-        mp_unreach: None,
-        nexthop: Some(Nexthop::V6(nexthop_v6)),
     });
 
     match round_trip(&msg, ipv4_extended_nexthop_codec()) {
-        Message::Update(Update {
-            reach,
-            mp_reach,
-            nexthop,
-            ..
+        ParsedMessage::Update(ParsedUpdate::Routes {
+            reach, mp_reach, ..
         }) => {
             // IPv4 NLRI must come back via mp_reach (not traditional reach)
             assert!(reach.is_none(), "reach must be None for extended nexthop");
@@ -404,7 +362,7 @@ fn update_ipv4_with_ipv6_nexthop() {
             assert_eq!(s.family, Family::IPV4);
             assert_eq!(s.entries, vec![prefix]);
             // Nexthop must be the IPv6 address
-            assert_eq!(nexthop, Some(Nexthop::V6(nexthop_v6)));
+            assert_eq!(s.nexthop, Some(Nexthop::V6(nexthop_v6)));
         }
         _ => panic!("expected Update"),
     }
@@ -413,20 +371,17 @@ fn update_ipv4_with_ipv6_nexthop() {
 #[test]
 fn update_ipv4_extended_nexthop_withdraw() {
     let prefix = ipv4_prefix("10.0.0.0", 8);
-    let msg = Message::Update(Update {
+    let msg = Message::Update(Update::Routes {
         reach: None,
-        mp_reach: None,
         attr: Arc::new(Vec::new()),
-        unreach: None,
-        mp_unreach: Some(NlriSet {
+        unreach: Some(UnreachNlri {
             family: Family::IPV4,
             entries: vec![prefix.clone()],
         }),
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_extended_nexthop_codec()) {
-        Message::Update(Update {
+        ParsedMessage::Update(ParsedUpdate::Routes {
             unreach,
             mp_unreach,
             ..
@@ -449,22 +404,20 @@ fn update_attr_community() {
         Attribute::new_with_bin(Attribute::COMMUNITY, community.to_be_bytes().to_vec()).unwrap(),
     );
 
-    let msg = Message::Update(Update {
-        reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4,
             entries: vec![ipv4_prefix("10.0.0.0", 8)],
+            nexthop: None,
         }),
-        mp_reach: None,
         attr: Arc::new(attrs),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_codec()) {
-        Message::Update(Update { attr, reach, .. }) => {
+        ParsedMessage::Update(ParsedUpdate::Routes { attrs, reach, .. }) => {
             assert!(!reach.unwrap().entries.is_empty());
-            let comm = attr
+            let comm = attrs
                 .iter()
                 .find(|a| a.code() == Attribute::COMMUNITY)
                 .expect("COMMUNITY attribute must be present");
@@ -510,12 +463,12 @@ fn update_ipv4_with_prefix_sid() {
     };
     let sid_bytes = sid.to_vec();
 
-    let msg = Message::Update(Update {
-        reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4,
             entries: vec![prefix.clone()],
+            nexthop: None,
         }),
-        mp_reach: None,
         attr: Arc::new(vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
             Attribute::new_with_bin(
@@ -531,14 +484,12 @@ fn update_ipv4_with_prefix_sid() {
             Attribute::new_with_bin(Attribute::PREFIX_SID, sid_bytes.clone()).unwrap(),
         ]),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_codec()) {
-        Message::Update(Update { reach, attr, .. }) => {
+        ParsedMessage::Update(ParsedUpdate::Routes { reach, attrs, .. }) => {
             assert_eq!(reach.unwrap().entries, vec![prefix]);
-            let a = attr
+            let a = attrs
                 .iter()
                 .find(|a| a.code() == Attribute::PREFIX_SID)
                 .expect("PREFIX_SID must be present");
@@ -564,12 +515,12 @@ fn update_passes_through_unknown_prefix_sid_tlv() {
     let sid_bytes = sid.to_vec();
     assert_eq!(sid_bytes, vec![0x55, 0x00, 0x03, 0xAA, 0xBB, 0xCC]);
 
-    let msg = Message::Update(Update {
-        reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4,
             entries: vec![prefix.clone()],
+            nexthop: None,
         }),
-        mp_reach: None,
         attr: Arc::new(vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
             Attribute::new_with_bin(
@@ -585,13 +536,11 @@ fn update_passes_through_unknown_prefix_sid_tlv() {
             Attribute::new_with_bin(Attribute::PREFIX_SID, sid_bytes.clone()).unwrap(),
         ]),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_codec()) {
-        Message::Update(Update { attr, .. }) => {
-            let a = attr
+        ParsedMessage::Update(ParsedUpdate::Routes { attrs, .. }) => {
+            let a = attrs
                 .iter()
                 .find(|a| a.code() == Attribute::PREFIX_SID)
                 .expect("PREFIX_SID must be present");
@@ -634,11 +583,11 @@ fn update_ipv4_mup_announce() {
         },
     )));
     let nexthop: Ipv4Addr = "10.0.0.1".parse().unwrap();
-    let msg = Message::Update(Update {
-        reach: None,
-        mp_reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4_MUP,
             entries: vec![nlri.clone()],
+            nexthop: None,
         }),
         attr: Arc::new(vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
@@ -650,12 +599,10 @@ fn update_ipv4_mup_announce() {
             Attribute::new_with_bin(Attribute::NEXTHOP, nexthop.octets().to_vec()).unwrap(),
         ]),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_mup_codec()) {
-        Message::Update(Update {
+        ParsedMessage::Update(ParsedUpdate::Routes {
             mp_reach,
             mp_unreach,
             ..
@@ -678,11 +625,11 @@ fn update_ipv6_mup_announce() {
         },
     )));
     let nexthop_bytes: Vec<u8> = "2001:db8::1".parse::<Ipv6Addr>().unwrap().octets().to_vec();
-    let msg = Message::Update(Update {
-        reach: None,
-        mp_reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV6_MUP,
             entries: vec![nlri.clone()],
+            nexthop: None,
         }),
         attr: Arc::new(vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
@@ -694,12 +641,10 @@ fn update_ipv6_mup_announce() {
             Attribute::new_with_bin(Attribute::NEXTHOP, nexthop_bytes).unwrap(),
         ]),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv6_mup_codec()) {
-        Message::Update(Update {
+        ParsedMessage::Update(ParsedUpdate::Routes {
             mp_reach,
             mp_unreach,
             ..
@@ -723,20 +668,17 @@ fn update_mup_withdraw() {
             teid: 0xdead_beef,
         },
     )));
-    let msg = Message::Update(Update {
+    let msg = Message::Update(Update::Routes {
         reach: None,
-        mp_reach: None,
         attr: Arc::new(Vec::new()),
-        unreach: None,
-        mp_unreach: Some(NlriSet {
+        unreach: Some(UnreachNlri {
             family: Family::IPV4_MUP,
             entries: vec![nlri.clone()],
         }),
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_mup_codec()) {
-        Message::Update(Update {
+        ParsedMessage::Update(ParsedUpdate::Routes {
             mp_reach,
             mp_unreach,
             ..
@@ -767,11 +709,11 @@ fn update_mup_with_ext_community() {
     }
     .encode(&mut ec_bytes);
     let nexthop: Ipv4Addr = "10.0.0.1".parse().unwrap();
-    let msg = Message::Update(Update {
-        reach: None,
-        mp_reach: Some(NlriSet {
+    let msg = Message::Update(Update::Routes {
+        reach: Some(ReachNlri {
             family: Family::IPV4_MUP,
             entries: vec![nlri.clone()],
+            nexthop: None,
         }),
         attr: Arc::new(vec![
             Attribute::new_with_value(Attribute::ORIGIN, 0).unwrap(),
@@ -784,15 +726,15 @@ fn update_mup_with_ext_community() {
             Attribute::new_with_bin(Attribute::EXTENDED_COMMUNITY, ec_bytes.clone()).unwrap(),
         ]),
         unreach: None,
-        mp_unreach: None,
-        nexthop: None,
     });
 
     match round_trip(&msg, ipv4_mup_codec()) {
-        Message::Update(Update { mp_reach, attr, .. }) => {
+        ParsedMessage::Update(ParsedUpdate::Routes {
+            mp_reach, attrs, ..
+        }) => {
             let s = mp_reach.unwrap();
             assert_eq!(s.entries, vec![nlri]);
-            let ec = attr
+            let ec = attrs
                 .iter()
                 .find(|a| a.code() == Attribute::EXTENDED_COMMUNITY)
                 .expect("EXTENDED_COMMUNITY missing");

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -469,16 +469,14 @@ pub struct Reach {
 
 impl From<Reach> for bgp::Message {
     fn from(c: Reach) -> bgp::Message {
-        bgp::Message::Update(bgp::Update {
-            reach: Some(packet::bgp::NlriSet {
+        bgp::Message::Update(bgp::Update::Routes {
+            reach: Some(packet::bgp::ReachNlri {
                 family: c.family,
                 entries: vec![c.net],
+                nexthop: c.nexthop,
             }),
-            mp_reach: None,
-            attr: c.attr,
             unreach: None,
-            mp_unreach: None,
-            nexthop: c.nexthop,
+            attr: c.attr,
         })
     }
 }


### PR DESCRIPTION
…g logic

The packet crate previously blurred the boundary between wire-format parsing and BGP routing logic by carrying Tx/Rx type distinctions and routing parameters (local_asn) in PeerCodec.

This refactor establishes a clean two-layer model:
- ParsedMessage: raw wire-format parse result from PeerCodec::try_parse
- validate_message(): RFC 7606 normalization at the packet/daemon boundary, returning an iterator of Message values
- Message: single unified type used throughout the daemon for both Tx and Rx

ReachNlri and UnreachNlri pair NLRIs with their address family, hiding MP_REACH/MP_UNREACH wire-format details from the daemon. Update gains an explicit EndOfRib(Family) variant, eliminating the implicit empty-routes convention.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>