### PR TITLE
packet,daemon: implement RFC 8654 Extended Message support

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -321,6 +321,11 @@ pub(crate) fn capability_to_api(cap: &Capability) -> api::Capability {
                 api::RouteRefreshCapability {},
             )),
         },
+        Capability::ExtendedMessage => api::Capability {
+            cap: Some(api::capability::Cap::ExtendedMessage(
+                api::ExtendedMessageCapability {},
+            )),
+        },
         Capability::ExtendedNexthop(v) => api::Capability {
             cap: Some(api::capability::Cap::ExtendedNexthop(
                 api::ExtendedNexthopCapability {

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -615,6 +615,8 @@ impl PeerParams {
         {
             local_cap.push(four_octet);
         }
+        // Always advertise RFC 8654 Extended Message support.
+        local_cap.push(packet::Capability::ExtendedMessage);
         local_cap
     }
 

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -736,7 +736,7 @@ pub enum Capability {
     MultiProtocol(Family),
     RouteRefresh,
     ExtendedNexthop(Vec<(Family, u16)>),
-    //    ExtendedMessage,
+    ExtendedMessage,
     GracefulRestart {
         flags: u8,
         restart_time: u16,
@@ -760,7 +760,7 @@ impl Capability {
     const MULTI_PROTOCOL: u8 = 1;
     const ROUTE_REFRESH: u8 = 2;
     const EXTENDED_NEXTHOP: u8 = 5;
-    //    const EXTENDED_MESSAGE: u8 = 6;
+    const EXTENDED_MESSAGE: u8 = 6;
     const GRACEFUL_RESTART: u8 = 64;
     pub const FOUR_OCTET_AS_NUMBER: u8 = 65;
     const ADD_PATH: u8 = 69;
@@ -777,6 +777,7 @@ impl From<&Capability> for u8 {
             Capability::MultiProtocol(_) => Capability::MULTI_PROTOCOL,
             Capability::RouteRefresh => Capability::ROUTE_REFRESH,
             Capability::ExtendedNexthop(_) => Capability::EXTENDED_NEXTHOP,
+            Capability::ExtendedMessage => Capability::EXTENDED_MESSAGE,
             Capability::GracefulRestart { .. } => Capability::GRACEFUL_RESTART,
             Capability::FourOctetAsNumber(_) => Capability::FOUR_OCTET_AS_NUMBER,
             Capability::AddPath(_) => Capability::ADD_PATH,
@@ -834,6 +835,9 @@ impl Capability {
                     c.put_u8(family.safi());
                     c.put_u8(*mode);
                 }
+            }
+            Capability::ExtendedMessage => {
+                c.put_u8(0);
             }
             Capability::EnhancedRouteRefresh => {
                 c.put_u8(0);
@@ -940,6 +944,12 @@ impl Capability {
                     v.push((Family(afi << 16 | safi), val));
                 }
                 Ok(Capability::AddPath(v))
+            }
+            Self::EXTENDED_MESSAGE => {
+                if len != 0 {
+                    return Err(());
+                }
+                Ok(Capability::ExtendedMessage)
             }
             Self::ENHANCED_ROUTE_REFRESH => {
                 if len != 0 {
@@ -1865,8 +1875,9 @@ impl PeerCodec {
                 );
             }
         }
+        let has = |v: &[Capability]| v.iter().any(|c| matches!(c, Capability::ExtendedMessage));
         PeerCodec {
-            extended_length: false,
+            extended_length: has(local) && has(remote),
             extended_nexthop,
             families,
         }

--- a/packet/tests/bgp_framer.rs
+++ b/packet/tests/bgp_framer.rs
@@ -15,7 +15,7 @@
 
 use bytes::BytesMut;
 use rustybgp_packet::Notification;
-use rustybgp_packet::bgp::{ParsedMessage, PeerCodec};
+use rustybgp_packet::bgp::{Capability, Family, ParsedMessage, PeerCodec};
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -204,4 +204,50 @@ fn framer_mixed_message_types() {
     ));
 
     assert!(matches!(framer.try_parse(&mut buf), Ok(None)));
+}
+
+// ─── RFC 8654 extended message tests ─────────────────────────────────────────
+
+fn extended_framer() -> PeerCodec {
+    let cap = vec![
+        Capability::MultiProtocol(Family::IPV4),
+        Capability::FourOctetAsNumber(65001),
+        Capability::ExtendedMessage,
+    ];
+    PeerCodec::negotiate(&cap, &cap)
+}
+
+#[test]
+fn framer_extended_accepts_large_message() {
+    // With extended_length negotiated, a message > 4096 bytes must be accepted.
+    // The framer must not return BadMessageLength for lengths up to 65535.
+    let mut framer = extended_framer();
+    assert!(
+        framer.extended_length,
+        "codec must have extended_length=true after negotiating ExtendedMessage"
+    );
+    // Use NOTIFICATION (type 3): only a minimum-length check applies, accepts variable data.
+    // KEEPALIVE (type 4) requires exactly 19 bytes and would fail inside parse_message.
+    let body = vec![0u8; 5000 - 19]; // error_code=0, subcode=0, rest zero data
+    let buf = bgp_msg(3, &body);
+    let mut bmut = BytesMut::from(buf.as_slice());
+    if let Err(Notification::BadMessageLength { .. }) = framer.try_parse(&mut bmut) {
+        panic!("extended framer must not reject messages <= 65535 bytes")
+    }
+}
+
+#[test]
+fn framer_default_rejects_large_message() {
+    // Without extended_length, a message > 4096 bytes must be rejected.
+    let body = vec![0u8; 5000 - 19];
+    let buf = bgp_msg(4, &body);
+    let mut framer = default_framer();
+    let mut bmut = BytesMut::from(buf.as_slice());
+    match framer.try_parse(&mut bmut) {
+        Err(Notification::BadMessageLength { .. }) => {}
+        other => panic!(
+            "default framer must reject messages > 4096 bytes, got {:?}",
+            other.map(|_| "ok")
+        ),
+    }
 }

--- a/packet/tests/bgp_message.rs
+++ b/packet/tests/bgp_message.rs
@@ -15,7 +15,8 @@
 
 use bytes::BytesMut;
 use rustybgp_packet::bgp::{
-    Attribute, Ipv4Net, Ipv6Net, Message, ParsedMessage, ParsedUpdate, PeerCodec, Update,
+    Attribute, Capability, Ipv4Net, Ipv6Net, Message, ParsedMessage, ParsedUpdate, PeerCodec,
+    Update,
 };
 use rustybgp_packet::{Family, Nlri, PathNlri};
 use std::collections::HashSet;
@@ -257,4 +258,38 @@ fn many_mp_unreach() {
         assert!(set.remove(n));
     }
     assert_eq!(set.len(), 0);
+}
+
+#[test]
+fn negotiate_extended_message_both_sides() {
+    // Both sides advertise ExtendedMessage -> extended_length = true.
+    let cap = vec![
+        Capability::MultiProtocol(Family::IPV4),
+        Capability::FourOctetAsNumber(65001),
+        Capability::ExtendedMessage,
+    ];
+    let codec = PeerCodec::negotiate(&cap, &cap);
+    assert!(
+        codec.extended_length,
+        "extended_length must be true when both sides advertise ExtendedMessage"
+    );
+}
+
+#[test]
+fn negotiate_extended_message_one_side_only() {
+    // Only local side advertises ExtendedMessage -> extended_length = false.
+    let local = vec![
+        Capability::MultiProtocol(Family::IPV4),
+        Capability::FourOctetAsNumber(65001),
+        Capability::ExtendedMessage,
+    ];
+    let remote = vec![
+        Capability::MultiProtocol(Family::IPV4),
+        Capability::FourOctetAsNumber(65002),
+    ];
+    let codec = PeerCodec::negotiate(&local, &remote);
+    assert!(
+        !codec.extended_length,
+        "extended_length must be false when only one side advertises ExtendedMessage"
+    );
 }


### PR DESCRIPTION
Advertise BGP Extended Message capability (code 6) unconditionally on all sessions; activate the 65535-byte message-length limit only when the peer also signals the capability.

packet:
- Add Capability::ExtendedMessage variant with encode/decode and u8 conversion.
- PeerCodec::negotiate() sets extended_length=true when both sides advertise the capability, keeping the 4096-byte default otherwise.

daemon:
- build_local_cap() always pushes Capability::ExtendedMessage.
- gRPC conversion maps Capability::ExtendedMessage to api::ExtendedMessageCapability.

Tests:
- negotiate_extended_message_both_sides: extended_length true when both sides advertise.
- negotiate_extended_message_one_side_only: extended_length false when only one side advertises.
- framer_extended_accepts_large_message: framer with extended_length must not reject a 5000-byte NOTIFICATION.
- framer_default_rejects_large_message: default framer must reject any message over 4096 bytes.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>