### PR TITLE
packet,daemon: discard iBGP-only attributes received from eBGP peers

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -5896,7 +5896,8 @@ impl PeerSession {
                                         Some(parsed) => {
                                             // Count one wire frame before validate_message moves `parsed`.
                                             (*self.counter_rx).sync_rx(&parsed);
-                                            match bgp::validate_message(parsed) {
+                                            let is_ebgp = matches!(self.export_ctx.role, PeerRole::Ebgp);
+                                            match bgp::validate_message(parsed, is_ebgp) {
                                                 Err(notif) => {
                                                     self.urgent.insert(0, bgp::Message::Notification(notif.clone()));
                                                     self.shutdown = Some(crate::fsm::SessionDownReason::LocalNotification(bgp::Message::Notification(notif)));

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -1618,14 +1618,21 @@ pub enum ParsedMessage {
 
 /// Validate a parsed BGP message and normalize it into send-path `Message`s.
 ///
+/// `is_ebgp` must be `true` when the message was received from a non-confederation
+/// eBGP peer.  When true, LOCAL_PREF, ORIGINATOR_ID, and CLUSTER_LIST are silently
+/// discarded per RFC 4271 §5.1.5 and RFC 4456 §8.
+///
 /// Returns `Err(Notification)` when the session must send that `Notification`
 /// and close.  Returns `Ok(iter)` otherwise; the iterator yields the resulting
 /// `Message`s (normally 1, 2 for a multi-family UPDATE, 0 for discard-only
 /// attribute errors with no NLRIs).
-pub fn validate_message(msg: ParsedMessage) -> Result<impl Iterator<Item = Message>, Notification> {
+pub fn validate_message(
+    msg: ParsedMessage,
+    is_ebgp: bool,
+) -> Result<impl Iterator<Item = Message>, Notification> {
     let msgs: Vec<Message> = match msg {
         ParsedMessage::Open(open) => vec![Message::Open(open)],
-        ParsedMessage::Update(update) => validate_update(update)?,
+        ParsedMessage::Update(update) => validate_update(update, is_ebgp)?,
         ParsedMessage::Notification(n) => vec![Message::Notification(n)],
         ParsedMessage::Keepalive => vec![Message::Keepalive],
         ParsedMessage::RouteRefresh { family } => vec![Message::RouteRefresh { family }],
@@ -1633,7 +1640,7 @@ pub fn validate_message(msg: ParsedMessage) -> Result<impl Iterator<Item = Messa
     Ok(msgs.into_iter())
 }
 
-fn validate_update(update: ParsedUpdate) -> Result<Vec<Message>, Notification> {
+fn validate_update(update: ParsedUpdate, is_ebgp: bool) -> Result<Vec<Message>, Notification> {
     match update {
         ParsedUpdate::EndOfRib(family) => Ok(vec![Message::Update(Update::EndOfRib(family))]),
         ParsedUpdate::Routes {
@@ -1671,6 +1678,24 @@ fn validate_update(update: ParsedUpdate) -> Result<Vec<Message>, Notification> {
                 }
                 return Ok(msgs);
             }
+
+            // RFC 4271 §5.1.5, RFC 4456 §8: discard iBGP-only attributes received
+            // from non-confederation eBGP peers.
+            let attrs: Vec<Attribute> = if is_ebgp {
+                attrs
+                    .into_iter()
+                    .filter(|a| {
+                        !matches!(
+                            a.code(),
+                            Attribute::LOCAL_PREF
+                                | Attribute::ORIGINATOR_ID
+                                | Attribute::CLUSTER_LIST
+                        )
+                    })
+                    .collect()
+            } else {
+                attrs
+            };
 
             // Normal path: attribute-discard errors are already absent from attrs.
             let attr = Arc::new(attrs);

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -1255,7 +1255,7 @@ fn invalid_origin_value_treat_as_withdraw() {
     let parsed = ipv4_codec()
         .parse_message(&buf)
         .expect("parse must not fail");
-    let msgs: Vec<Message> = validate_message(parsed).unwrap().collect();
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
     assert_eq!(msgs.len(), 1);
     assert!(
         matches!(&msgs[0], Message::Update(Update::Unreach { .. })),
@@ -1276,7 +1276,7 @@ fn malformed_community_length_treat_as_withdraw() {
     let parsed = ipv4_codec()
         .parse_message(&buf)
         .expect("parse must not fail");
-    let msgs: Vec<Message> = validate_message(parsed).unwrap().collect();
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
     assert_eq!(msgs.len(), 1);
     assert!(
         matches!(&msgs[0], Message::Update(Update::Unreach { .. })),
@@ -1297,7 +1297,7 @@ fn malformed_aggregator_length_treat_as_withdraw() {
     let parsed = ipv4_codec()
         .parse_message(&buf)
         .expect("parse must not fail");
-    let msgs: Vec<Message> = validate_message(parsed).unwrap().collect();
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
     assert_eq!(msgs.len(), 1);
     assert!(
         matches!(&msgs[0], Message::Update(Update::Unreach { .. })),
@@ -1318,7 +1318,7 @@ fn malformed_cluster_list_length_discarded() {
     let parsed = ipv4_codec()
         .parse_message(&buf)
         .expect("parse must not fail");
-    let msgs: Vec<Message> = validate_message(parsed).unwrap().collect();
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
     // The route must still be accepted; CLUSTER_LIST is silently discarded.
     assert_eq!(msgs.len(), 1);
     assert!(
@@ -1357,7 +1357,7 @@ fn malformed_aspath_truncated_segment_treat_as_withdraw() {
     let parsed = ipv4_codec()
         .parse_message(&buf)
         .expect("parse must not fail");
-    let msgs: Vec<Message> = validate_message(parsed).unwrap().collect();
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
     assert_eq!(msgs.len(), 1);
     assert!(
         matches!(&msgs[0], Message::Update(Update::Unreach { .. })),
@@ -1386,10 +1386,79 @@ fn malformed_aspath_invalid_segment_type_treat_as_withdraw() {
     let parsed = ipv4_codec()
         .parse_message(&buf)
         .expect("parse must not fail");
-    let msgs: Vec<Message> = validate_message(parsed).unwrap().collect();
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
     assert_eq!(msgs.len(), 1);
     assert!(
         matches!(&msgs[0], Message::Update(Update::Unreach { .. })),
         "invalid AS_PATH segment type must trigger treat-as-withdraw"
     );
+}
+
+// ─── eBGP attribute filtering (RFC 4271 §5.1.5, RFC 4456 §8) ─────────────────
+
+/// Build a raw IPv4 UPDATE that carries LOCAL_PREF, ORIGINATOR_ID, and CLUSTER_LIST
+/// in addition to the minimal well-known attributes and the NLRI 10.0.0.0/8.
+fn raw_update_with_ibgp_attrs() -> Vec<u8> {
+    let mut attr_bytes = Vec::new();
+    attr_bytes.extend_from_slice(&[0x40, 0x01, 0x01, 0x00]); // ORIGIN=IGP
+    attr_bytes.extend_from_slice(&base_attrs_without_origin());
+    // LOCAL_PREF = 100 (flags: well-known discretionary = transitive)
+    attr_bytes.extend_from_slice(&[0x40, 0x05, 0x04, 0x00, 0x00, 0x00, 0x64]);
+    // ORIGINATOR_ID = 192.0.2.1 (flags: optional non-transitive)
+    attr_bytes.extend_from_slice(&[0x80, 0x09, 0x04, 0xC0, 0x00, 0x02, 0x01]);
+    // CLUSTER_LIST = [0x00000001] (flags: optional non-transitive)
+    attr_bytes.extend_from_slice(&[0x80, 0x0A, 0x04, 0x00, 0x00, 0x00, 0x01]);
+    raw_update_with_attrs(&attr_bytes)
+}
+
+#[test]
+fn ebgp_discards_local_pref_originator_id_cluster_list() {
+    // LOCAL_PREF, ORIGINATOR_ID, and CLUSTER_LIST MUST be discarded when received
+    // from a non-confederation eBGP peer (RFC 4271 §5.1.5, RFC 4456 §8).
+    let buf = raw_update_with_ibgp_attrs();
+    let parsed = ipv4_codec()
+        .parse_message(&buf)
+        .expect("parse must not fail");
+    let msgs: Vec<Message> = validate_message(parsed, true).unwrap().collect();
+
+    assert_eq!(msgs.len(), 1);
+    assert!(
+        matches!(&msgs[0], Message::Update(Update::Reach { .. })),
+        "route must be accepted despite iBGP-only attributes"
+    );
+    if let Message::Update(Update::Reach { attr, .. }) = &msgs[0] {
+        assert!(
+            attr.iter().all(|a| !matches!(
+                a.code(),
+                Attribute::LOCAL_PREF | Attribute::ORIGINATOR_ID | Attribute::CLUSTER_LIST
+            )),
+            "LOCAL_PREF, ORIGINATOR_ID, CLUSTER_LIST must be absent after eBGP filtering"
+        );
+    }
+}
+
+#[test]
+fn ibgp_retains_local_pref_originator_id_cluster_list() {
+    // The same attributes MUST be retained when received from an iBGP peer.
+    let buf = raw_update_with_ibgp_attrs();
+    let parsed = ipv4_codec()
+        .parse_message(&buf)
+        .expect("parse must not fail");
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
+
+    assert_eq!(msgs.len(), 1);
+    if let Message::Update(Update::Reach { attr, .. }) = &msgs[0] {
+        assert!(
+            attr.iter().any(|a| a.code() == Attribute::LOCAL_PREF),
+            "LOCAL_PREF must be retained for iBGP"
+        );
+        assert!(
+            attr.iter().any(|a| a.code() == Attribute::ORIGINATOR_ID),
+            "ORIGINATOR_ID must be retained for iBGP"
+        );
+        assert!(
+            attr.iter().any(|a| a.code() == Attribute::CLUSTER_LIST),
+            "CLUSTER_LIST must be retained for iBGP"
+        );
+    }
 }


### PR DESCRIPTION
LOCAL_PREF must not be accepted from non-confederation eBGP peers (RFC 4271 §5.1.5). ORIGINATOR_ID and CLUSTER_LIST are route-reflector attributes that must be silently discarded when received from eBGP peers (RFC 4456 §8). Confederation-internal eBGP (ConfedEbgp) is excluded from this filtering because LOCAL_PREF and RR attributes are propagated within a confederation (RFC 5065 §5).

Add is_ebgp: bool to validate_message and validate_update. The daemon derives the flag from PeerRole::Ebgp at the call site. Confederation eBGP peers (PeerRole::ConfedEbgp) pass false so their attributes are retained.

Add two tests: one verifying the three attributes are stripped for eBGP, one verifying they are retained for iBGP.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>