### PR TITLE
packet,daemon: add typed Cease variants to Notification

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -1579,11 +1579,8 @@ impl GoBgpService for GrpcService {
         request: tonic::Request<api::StopBgpRequest>,
     ) -> Result<tonic::Response<api::StopBgpResponse>, tonic::Status> {
         let allow_gr = request.into_inner().allow_graceful_restart;
-        let cease = bgp::Message::Notification(rustybgp_packet::Notification::Other {
-            code: 6,
-            subcode: 3,
-            data: vec![],
-        });
+        let cease =
+            bgp::Message::Notification(rustybgp_packet::Notification::CeasePeerDeconfigured);
 
         let mut global = self.global.write().await;
         if global.asn == 0 {
@@ -1691,11 +1688,7 @@ impl GoBgpService for GrpcService {
                     let mut ctx = p.context.lock().unwrap();
                     ctx.force_down(
                         CloseReason::SendMessage(bgp::Message::Notification(
-                            rustybgp_packet::Notification::Other {
-                                code: 6,
-                                subcode: 3,
-                                data: vec![],
-                            },
+                            rustybgp_packet::Notification::CeasePeerDeconfigured,
                         )),
                         true,
                     );
@@ -1870,11 +1863,7 @@ impl GoBgpService for GrpcService {
                 let mut ctx = peer.context.lock().unwrap();
                 ctx.force_down(
                     CloseReason::SendMessage(bgp::Message::Notification(
-                        rustybgp_packet::Notification::Other {
-                            code: 6,
-                            subcode: 3,
-                            data: vec![],
-                        },
+                        rustybgp_packet::Notification::CeasePeerDeconfigured,
                     )),
                     true,
                 );
@@ -1924,11 +1913,7 @@ impl GoBgpService for GrpcService {
             let mut ctx = peer.context.lock().unwrap();
             ctx.force_down(
                 CloseReason::SendMessage(bgp::Message::Notification(
-                    rustybgp_packet::Notification::Other {
-                        code: 6,
-                        subcode: 3,
-                        data: vec![],
-                    },
+                    rustybgp_packet::Notification::CeasePeerDeconfigured,
                 )),
                 false,
             );
@@ -5710,11 +5695,9 @@ impl PeerSession {
             }
             let rx_timestamp = std::time::SystemTime::now();
             if self.rx_update(reach, unreach, attr, rx_timestamp).await {
-                let cease = bgp::Message::Notification(rustybgp_packet::Notification::Other {
-                    code: 6,
-                    subcode: 1,
-                    data: vec![],
-                });
+                let cease = bgp::Message::Notification(
+                    rustybgp_packet::Notification::CeaseMaxPrefixReached,
+                );
                 self.urgent.insert(0, cease.clone());
                 self.shutdown = Some(crate::fsm::SessionDownReason::LocalNotification(cease));
                 return Ok(());
@@ -7620,11 +7603,7 @@ mod tests {
     }
 
     fn cease_notification() -> bgp::Message {
-        bgp::Message::Notification(packet::Notification::Other {
-            code: 6,    // Cease
-            subcode: 7, // Connection Collision Resolution
-            data: vec![],
-        })
+        bgp::Message::Notification(packet::Notification::CeaseConnectionCollision)
     }
 
     /// Helper: add a peer and return a passive PeerSession via accept_connection.
@@ -8529,8 +8508,11 @@ mod tests {
 
     #[test]
     fn gr_on_disconnect_hard_reset_never_applies() {
-        assert!(gr_on_disconnect(&Some(cease(9)), make_negotiated_gr(false)).is_none());
-        assert!(gr_on_disconnect(&Some(cease(9)), make_negotiated_gr(true)).is_none());
+        let hard_reset = crate::fsm::SessionDownReason::RemoteNotification(
+            bgp::Message::Notification(rustybgp_packet::Notification::CeaseHardReset),
+        );
+        assert!(gr_on_disconnect(&Some(hard_reset.clone()), make_negotiated_gr(false)).is_none());
+        assert!(gr_on_disconnect(&Some(hard_reset), make_negotiated_gr(true)).is_none());
     }
 
     #[test]
@@ -8541,7 +8523,10 @@ mod tests {
 
     #[test]
     fn gr_on_disconnect_local_hard_reset_never_applies() {
-        assert!(gr_on_disconnect(&Some(local_cease(9)), make_negotiated_gr(true)).is_none());
+        let hard_reset = crate::fsm::SessionDownReason::LocalNotification(
+            bgp::Message::Notification(rustybgp_packet::Notification::CeaseHardReset),
+        );
+        assert!(gr_on_disconnect(&Some(hard_reset), make_negotiated_gr(true)).is_none());
     }
 
     #[test]

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -367,7 +367,12 @@ impl Connection {
     fn on_hold_timer_expired(&mut self) -> Vec<Output> {
         match self.state {
             State::OpenSent | State::OpenConfirm | State::Established => {
-                vec![Output::SessionDown(SessionDownReason::HoldTimerExpired)]
+                let notif =
+                    bgp::Message::Notification(rustybgp_packet::Notification::HoldTimerExpired);
+                vec![
+                    Output::SendMessage(notif),
+                    Output::SessionDown(SessionDownReason::HoldTimerExpired),
+                ]
             }
             _ => Vec::new(),
         }

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -392,11 +392,7 @@ impl Connection {
     fn on_admin_shutdown(&mut self) -> Vec<Output> {
         vec![
             Output::SendMessage(bgp::Message::Notification(
-                rustybgp_packet::Notification::Other {
-                    code: 6,
-                    subcode: 2,
-                    data: vec![],
-                },
+                rustybgp_packet::Notification::CeaseAdminShutdown,
             )),
             Output::SessionDown(SessionDownReason::AdminShutdown),
         ]
@@ -629,11 +625,7 @@ impl PeerFsm {
         let outputs = vec![PeerFsmOutput::Connection(
             loser,
             Output::SendMessage(bgp::Message::Notification(
-                rustybgp_packet::Notification::Other {
-                    code: 6,    // Cease
-                    subcode: 7, // Connection Collision Resolution
-                    data: vec![],
-                },
+                rustybgp_packet::Notification::CeaseConnectionCollision,
             )),
         )];
 

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -256,11 +256,7 @@ impl Connection {
         // Validate ASN if pre-configured
         if self.expected_remote_asn != 0 && self.expected_remote_asn != open.as_number {
             out.push(Output::SendMessage(bgp::Message::Notification(
-                rustybgp_packet::Notification::Other {
-                    code: 2,
-                    subcode: 2,
-                    data: vec![],
-                },
+                rustybgp_packet::Notification::OpenBadPeerAs,
             )));
             out.push(Output::SessionDown(SessionDownReason::AdminShutdown));
             return out;

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -53,6 +53,10 @@ pub enum Notification {
     #[error("update error: optional attribute error")]
     UpdateOptionalAttributeError,
 
+    // Code 4: Hold Timer Expired
+    #[error("hold timer expired")]
+    HoldTimerExpired,
+
     // Code 5: FSM Error
     #[error("FSM error: unexpected state {state}")]
     FsmUnexpectedState { state: u8 },
@@ -92,6 +96,7 @@ impl Notification {
             | Self::OpenUnsupportedOptionalParameter { .. }
             | Self::OpenUnacceptableHoldTime { .. } => 2,
             Self::UpdateMalformedAttributeList | Self::UpdateOptionalAttributeError => 3,
+            Self::HoldTimerExpired => 4,
             Self::FsmUnexpectedState { .. } => 5,
             Self::CeaseMaxPrefixReached
             | Self::CeaseAdminShutdown
@@ -114,6 +119,7 @@ impl Notification {
             Self::OpenUnacceptableHoldTime { .. } => 6,
             Self::UpdateMalformedAttributeList => 1,
             Self::UpdateOptionalAttributeError => 9,
+            Self::HoldTimerExpired => 0,
             Self::FsmUnexpectedState { state } => *state,
             Self::CeaseMaxPrefixReached => 1,
             Self::CeaseAdminShutdown => 2,
@@ -155,6 +161,7 @@ impl Notification {
             (2, 6) => Self::OpenUnacceptableHoldTime { data },
             (3, 1) => Self::UpdateMalformedAttributeList,
             (3, 9) => Self::UpdateOptionalAttributeError,
+            (4, _) => Self::HoldTimerExpired,
             (5, state) => Self::FsmUnexpectedState { state },
             (6, 1) => Self::CeaseMaxPrefixReached,
             (6, 2) => Self::CeaseAdminShutdown,

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -40,6 +40,8 @@ pub enum Notification {
     // Code 2: OPEN Message Error
     #[error("open error: malformed")]
     OpenMalformed,
+    #[error("open error: bad peer AS")]
+    OpenBadPeerAs,
     #[error("open error: unsupported optional parameter")]
     OpenUnsupportedOptionalParameter { data: Vec<u8> },
     #[error("open error: unacceptable hold time")]
@@ -86,6 +88,7 @@ impl Notification {
         match self {
             Self::BadMessageLength { .. } | Self::BadMessageType { .. } => 1,
             Self::OpenMalformed
+            | Self::OpenBadPeerAs
             | Self::OpenUnsupportedOptionalParameter { .. }
             | Self::OpenUnacceptableHoldTime { .. } => 2,
             Self::UpdateMalformedAttributeList | Self::UpdateOptionalAttributeError => 3,
@@ -106,6 +109,7 @@ impl Notification {
             Self::BadMessageLength { .. } => 2,
             Self::BadMessageType { .. } => 3,
             Self::OpenMalformed => 0,
+            Self::OpenBadPeerAs => 2,
             Self::OpenUnsupportedOptionalParameter { .. } => 4,
             Self::OpenUnacceptableHoldTime { .. } => 6,
             Self::UpdateMalformedAttributeList => 1,
@@ -146,6 +150,7 @@ impl Notification {
             (1, 2) => Self::BadMessageLength { data },
             (1, 3) => Self::BadMessageType { data },
             (2, 0) => Self::OpenMalformed,
+            (2, 2) => Self::OpenBadPeerAs,
             (2, 4) => Self::OpenUnsupportedOptionalParameter { data },
             (2, 6) => Self::OpenUnacceptableHoldTime { data },
             (3, 1) => Self::UpdateMalformedAttributeList,

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -2547,7 +2547,12 @@ impl PeerCodec {
                     ),
                 ))
             }
-            Message::KEEPALIVE => Ok(ParsedMessage::Keepalive),
+            Message::KEEPALIVE => {
+                if buf.len() != Message::HEADER_LENGTH as usize {
+                    return Err(header_len_error);
+                }
+                Ok(ParsedMessage::Keepalive)
+            }
             Message::ROUTE_REFRESH => {
                 const ROUTE_REFRESH_LENGTH: usize = Message::HEADER_LENGTH as usize + 4;
                 if buf.len() < ROUTE_REFRESH_LENGTH {

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -272,6 +272,8 @@ impl Family {
 
     const SAFI_UNICAST: u8 = 1;
     const SAFI_MUP: u8 = 85;
+    const SAFI_FLOWSPEC: u8 = 133;
+    const SAFI_FLOWSPEC_VPN: u8 = 134;
     const SAFI_MPLS_VPN: u8 = 128;
     const SAFI_MPLS_VPN6: u8 = 129;
 
@@ -2411,8 +2413,13 @@ impl PeerCodec {
                     }
                     let mut data = Vec::with_capacity(nexthop_len as usize);
                     match nexthop_len {
-                        // Flowspec and similar AFIs carry no nexthop (RFC 5575 §4).
-                        0 => {}
+                        // FlowSpec carries no nexthop (RFC 8955 §4). Any other
+                        // family with nexthop_len=0 is malformed.
+                        0 if matches!(
+                            mp_reach_family.safi(),
+                            Family::SAFI_FLOWSPEC | Family::SAFI_FLOWSPEC_VPN
+                        ) => {}
+                        0 => return Err(err),
                         4 | 16 | 32 => {
                             for _ in 0..nexthop_len {
                                 data.push(c.read_u8().unwrap());

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -40,8 +40,12 @@ pub enum Notification {
     // Code 2: OPEN Message Error
     #[error("open error: malformed")]
     OpenMalformed,
+    #[error("open error: unsupported version number")]
+    OpenUnsupportedVersionNumber { data: Vec<u8> },
     #[error("open error: bad peer AS")]
     OpenBadPeerAs,
+    #[error("open error: bad BGP identifier")]
+    OpenBadBgpIdentifier,
     #[error("open error: unsupported optional parameter")]
     OpenUnsupportedOptionalParameter { data: Vec<u8> },
     #[error("open error: unacceptable hold time")]
@@ -92,7 +96,9 @@ impl Notification {
         match self {
             Self::BadMessageLength { .. } | Self::BadMessageType { .. } => 1,
             Self::OpenMalformed
+            | Self::OpenUnsupportedVersionNumber { .. }
             | Self::OpenBadPeerAs
+            | Self::OpenBadBgpIdentifier
             | Self::OpenUnsupportedOptionalParameter { .. }
             | Self::OpenUnacceptableHoldTime { .. } => 2,
             Self::UpdateMalformedAttributeList | Self::UpdateOptionalAttributeError => 3,
@@ -114,7 +120,9 @@ impl Notification {
             Self::BadMessageLength { .. } => 2,
             Self::BadMessageType { .. } => 3,
             Self::OpenMalformed => 0,
+            Self::OpenUnsupportedVersionNumber { .. } => 1,
             Self::OpenBadPeerAs => 2,
+            Self::OpenBadBgpIdentifier => 3,
             Self::OpenUnsupportedOptionalParameter { .. } => 4,
             Self::OpenUnacceptableHoldTime { .. } => 6,
             Self::UpdateMalformedAttributeList => 1,
@@ -136,6 +144,7 @@ impl Notification {
         match self {
             Self::BadMessageLength { data }
             | Self::BadMessageType { data }
+            | Self::OpenUnsupportedVersionNumber { data }
             | Self::OpenUnsupportedOptionalParameter { data }
             | Self::OpenUnacceptableHoldTime { data }
             | Self::RouteRefreshInvalidLength { data }
@@ -156,7 +165,9 @@ impl Notification {
             (1, 2) => Self::BadMessageLength { data },
             (1, 3) => Self::BadMessageType { data },
             (2, 0) => Self::OpenMalformed,
+            (2, 1) => Self::OpenUnsupportedVersionNumber { data },
             (2, 2) => Self::OpenBadPeerAs,
+            (2, 3) => Self::OpenBadBgpIdentifier,
             (2, 4) => Self::OpenUnsupportedOptionalParameter { data },
             (2, 6) => Self::OpenUnacceptableHoldTime { data },
             (3, 1) => Self::UpdateMalformedAttributeList,
@@ -2101,7 +2112,10 @@ impl PeerCodec {
                 let version = c.read_u8().unwrap();
                 // BGP version must be 4 (RFC 4271 §4.2)
                 if version != 4 {
-                    return Err(Notification::OpenMalformed);
+                    // data: 2-octet max supported version (RFC 4271 §6.2)
+                    return Err(Notification::OpenUnsupportedVersionNumber {
+                        data: 4u16.to_be_bytes().to_vec(),
+                    });
                 }
                 let mut as_number = c.read_u16::<NetworkEndian>().unwrap() as u32;
                 let raw_holdtime = c.read_u16::<NetworkEndian>().unwrap();
@@ -2110,6 +2124,14 @@ impl PeerCodec {
                         data: raw_holdtime.to_be_bytes().to_vec(),
                     })?;
                 let router_id = c.read_u32::<NetworkEndian>().unwrap();
+                // BGP Identifier must be a valid unicast address (RFC 4271 §6.2)
+                let router_id_addr = Ipv4Addr::from(router_id);
+                if router_id_addr.is_unspecified()
+                    || router_id_addr.is_broadcast()
+                    || router_id_addr.is_multicast()
+                {
+                    return Err(Notification::OpenBadBgpIdentifier);
+                }
                 let param_len = c.read_u8().unwrap();
                 if buf.len() < MINIMUM_OPEN_LENGTH + param_len as usize {
                     return Err(Notification::OpenMalformed);

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -55,6 +55,18 @@ pub enum Notification {
     #[error("FSM error: unexpected state {state}")]
     FsmUnexpectedState { state: u8 },
 
+    // Code 6: Cease (RFC 4486)
+    #[error("cease: maximum number of prefixes reached")]
+    CeaseMaxPrefixReached,
+    #[error("cease: administrative shutdown")]
+    CeaseAdminShutdown,
+    #[error("cease: peer deconfigured")]
+    CeasePeerDeconfigured,
+    #[error("cease: connection collision resolution")]
+    CeaseConnectionCollision,
+    #[error("cease: hard reset")]
+    CeaseHardReset,
+
     // Code 7: ROUTE-REFRESH Message Error
     #[error("route-refresh error: invalid message length")]
     RouteRefreshInvalidLength { data: Vec<u8> },
@@ -78,6 +90,11 @@ impl Notification {
             | Self::OpenUnacceptableHoldTime { .. } => 2,
             Self::UpdateMalformedAttributeList | Self::UpdateOptionalAttributeError => 3,
             Self::FsmUnexpectedState { .. } => 5,
+            Self::CeaseMaxPrefixReached
+            | Self::CeaseAdminShutdown
+            | Self::CeasePeerDeconfigured
+            | Self::CeaseConnectionCollision
+            | Self::CeaseHardReset => 6,
             Self::RouteRefreshInvalidLength { .. } => 7,
             Self::Other { code, .. } => *code,
         }
@@ -94,6 +111,11 @@ impl Notification {
             Self::UpdateMalformedAttributeList => 1,
             Self::UpdateOptionalAttributeError => 9,
             Self::FsmUnexpectedState { state } => *state,
+            Self::CeaseMaxPrefixReached => 1,
+            Self::CeaseAdminShutdown => 2,
+            Self::CeasePeerDeconfigured => 3,
+            Self::CeaseConnectionCollision => 7,
+            Self::CeaseHardReset => 9,
             Self::RouteRefreshInvalidLength { .. } => 1,
             Self::Other { subcode, .. } => *subcode,
         }
@@ -115,14 +137,7 @@ impl Notification {
     /// Returns true if this is a CEASE Hard Reset (RFC 8538 §3: code 6, subcode 9).
     /// Hard Reset terminates GR even when the N-bit is negotiated.
     pub fn is_hard_reset(&self) -> bool {
-        matches!(
-            self,
-            Self::Other {
-                code: 6,
-                subcode: 9,
-                ..
-            }
-        )
+        matches!(self, Self::CeaseHardReset)
     }
 
     /// Constructs a `Notification` from a received NOTIFICATION message.
@@ -136,6 +151,11 @@ impl Notification {
             (3, 1) => Self::UpdateMalformedAttributeList,
             (3, 9) => Self::UpdateOptionalAttributeError,
             (5, state) => Self::FsmUnexpectedState { state },
+            (6, 1) => Self::CeaseMaxPrefixReached,
+            (6, 2) => Self::CeaseAdminShutdown,
+            (6, 3) => Self::CeasePeerDeconfigured,
+            (6, 7) => Self::CeaseConnectionCollision,
+            (6, 9) => Self::CeaseHardReset,
             (7, 1) => Self::RouteRefreshInvalidLength { data },
             _ => Self::Other {
                 code,
@@ -2646,12 +2666,9 @@ mod notification_tests {
 
     #[test]
     fn hard_reset_is_cease_subcode_9() {
-        let err = Notification::Other {
-            code: 6,
-            subcode: 9,
-            data: vec![],
-        };
-        assert!(err.is_hard_reset());
+        assert!(Notification::CeaseHardReset.is_hard_reset());
+        // from_notification maps (6,9) to CeaseHardReset
+        assert!(Notification::from_notification(6, 9, vec![]).is_hard_reset());
     }
 
     #[test]

--- a/packet/tests/bgp_misc.rs
+++ b/packet/tests/bgp_misc.rs
@@ -60,6 +60,17 @@ fn keepalive_round_trip() {
     }
 }
 
+#[test]
+fn keepalive_with_extra_body_is_error() {
+    // RFC 4271 §4.4: KEEPALIVE must be exactly 19 bytes (header only).
+    let buf = bgp_msg(4, &[0x00]); // 20 bytes
+    let mut codec = default_codec();
+    match codec.parse_message(&buf) {
+        Err(Notification::BadMessageLength { .. }) => {}
+        other => panic!("expected BadMessageLength, got {:?}", other.err()),
+    }
+}
+
 // ─── NOTIFICATION ────────────────────────────────────────────────────────────
 
 #[test]

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -14,13 +14,13 @@
 // limitations under the License.
 
 use rustybgp_packet::bgp::{
-    Attribute, Capability, Ipv4Net, Ipv6Net, Message, Nexthop, ParsedMessage, ParsedUpdate,
-    PeerCodec, ReachNlri, UnreachNlri, Update,
+    Attribute, Capability, FamilyState, Ipv4Net, Ipv6Net, Message, Nexthop, ParsedMessage,
+    ParsedUpdate, PeerCodec, ReachNlri, UnreachNlri, Update,
 };
 use rustybgp_packet::mup;
 use rustybgp_packet::prefix_sid;
 use rustybgp_packet::rd::RouteDistinguisher;
-use rustybgp_packet::{Family, Nlri, PathNlri};
+use rustybgp_packet::{Family, Nlri, Notification, PathNlri};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 
@@ -732,4 +732,57 @@ fn update_mup_with_ext_community() {
         }
         _ => panic!("expected Update"),
     }
+}
+
+// ─── MP_REACH_NLRI nexthop_len=0 (RFC 8955 §4 / GoBGP issue #3450) ──────────
+
+fn mp_reach_zero_nexthop_update(afi: u16, safi: u8) -> Vec<u8> {
+    // Builds a minimal UPDATE with one MP_REACH_NLRI attribute that has
+    // nexthop_len=0 and no NLRI entries.
+    let attr: Vec<u8> = vec![
+        0x80,
+        0x0E, // flags=optional|non-transitive, type=MP_REACH_NLRI(14)
+        0x05, // attr length = 5
+        (afi >> 8) as u8,
+        afi as u8, // AFI
+        safi,      // SAFI
+        0x00,      // nexthop_len = 0
+        0x00,      // SNPA count = 0
+    ];
+    let attr_len = attr.len() as u16;
+    let total = 19u16 + 2 + 2 + attr_len;
+    let mut buf = vec![0xff; 16];
+    buf.extend_from_slice(&total.to_be_bytes());
+    buf.push(2); // UPDATE
+    buf.extend_from_slice(&0u16.to_be_bytes()); // withdrawn_len
+    buf.extend_from_slice(&attr_len.to_be_bytes()); // total_attr_len
+    buf.extend_from_slice(&attr);
+    buf
+}
+
+#[test]
+fn mp_reach_zero_nexthop_non_flowspec_is_error() {
+    // nexthop_len=0 for IPv4 unicast (non-FlowSpec) must be rejected per
+    // RFC 4760 §3 -- BIRD rejects this with bgp_parse_error (GoBGP #3450).
+    let buf = mp_reach_zero_nexthop_update(Family::AFI_IP, 1);
+    let mut codec = PeerCodec::new();
+    codec.set_family(Family::IPV4, FamilyState::default());
+    match codec.parse_message(&buf) {
+        Err(Notification::UpdateOptionalAttributeError) => {}
+        Err(e) => panic!("expected UpdateOptionalAttributeError, got Err({})", e),
+        Ok(_) => panic!("expected Err, got Ok"),
+    }
+}
+
+#[test]
+fn mp_reach_zero_nexthop_flowspec_is_ok() {
+    // nexthop_len=0 is valid for FlowSpec (RFC 8955 §4).
+    let ipv4_flowspec = Family::new((Family::AFI_IP as u32) << 16 | 133);
+    let buf = mp_reach_zero_nexthop_update(Family::AFI_IP, 133);
+    let mut codec = PeerCodec::new();
+    codec.set_family(ipv4_flowspec, FamilyState::default());
+    assert!(
+        codec.parse_message(&buf).is_ok(),
+        "FlowSpec nexthop_len=0 must be accepted"
+    );
 }


### PR DESCRIPTION
All CEASE subcodes (code 6) used by RustyBGP fell through to the Other catch-all, making pattern matching fragile and error messages opaque.  Add typed variants for the subcodes that are actually sent or received:

- CeaseMaxPrefixReached  (subcode 1, RFC 4486)
- CeaseAdminShutdown     (subcode 2, RFC 4486)
- CeasePeerDeconfigured  (subcode 3, RFC 4486)
- CeaseConnectionCollision (subcode 7, RFC 4486)
- CeaseHardReset         (subcode 9, RFC 8538)

from_notification() maps incoming NOTIFICATION bytes to these variants, so received messages now decode correctly.  is_hard_reset() is simplified to a single-variant match.  All call sites in fsm.rs and event.rs are updated to use the typed variants.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>