### PR TITLE
packet: treat missing well-known mandatory attributes as withdraw

### DIFF
--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -1657,14 +1657,30 @@ fn validate_update(update: ParsedUpdate, is_ebgp: bool) -> Result<Vec<Message>, 
             attrs,
             error_attrs,
         } => {
+            // RFC 4271 §6.3 / BIRD+FRR practice: missing well-known mandatory
+            // attributes are treated as withdraw (session-drop per RFC 4271 §6.3,
+            // but both BIRD and FRR use treat-as-withdraw for operability).
+            // Malformed well-known attrs are already in error_attrs and trigger
+            // treat-as-withdraw through the check below; only absent attrs need
+            // the missing-mandatory path here.
+            // NEXTHOP is extracted into reach.nexthop (from the NEXTHOP attribute
+            // for traditional IPv4, or from MP_REACH_NLRI for other families) and
+            // never appears in attrs, so its presence is checked via the ReachNlri.
+            let missing_mandatory = (reach.is_some() || mp_reach.is_some())
+                && (!attrs.iter().any(|a| a.code() == Attribute::ORIGIN)
+                    || !attrs.iter().any(|a| a.code() == Attribute::AS_PATH)
+                    || reach.as_ref().is_some_and(|r| r.nexthop.is_none())
+                    || mp_reach.as_ref().is_some_and(|r| r.nexthop.is_none()));
+
             // RFC 7606: classify each attribute error.
             // Optional non-transitive: attribute discard (already absent from attrs).
             // Well-known or optional transitive: treat-as-withdraw.
-            let treat_as_withdraw = error_attrs.iter().any(|e| {
-                let optional = e.attr_flags & Attribute::FLAG_OPTIONAL != 0;
-                let transitive = e.attr_flags & Attribute::FLAG_TRANSITIVE != 0;
-                !optional || transitive
-            });
+            let treat_as_withdraw = missing_mandatory
+                || error_attrs.iter().any(|e| {
+                    let optional = e.attr_flags & Attribute::FLAG_OPTIONAL != 0;
+                    let transitive = e.attr_flags & Attribute::FLAG_TRANSITIVE != 0;
+                    !optional || transitive
+                });
 
             if treat_as_withdraw {
                 let mut msgs: Vec<Message> = Vec::new();

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -1462,3 +1462,100 @@ fn ibgp_retains_local_pref_originator_id_cluster_list() {
         );
     }
 }
+
+/// Raw IPv6-only UPDATE with ORIGIN + AS_PATH + MP_REACH_NLRI (no traditional NLRI,
+/// no separate NEXTHOP attribute). The nexthop is carried inside MP_REACH_NLRI.
+fn raw_ipv6_mpreach_update() -> Vec<u8> {
+    let mut attr_bytes: Vec<u8> = Vec::new();
+    // ORIGIN = IGP
+    attr_bytes.extend_from_slice(&[0x40, 0x01, 0x01, 0x00]);
+    // AS_PATH = AS_SEQUENCE [65002]
+    attr_bytes.extend_from_slice(&[0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0xfd, 0xea]);
+    // MP_REACH_NLRI: AFI=IPv6, SAFI=unicast, nexthop=2001:db8::, NLRI=2001:db8::/32
+    let mp: &[u8] = &[
+        0x00, 0x02, // AFI = IPv6
+        0x01, // SAFI = unicast
+        0x10, // nexthop_len = 16
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, // 2001:db8::
+        0x00, // SNPA = 0
+        0x20, 0x20, 0x01, 0x0d, 0xb8, // 2001:db8::/32
+    ];
+    attr_bytes.push(0x80); // optional non-transitive
+    attr_bytes.push(0x0e); // type = MP_REACH_NLRI
+    attr_bytes.push(mp.len() as u8);
+    attr_bytes.extend_from_slice(mp);
+
+    let attr_len = attr_bytes.len() as u16;
+    let total = 19u16 + 2 + 2 + attr_len; // no traditional NLRI
+    let mut buf = vec![0xffu8; 16];
+    buf.extend_from_slice(&total.to_be_bytes());
+    buf.push(2); // UPDATE
+    buf.extend_from_slice(&0u16.to_be_bytes()); // withdrawn_len = 0
+    buf.extend_from_slice(&attr_len.to_be_bytes());
+    buf.extend_from_slice(&attr_bytes);
+    buf
+}
+
+#[test]
+fn missing_origin_treat_as_withdraw() {
+    // AS_PATH + NEXTHOP present, ORIGIN absent.
+    // BIRD and FRR treat missing mandatory attributes as withdraw (session continues).
+    let mut attr_bytes: Vec<u8> = Vec::new();
+    attr_bytes.extend_from_slice(&[0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0xfd, 0xea]); // AS_PATH
+    attr_bytes.extend_from_slice(&[0x40, 0x03, 0x04, 0xc0, 0x00, 0x02, 0x01]); // NEXTHOP
+    let buf = raw_update_with_attrs(&attr_bytes);
+    let parsed = ipv4_codec().parse_message(&buf).expect("parse ok");
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
+    assert_eq!(msgs.len(), 1);
+    assert!(
+        matches!(&msgs[0], Message::Update(Update::Unreach { .. })),
+        "missing ORIGIN must trigger treat-as-withdraw"
+    );
+}
+
+#[test]
+fn missing_aspath_treat_as_withdraw() {
+    // ORIGIN + NEXTHOP present, AS_PATH absent.
+    let mut attr_bytes: Vec<u8> = Vec::new();
+    attr_bytes.extend_from_slice(&[0x40, 0x01, 0x01, 0x00]); // ORIGIN = IGP
+    attr_bytes.extend_from_slice(&[0x40, 0x03, 0x04, 0xc0, 0x00, 0x02, 0x01]); // NEXTHOP
+    let buf = raw_update_with_attrs(&attr_bytes);
+    let parsed = ipv4_codec().parse_message(&buf).expect("parse ok");
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
+    assert_eq!(msgs.len(), 1);
+    assert!(
+        matches!(&msgs[0], Message::Update(Update::Unreach { .. })),
+        "missing AS_PATH must trigger treat-as-withdraw"
+    );
+}
+
+#[test]
+fn missing_nexthop_ipv4_treat_as_withdraw() {
+    // ORIGIN + AS_PATH present, NEXTHOP absent for traditional IPv4 NLRI.
+    let mut attr_bytes: Vec<u8> = Vec::new();
+    attr_bytes.extend_from_slice(&[0x40, 0x01, 0x01, 0x00]); // ORIGIN = IGP
+    attr_bytes.extend_from_slice(&[0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0xfd, 0xea]); // AS_PATH
+    let buf = raw_update_with_attrs(&attr_bytes);
+    let parsed = ipv4_codec().parse_message(&buf).expect("parse ok");
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
+    assert_eq!(msgs.len(), 1);
+    assert!(
+        matches!(&msgs[0], Message::Update(Update::Unreach { .. })),
+        "missing NEXTHOP for IPv4 traditional NLRI must trigger treat-as-withdraw"
+    );
+}
+
+#[test]
+fn missing_nexthop_attr_with_mpreach_ok() {
+    // MP_REACH_NLRI carries its own nexthop; no separate NEXTHOP attribute is required.
+    // An IPv6 UPDATE without a NEXTHOP attribute must NOT trigger treat-as-withdraw.
+    let buf = raw_ipv6_mpreach_update();
+    let parsed = ipv6_codec().parse_message(&buf).expect("parse ok");
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
+    assert_eq!(msgs.len(), 1);
+    assert!(
+        matches!(&msgs[0], Message::Update(Update::Reach { .. })),
+        "IPv6 MP_REACH without NEXTHOP attribute must be accepted"
+    );
+}


### PR DESCRIPTION
RFC 4271 §6.3 mandates session drop for missing ORIGIN, AS_PATH, or NEXT_HOP in an UPDATE with NLRIs. However, both BIRD and FRR implement treat-as-withdraw instead, preferring session continuity over strict RFC compliance. Following their practice for operability with real-world implementations.

NEXT_HOP is only required for traditional IPv4 unicast NLRIs; when MP_REACH_NLRI is present the next-hop is carried inside that attribute, matching FRR's logic (!NEXT_HOP && !MP_REACH_NLRI). Because the parser extracts NEXT_HOP into reach.nexthop rather than leaving it in attrs, the presence check uses reach.nexthop.is_some() rather than scanning attrs.

Add four tests: missing ORIGIN, missing AS_PATH, missing NEXT_HOP for traditional IPv4 reach, and IPv6 MP_REACH without a NEXT_HOP attribute (the last must NOT trigger treat-as-withdraw).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>