### PR TITLE
packet,daemon: refuse sessions from 2-octet-only ASN peers

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -7687,7 +7687,7 @@ mod tests {
                 as_number: 65002,
                 holdtime: HoldTime::new(90).unwrap(),
                 router_id: u32::from(Ipv4Addr::new(10, 0, 0, 1)),
-                capability: vec![],
+                capability: vec![bgp::Capability::FourOctetAsNumber(65002)],
             });
             let mut arb = conn.conn_arbiter.lock().unwrap();
             arb.process(
@@ -7927,7 +7927,7 @@ mod tests {
             as_number: 65001,
             holdtime: HoldTime::new(90).unwrap(),
             router_id: u32::from(Ipv4Addr::new(10, 0, 0, 1)),
-            capability: vec![],
+            capability: vec![bgp::Capability::FourOctetAsNumber(65001)],
         });
 
         {

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -262,6 +262,23 @@ impl Connection {
             return out;
         }
 
+        // Require 4-octet ASN capability (RFC 6793).
+        // 2-octet-only peers are not supported; refuse to prevent silent AS_PATH corruption.
+        let peer_as4 = open
+            .capability
+            .iter()
+            .any(|c| matches!(c, Capability::FourOctetAsNumber(_)));
+        if !peer_as4 {
+            // RFC 5492 §4: data contains the capability TLV we require.
+            let mut cap_data = vec![Capability::FOUR_OCTET_AS_NUMBER, 4];
+            cap_data.extend_from_slice(&self.local_asn.to_be_bytes());
+            out.push(Output::SendMessage(bgp::Message::Notification(
+                rustybgp_packet::Notification::OpenUnsupportedCapability { data: cap_data },
+            )));
+            out.push(Output::SessionDown(SessionDownReason::AdminShutdown));
+            return out;
+        }
+
         // Store remote parameters
         self.remote_asn = open.as_number;
         self.remote_id = open.router_id;
@@ -666,7 +683,10 @@ mod tests {
             as_number: asn,
             holdtime: HoldTime::new(holdtime).unwrap(),
             router_id,
-            capability: vec![Capability::MultiProtocol(Family::IPV4)],
+            capability: vec![
+                Capability::MultiProtocol(Family::IPV4),
+                Capability::FourOctetAsNumber(asn),
+            ],
         })
     }
 
@@ -1225,7 +1245,10 @@ mod tests {
             as_number: asn,
             holdtime: HoldTime::new(60).unwrap(),
             router_id,
-            capability: vec![Capability::MultiProtocol(Family::IPV4)],
+            capability: vec![
+                Capability::MultiProtocol(Family::IPV4),
+                Capability::FourOctetAsNumber(asn),
+            ],
         })
     }
 

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -48,6 +48,8 @@ pub enum Notification {
     OpenBadBgpIdentifier,
     #[error("open error: unsupported optional parameter")]
     OpenUnsupportedOptionalParameter { data: Vec<u8> },
+    #[error("open error: unsupported capability")]
+    OpenUnsupportedCapability { data: Vec<u8> },
     #[error("open error: unacceptable hold time")]
     OpenUnacceptableHoldTime { data: Vec<u8> },
 
@@ -100,6 +102,7 @@ impl Notification {
             | Self::OpenBadPeerAs
             | Self::OpenBadBgpIdentifier
             | Self::OpenUnsupportedOptionalParameter { .. }
+            | Self::OpenUnsupportedCapability { .. }
             | Self::OpenUnacceptableHoldTime { .. } => 2,
             Self::UpdateMalformedAttributeList | Self::UpdateOptionalAttributeError => 3,
             Self::HoldTimerExpired => 4,
@@ -124,6 +127,7 @@ impl Notification {
             Self::OpenBadPeerAs => 2,
             Self::OpenBadBgpIdentifier => 3,
             Self::OpenUnsupportedOptionalParameter { .. } => 4,
+            Self::OpenUnsupportedCapability { .. } => 7,
             Self::OpenUnacceptableHoldTime { .. } => 6,
             Self::UpdateMalformedAttributeList => 1,
             Self::UpdateOptionalAttributeError => 9,
@@ -146,6 +150,7 @@ impl Notification {
             | Self::BadMessageType { data }
             | Self::OpenUnsupportedVersionNumber { data }
             | Self::OpenUnsupportedOptionalParameter { data }
+            | Self::OpenUnsupportedCapability { data }
             | Self::OpenUnacceptableHoldTime { data }
             | Self::RouteRefreshInvalidLength { data }
             | Self::Other { data, .. } => data,
@@ -169,6 +174,7 @@ impl Notification {
             (2, 2) => Self::OpenBadPeerAs,
             (2, 3) => Self::OpenBadBgpIdentifier,
             (2, 4) => Self::OpenUnsupportedOptionalParameter { data },
+            (2, 7) => Self::OpenUnsupportedCapability { data },
             (2, 6) => Self::OpenUnacceptableHoldTime { data },
             (3, 1) => Self::UpdateMalformedAttributeList,
             (3, 9) => Self::UpdateOptionalAttributeError,
@@ -756,7 +762,7 @@ impl Capability {
     const EXTENDED_NEXTHOP: u8 = 5;
     //    const EXTENDED_MESSAGE: u8 = 6;
     const GRACEFUL_RESTART: u8 = 64;
-    const FOUR_OCTET_AS_NUMBER: u8 = 65;
+    pub const FOUR_OCTET_AS_NUMBER: u8 = 65;
     const ADD_PATH: u8 = 69;
     const ENHANCED_ROUTE_REFRESH: u8 = 70;
     const LONG_LIVED_GRACEFUL_RESTART: u8 = 71;


### PR DESCRIPTION
RustyBGP does not implement RFC 6793 interoperability with peers that advertise only 2-octet ASNs. Without detection, such a session would silently encode AS_PATH in 4-octet format while the peer expects 2-octet, causing undetectable routing data corruption.

Add Notification::OpenUnsupportedCapability (OPEN error code 2 subcode 7, RFC 5492 §4) and check for FourOctetAsNumber in the remote OPEN capability list during fsm on_open. If absent, send the notification with the required capability TLV and close the session.

Update fsm and event test helpers to include FourOctetAsNumber in remote OPEN capabilities, matching what any modern BGP implementation would send.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>