### PR TITLE
packet,daemon: add BGP Labeled Unicast (RFC 8277) SAFI=4 support

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -73,6 +73,24 @@ pub(crate) fn nlri_to_api(f: &Nlri) -> api::Nlri {
                 },
             )),
         },
+        Nlri::LabeledV4(n) => api::Nlri {
+            nlri: Some(api::nlri::Nlri::LabeledPrefix(
+                api::LabeledIpAddressPrefix {
+                    labels: n.labels.labels().iter().map(|l| l.value()).collect(),
+                    prefix_len: n.prefix.mask as u32,
+                    prefix: n.prefix.addr.to_string(),
+                },
+            )),
+        },
+        Nlri::LabeledV6(n) => api::Nlri {
+            nlri: Some(api::nlri::Nlri::LabeledPrefix(
+                api::LabeledIpAddressPrefix {
+                    labels: n.labels.labels().iter().map(|l| l.value()).collect(),
+                    prefix_len: n.prefix.mask as u32,
+                    prefix: n.prefix.addr.to_string(),
+                },
+            )),
+        },
     }
 }
 
@@ -750,6 +768,8 @@ pub(crate) fn family_from_config(f: &config::generate::AfiSafiType) -> Result<Fa
         config::generate::AfiSafiType::Ipv6Unicast => Ok(Family::IPV6),
         config::generate::AfiSafiType::Ipv4Multicast => Ok(Family::IPV4_MC),
         config::generate::AfiSafiType::Ipv6Multicast => Ok(Family::IPV6_MC),
+        config::generate::AfiSafiType::Ipv4LabelledUnicast => Ok(Family::IPV4_MPLS),
+        config::generate::AfiSafiType::Ipv6LabelledUnicast => Ok(Family::IPV6_MPLS),
         config::generate::AfiSafiType::Ipv4Mup => Ok(Family::IPV4_MUP),
         config::generate::AfiSafiType::Ipv6Mup => Ok(Family::IPV6_MUP),
         _ => Err(()),

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -195,7 +195,11 @@ impl Handle {
         let (dst, prefix_len) = match change.net {
             packet::Nlri::V4(net) => (IpAddr::V4(net.addr), net.mask),
             packet::Nlri::V6(net) => (IpAddr::V6(net.addr), net.mask),
-            packet::Nlri::Mup(_) | packet::Nlri::VpnV4(_) | packet::Nlri::VpnV6(_) => {
+            packet::Nlri::Mup(_)
+            | packet::Nlri::VpnV4(_)
+            | packet::Nlri::VpnV6(_)
+            | packet::Nlri::LabeledV4(_)
+            | packet::Nlri::LabeledV6(_) => {
                 return Ok(());
             }
         };

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -278,6 +278,7 @@ impl Family {
 
     const SAFI_UNICAST: u8 = 1;
     const SAFI_MULTICAST: u8 = 2;
+    const SAFI_LABELED_UNICAST: u8 = 4;
     const SAFI_MUP: u8 = 85;
     const SAFI_FLOWSPEC: u8 = 133;
     const SAFI_FLOWSPEC_VPN: u8 = 134;
@@ -291,6 +292,10 @@ impl Family {
         Family((Family::AFI_IP as u32) << 16 | Family::SAFI_MULTICAST as u32);
     pub const IPV6_MC: Family =
         Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_MULTICAST as u32);
+    pub const IPV4_MPLS: Family =
+        Family((Family::AFI_IP as u32) << 16 | Family::SAFI_LABELED_UNICAST as u32);
+    pub const IPV6_MPLS: Family =
+        Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_LABELED_UNICAST as u32);
     pub const IPV4_MUP: Family = Family((Family::AFI_IP as u32) << 16 | Family::SAFI_MUP as u32);
     pub const IPV6_MUP: Family = Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_MUP as u32);
     pub const IPV4_VPN: Family =
@@ -436,6 +441,8 @@ pub enum Nlri {
     Mup(crate::mup::MupNlri),
     VpnV4(crate::vpn::VpnV4Nlri),
     VpnV6(crate::vpn::VpnV6Nlri),
+    LabeledV4(crate::labeled::LabeledV4Nlri),
+    LabeledV6(crate::labeled::LabeledV6Nlri),
 }
 
 impl Nlri {
@@ -446,6 +453,8 @@ impl Nlri {
             Nlri::Mup(m) => Ok(m.encode(dst)),
             Nlri::VpnV4(n) => Ok(n.encode(dst)),
             Nlri::VpnV6(n) => Ok(n.encode(dst)),
+            Nlri::LabeledV4(n) => Ok(n.encode(dst)),
+            Nlri::LabeledV6(n) => Ok(n.encode(dst)),
         }
     }
 
@@ -462,6 +471,7 @@ impl Nlri {
         family: Family,
         c: &mut BgpReader<C>,
         len: usize,
+        is_reach: bool,
     ) -> Result<Nlri, Notification> {
         match family {
             Family::IPV4 | Family::IPV4_MC => Ipv4Net::decode(c, len).map(Nlri::V4),
@@ -474,6 +484,12 @@ impl Nlri {
                 .map_err(|_| Notification::UpdateMalformedAttributeList),
             Family::IPV6_VPN => crate::vpn::VpnV6Nlri::decode(c, len)
                 .map(Nlri::VpnV6)
+                .map_err(|_| Notification::UpdateMalformedAttributeList),
+            Family::IPV4_MPLS => crate::labeled::LabeledV4Nlri::decode(c, len, is_reach)
+                .map(Nlri::LabeledV4)
+                .map_err(|_| Notification::UpdateMalformedAttributeList),
+            Family::IPV6_MPLS => crate::labeled::LabeledV6Nlri::decode(c, len, is_reach)
+                .map(Nlri::LabeledV6)
                 .map_err(|_| Notification::UpdateMalformedAttributeList),
             _ => Err(Notification::UpdateMalformedAttributeList),
         }
@@ -502,6 +518,8 @@ impl fmt::Display for Nlri {
             Nlri::Mup(m) => m.fmt(f),
             Nlri::VpnV4(n) => n.fmt(f),
             Nlri::VpnV6(n) => n.fmt(f),
+            Nlri::LabeledV4(n) => n.fmt(f),
+            Nlri::LabeledV6(n) => n.fmt(f),
         }
     }
 }
@@ -705,7 +723,7 @@ fn nlri_decode_ipv4() {
     let len = buf.len();
     let mut c = BgpReader::<UpdateCtx>::new(&buf);
     assert_eq!(
-        Nlri::decode(Family::IPV4, &mut c, len).unwrap(),
+        Nlri::decode(Family::IPV4, &mut c, len, true).unwrap(),
         Nlri::V4(Ipv4Net {
             addr: Ipv4Addr::new(10, 0, 0, 0),
             mask: 24,
@@ -719,7 +737,7 @@ fn nlri_decode_ipv6() {
     let len = buf.len();
     let mut c = BgpReader::<UpdateCtx>::new(&buf);
     assert_eq!(
-        Nlri::decode(Family::IPV6, &mut c, len).unwrap(),
+        Nlri::decode(Family::IPV6, &mut c, len, true).unwrap(),
         Nlri::V6(Ipv6Net {
             addr: Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 0),
             mask: 32,
@@ -733,7 +751,7 @@ fn nlri_decode_unsupported_family() {
     let len = buf.len();
     let mut c = BgpReader::<UpdateCtx>::new(&buf);
     let mup_ipv4 = Family::new((Family::AFI_IP as u32) << 16 | 85);
-    assert!(Nlri::decode(mup_ipv4, &mut c, len).is_err());
+    assert!(Nlri::decode(mup_ipv4, &mut c, len, true).is_err());
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -2222,6 +2240,7 @@ impl PeerCodec {
     fn decode_nlri<C: ParseContext>(
         family: Family,
         addpath_rx: bool,
+        is_reach: bool,
         c: &mut BgpReader<C>,
         mut len: usize,
     ) -> Result<PathNlri, Notification> {
@@ -2235,18 +2254,25 @@ impl PeerCodec {
         } else {
             0
         };
-        Nlri::decode(family, c, len).map(|nlri| PathNlri { path_id: id, nlri })
+        Nlri::decode(family, c, len, is_reach).map(|nlri| PathNlri { path_id: id, nlri })
     }
     fn decode_nlri_list(
         family: Family,
         addpath_rx: bool,
+        is_reach: bool,
         buf: &[u8],
     ) -> Result<Vec<PathNlri>, Notification> {
         let mut reader = BgpReader::<UpdateCtx>::new(buf);
         let mut entries = Vec::new();
         while reader.remaining_len() > 0 {
             let rest = reader.remaining_len();
-            entries.push(Self::decode_nlri(family, addpath_rx, &mut reader, rest)?);
+            entries.push(Self::decode_nlri(
+                family,
+                addpath_rx,
+                is_reach,
+                &mut reader,
+                rest,
+            )?);
         }
         Ok(entries)
     }
@@ -2494,6 +2520,7 @@ impl PeerCodec {
                     reach = Self::decode_nlri_list(
                         Family::IPV4,
                         addpath_rx,
+                        true,
                         &buf[c.position() as usize..],
                     )?;
                 }
@@ -2508,6 +2535,7 @@ impl PeerCodec {
                     unreach = Self::decode_nlri_list(
                         Family::IPV4,
                         addpath_rx,
+                        false,
                         &buf[start..start + withdrawn_len as usize],
                     )?;
                 }
@@ -2561,8 +2589,12 @@ impl PeerCodec {
                         _ => return Err(err),
                     };
                     c.read_u8().unwrap();
-                    let entries =
-                        Self::decode_nlri_list(family, addpath_rx, &buf[c.position() as usize..])?;
+                    let entries = Self::decode_nlri_list(
+                        family,
+                        addpath_rx,
+                        true,
+                        &buf[c.position() as usize..],
+                    )?;
                     Some((family, entries, nexthop))
                 } else {
                     None
@@ -2583,8 +2615,12 @@ impl PeerCodec {
                     let safi = c.read_u8().unwrap();
                     let family = Family((afi as u32) << 16 | safi as u32);
                     let addpath_rx = self.families.get(&family).ok_or_else(malformed)?.addpath_rx;
-                    let entries =
-                        Self::decode_nlri_list(family, addpath_rx, &buf[c.position() as usize..])?;
+                    let entries = Self::decode_nlri_list(
+                        family,
+                        addpath_rx,
+                        false,
+                        &buf[c.position() as usize..],
+                    )?;
                     Some((family, entries))
                 } else {
                     None

--- a/packet/src/labeled.rs
+++ b/packet/src/labeled.rs
@@ -1,0 +1,291 @@
+// Copyright (C) 2026 The RustyBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+//! BGP Labeled Unicast NLRI (RFC 8277), AFI=1/SAFI=4 and AFI=2/SAFI=4.
+//!
+//! Wire format per NLRI entry (reach):
+//!   1 byte  total bit-length = label_bits + prefix_bits
+//!   N×3 bytes MPLS label stack (RFC 3032; BoS bit terminates the stack)
+//!   ceil(prefix_bits/8) bytes IP prefix (significant octets only)
+//!
+//! For unreach (RFC 8277 §2.4), the label field is a fixed 24-bit
+//! Compatibility field that MUST be ignored on receipt.
+
+use crate::bgp::{Ipv4Net, Ipv6Net};
+use crate::mpls::{MplsLabel, MplsLabelStack};
+use byteorder::ReadBytesExt;
+use bytes::BufMut;
+use std::fmt;
+use std::io;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+fn malformed() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "malformed labeled unicast NLRI")
+}
+
+/// Labeled IPv4 Unicast NLRI (AFI=1, SAFI=4).
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub struct LabeledV4Nlri {
+    pub labels: MplsLabelStack,
+    pub prefix: Ipv4Net,
+}
+
+/// Labeled IPv6 Unicast NLRI (AFI=2, SAFI=4).
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub struct LabeledV6Nlri {
+    pub labels: MplsLabelStack,
+    pub prefix: Ipv6Net,
+}
+
+impl LabeledV4Nlri {
+    /// Decode a single labeled IPv4 NLRI from `c`.
+    ///
+    /// `is_reach`: true for MP_REACH_NLRI (BoS-terminated label stack),
+    /// false for MP_UNREACH_NLRI (RFC 8277 §2.4: fixed 3-byte compatibility
+    /// field, ignored on receipt).
+    pub fn decode<T: io::Read>(c: &mut T, len: usize, is_reach: bool) -> Result<Self, io::Error> {
+        if len < 1 + 3 {
+            return Err(malformed());
+        }
+        let total_bits = c.read_u8()?;
+        if total_bits < 24 {
+            return Err(malformed());
+        }
+
+        let (labels, label_bits) = if is_reach {
+            let stack = MplsLabelStack::decode(c)?;
+            let bits = (stack.encoded_len() * 8) as u8;
+            (stack, bits)
+        } else {
+            // Unreach: discard the fixed 3-byte compatibility field.
+            let mut buf = [0u8; 3];
+            c.read_exact(&mut buf)?;
+            (MplsLabelStack::new(vec![MplsLabel::new(0)]), 24)
+        };
+
+        if total_bits < label_bits {
+            return Err(malformed());
+        }
+        let prefix_bits = total_bits - label_bits;
+        if prefix_bits > 32 {
+            return Err(malformed());
+        }
+        let prefix_bytes = prefix_bits.div_ceil(8) as usize;
+
+        let mut addr = [0u8; 4];
+        for b in addr.iter_mut().take(prefix_bytes) {
+            *b = c.read_u8()?;
+        }
+
+        Ok(LabeledV4Nlri {
+            labels,
+            prefix: Ipv4Net {
+                addr: Ipv4Addr::from(addr),
+                mask: prefix_bits,
+            },
+        })
+    }
+
+    /// Encode to wire format. Returns the number of bytes written.
+    pub fn encode<B: BufMut>(&self, dst: &mut B) -> u16 {
+        let prefix_bits = self.prefix.mask;
+        let prefix_bytes = prefix_bits.div_ceil(8) as usize;
+        dst.put_u8((self.labels.encoded_len() * 8) as u8 + prefix_bits);
+        self.labels.encode(dst);
+        for i in 0..prefix_bytes {
+            dst.put_u8(self.prefix.addr.octets()[i]);
+        }
+        (1 + self.labels.encoded_len() + prefix_bytes) as u16
+    }
+}
+
+impl LabeledV6Nlri {
+    /// Decode a single labeled IPv6 NLRI from `c`.
+    ///
+    /// `is_reach`: true for MP_REACH_NLRI, false for MP_UNREACH_NLRI.
+    /// See `LabeledV4Nlri::decode` for details.
+    pub fn decode<T: io::Read>(c: &mut T, len: usize, is_reach: bool) -> Result<Self, io::Error> {
+        if len < 1 + 3 {
+            return Err(malformed());
+        }
+        let total_bits = c.read_u8()?;
+        if total_bits < 24 {
+            return Err(malformed());
+        }
+
+        let (labels, label_bits) = if is_reach {
+            let stack = MplsLabelStack::decode(c)?;
+            let bits = (stack.encoded_len() * 8) as u8;
+            (stack, bits)
+        } else {
+            let mut buf = [0u8; 3];
+            c.read_exact(&mut buf)?;
+            (MplsLabelStack::new(vec![MplsLabel::new(0)]), 24)
+        };
+
+        if total_bits < label_bits {
+            return Err(malformed());
+        }
+        let prefix_bits = total_bits - label_bits;
+        if prefix_bits > 128 {
+            return Err(malformed());
+        }
+        let prefix_bytes = prefix_bits.div_ceil(8) as usize;
+
+        let mut addr = [0u8; 16];
+        for b in addr.iter_mut().take(prefix_bytes) {
+            *b = c.read_u8()?;
+        }
+
+        Ok(LabeledV6Nlri {
+            labels,
+            prefix: Ipv6Net {
+                addr: Ipv6Addr::from(addr),
+                mask: prefix_bits,
+            },
+        })
+    }
+
+    /// Encode to wire format. Returns the number of bytes written.
+    pub fn encode<B: BufMut>(&self, dst: &mut B) -> u16 {
+        let prefix_bits = self.prefix.mask;
+        let prefix_bytes = prefix_bits.div_ceil(8) as usize;
+        dst.put_u8((self.labels.encoded_len() * 8) as u8 + prefix_bits);
+        self.labels.encode(dst);
+        for i in 0..prefix_bytes {
+            dst.put_u8(self.prefix.addr.octets()[i]);
+        }
+        (1 + self.labels.encoded_len() + prefix_bytes) as u16
+    }
+}
+
+impl fmt::Display for LabeledV4Nlri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.prefix.addr, self.prefix.mask)
+    }
+}
+
+impl fmt::Display for LabeledV6Nlri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.prefix.addr, self.prefix.mask)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mpls::MplsLabel;
+    use std::io::Cursor;
+
+    // Test vectors generated by tools/gen_mpls_nlri (GoBGP v4 library).
+    // Each constant is the wire encoding of a single NLRI entry including
+    // the leading total-bit-length byte.
+
+    // IPv4: label=100, 10.0.1.0/24
+    // total_bits = 24 + 24 = 48 = 0x30
+    // label 100 wire: (100 << 4) | BoS=1 = 1601 = 0x000641 -> [0x00, 0x06, 0x41]
+    // prefix = 0x0a 0x00 0x01
+    const V4_SINGLE_LABEL: &[u8] = &[0x30, 0x00, 0x06, 0x41, 0x0a, 0x00, 0x01];
+
+    // IPv4: labels=[100, 200], 10.0.1.0/24
+    // total_bits = 24*2 + 24 = 72 = 0x48
+    // label 100 no-BoS: (100 << 4) = 1600 = 0x640 -> [0x00, 0x06, 0x40]
+    // label 200 BoS:    (200 << 4) | 1 = 3201 = 0xC81 -> [0x00, 0x0c, 0x81]
+    const V4_LABEL_STACK: &[u8] = &[0x48, 0x00, 0x06, 0x40, 0x00, 0x0c, 0x81, 0x0a, 0x00, 0x01];
+
+    // IPv6: label=300, 2001:db8::/32
+    // total_bits = 24 + 32 = 56 = 0x38
+    // label 300 wire: (300 << 4) | BoS=1 = 4801 = 0x12C1 -> [0x00, 0x12, 0xc1]
+    const V6_SINGLE_LABEL: &[u8] = &[0x38, 0x00, 0x12, 0xc1, 0x20, 0x01, 0x0d, 0xb8];
+
+    #[test]
+    fn v4_single_label_roundtrip() {
+        let mut c = Cursor::new(V4_SINGLE_LABEL);
+        let nlri = LabeledV4Nlri::decode(&mut c, V4_SINGLE_LABEL.len(), true).unwrap();
+        assert_eq!(nlri.labels.labels().len(), 1);
+        assert_eq!(nlri.labels.labels()[0].value(), 100);
+        assert_eq!(nlri.prefix.addr, Ipv4Addr::new(10, 0, 1, 0));
+        assert_eq!(nlri.prefix.mask, 24);
+
+        let mut buf = Vec::new();
+        nlri.encode(&mut buf);
+        assert_eq!(buf, V4_SINGLE_LABEL);
+    }
+
+    #[test]
+    fn v4_label_stack_roundtrip() {
+        let mut c = Cursor::new(V4_LABEL_STACK);
+        let nlri = LabeledV4Nlri::decode(&mut c, V4_LABEL_STACK.len(), true).unwrap();
+        assert_eq!(nlri.labels.labels().len(), 2);
+        assert_eq!(nlri.labels.labels()[0].value(), 100);
+        assert_eq!(nlri.labels.labels()[1].value(), 200);
+        assert_eq!(nlri.prefix.addr, Ipv4Addr::new(10, 0, 1, 0));
+        assert_eq!(nlri.prefix.mask, 24);
+
+        let mut buf = Vec::new();
+        nlri.encode(&mut buf);
+        assert_eq!(buf, V4_LABEL_STACK);
+    }
+
+    #[test]
+    fn v4_unreach_ignores_label() {
+        // Unreach with RFC 8277 compatibility value 0x800000 (BoS=0).
+        // total_bits = 24 + 24 = 48 = 0x30
+        let wire: &[u8] = &[0x30, 0x80, 0x00, 0x00, 0x0a, 0x00, 0x01];
+        let mut c = Cursor::new(wire);
+        let nlri = LabeledV4Nlri::decode(&mut c, wire.len(), false).unwrap();
+        // Label value is ignored; prefix must be decoded correctly.
+        assert_eq!(nlri.prefix.addr, Ipv4Addr::new(10, 0, 1, 0));
+        assert_eq!(nlri.prefix.mask, 24);
+    }
+
+    #[test]
+    fn v4_unreach_bird_compat_label() {
+        // Unreach with BIRD-style 0x000001 (label=0, BoS=1).
+        let wire: &[u8] = &[0x30, 0x00, 0x00, 0x01, 0x0a, 0x00, 0x01];
+        let mut c = Cursor::new(wire);
+        let nlri = LabeledV4Nlri::decode(&mut c, wire.len(), false).unwrap();
+        assert_eq!(nlri.prefix.addr, Ipv4Addr::new(10, 0, 1, 0));
+        assert_eq!(nlri.prefix.mask, 24);
+    }
+
+    #[test]
+    fn v6_single_label_roundtrip() {
+        let mut c = Cursor::new(V6_SINGLE_LABEL);
+        let nlri = LabeledV6Nlri::decode(&mut c, V6_SINGLE_LABEL.len(), true).unwrap();
+        assert_eq!(nlri.labels.labels().len(), 1);
+        assert_eq!(nlri.labels.labels()[0].value(), 300);
+        assert_eq!(nlri.prefix.addr, "2001:db8::".parse::<Ipv6Addr>().unwrap());
+        assert_eq!(nlri.prefix.mask, 32);
+
+        let mut buf = Vec::new();
+        nlri.encode(&mut buf);
+        assert_eq!(buf, V6_SINGLE_LABEL);
+    }
+
+    #[test]
+    fn v4_encode_uses_label_stack() {
+        let nlri = LabeledV4Nlri {
+            labels: MplsLabelStack::new(vec![MplsLabel::new(0)]),
+            prefix: Ipv4Net {
+                addr: Ipv4Addr::new(192, 168, 1, 0),
+                mask: 24,
+            },
+        };
+        let mut buf = Vec::new();
+        nlri.encode(&mut buf);
+        // total_bits = 24 + 24 = 0x30; label 0 BoS = 0x000001; prefix = 0xc0 0xa8 0x01
+        assert_eq!(buf, &[0x30, 0x00, 0x00, 0x01, 0xc0, 0xa8, 0x01]);
+    }
+}

--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -24,6 +24,7 @@ pub use self::error::Error;
 
 pub mod bmp;
 pub mod error;
+pub mod labeled;
 pub mod mpls;
 pub mod mrt;
 pub mod mup;

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -1675,7 +1675,11 @@ impl RpkiTable {
                 let (mut addr, mask) = match net {
                     packet::Nlri::V4(net) => (net.addr.octets().to_vec(), net.mask),
                     packet::Nlri::V6(net) => (net.addr.octets().to_vec(), net.mask),
-                    packet::Nlri::Mup(_) | packet::Nlri::VpnV4(_) | packet::Nlri::VpnV6(_) => {
+                    packet::Nlri::Mup(_)
+                    | packet::Nlri::VpnV4(_)
+                    | packet::Nlri::VpnV6(_)
+                    | packet::Nlri::LabeledV4(_)
+                    | packet::Nlri::LabeledV6(_) => {
                         return None;
                     }
                 };

--- a/table/src/policy.rs
+++ b/table/src/policy.rs
@@ -374,6 +374,7 @@ impl Condition {
                     packet::Nlri::V6(_) => {}
                     packet::Nlri::Mup(_) => {}
                     packet::Nlri::VpnV4(_) | packet::Nlri::VpnV6(_) => {}
+                    packet::Nlri::LabeledV4(_) | packet::Nlri::LabeledV6(_) => {}
                 };
             }
             Condition::AsPath(_name, opt, set) => {
@@ -543,6 +544,8 @@ fn nlri_family(net: &packet::Nlri) -> bgp::Family {
         }
         packet::Nlri::VpnV4(_) => bgp::Family::IPV4_VPN,
         packet::Nlri::VpnV6(_) => bgp::Family::IPV6_VPN,
+        packet::Nlri::LabeledV4(_) => bgp::Family::IPV4_MPLS,
+        packet::Nlri::LabeledV6(_) => bgp::Family::IPV6_MPLS,
     }
 }
 


### PR DESCRIPTION
Introduce labeled.rs with LabeledV4Nlri and LabeledV6Nlri structs (MPLS label stack + IP prefix, no RD), parallel to vpn.rs.

packet:
- labeled.rs: decode/encode for AFI=1/2 SAFI=4 NLRI. is_reach=true reads a BoS-terminated label stack (MP_REACH_NLRI); is_reach=false reads a fixed 3-byte compatibility field and discards it per RFC 8277 SS2.4, making the withdraw match prefix-only.
- Family::IPV4_MPLS (AFI=1, SAFI=4) and IPV6_MPLS (AFI=2, SAFI=4).
- Nlri::LabeledV4 / LabeledV6 variants with encode, decode, Display.
- Nlri::decode and decode_nlri_list gain is_reach: bool, forwarded only to the labeled unicast arms; all other families ignore it.

daemon:
- nlri_to_api maps LabeledV4/V6 to api::LabeledIPAddressPrefix.
- family_from_config maps Ipv4LabelledUnicast/Ipv6LabelledUnicast.

kernel/table:
- Treat LabeledV4/V6 NLRI like Mup/VPN: skip kernel FIB programming and RPKI/policy prefix matching (no IP-prefix-only semantics there).

Tests: 6 new tests in labeled.rs covering single-label and multi-label roundtrips, RFC 8277 compatibility value (0x800000), and BIRD-style withdraw label (0x000001).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>