### PR TITLE
packet,daemon: send MED to iBGP peers, strip it on eBGP export

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -4878,6 +4878,7 @@ impl PeerExportContext {
                             bgp::Attribute::LOCAL_PREF
                                 | bgp::Attribute::ORIGINATOR_ID
                                 | bgp::Attribute::CLUSTER_LIST
+                                | bgp::Attribute::MULTI_EXIT_DESC
                         )
                     })
                     .map(|a| {
@@ -9308,6 +9309,13 @@ mod tests {
             ])
         }
 
+        fn attr_with_med() -> Arc<Vec<packet::Attribute>> {
+            Arc::new(vec![
+                packet::Attribute::new_with_value(packet::Attribute::ORIGIN, 0).unwrap(),
+                packet::Attribute::new_with_value(packet::Attribute::MULTI_EXIT_DESC, 50).unwrap(),
+            ])
+        }
+
         #[test]
         fn ebgp_export_strips_local_pref() {
             let ctx = ebgp_ctx();
@@ -9370,6 +9378,30 @@ mod tests {
                     .any(|a| a.code() == packet::Attribute::LOCAL_PREF
                         && a.value() == Some(packet::Attribute::DEFAULT_LOCAL_PREF)),
                 "iBGP export must inject LOCAL_PREF=100 when absent"
+            );
+        }
+
+        #[test]
+        fn ebgp_export_strips_med() {
+            let ctx = ebgp_ctx();
+            let exported = ctx.export_attrs(&attr_with_med());
+            assert!(
+                exported
+                    .iter()
+                    .all(|a| a.code() != packet::Attribute::MULTI_EXIT_DESC),
+                "MED must be stripped for eBGP (non-transitive, MUST NOT leak to other ASes)"
+            );
+        }
+
+        #[test]
+        fn ibgp_export_keeps_med() {
+            let ctx = ibgp_ctx();
+            let exported = ctx.export_attrs(&attr_with_med());
+            assert!(
+                exported.iter().any(
+                    |a| a.code() == packet::Attribute::MULTI_EXIT_DESC && a.value() == Some(50)
+                ),
+                "MED must be passed through for iBGP"
             );
         }
 

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -2236,12 +2236,18 @@ impl PeerCodec {
                 // Write path attributes.  Encode transitive attrs plus
                 // ORIGINATOR_ID and CLUSTER_LIST, which are optional
                 // non-transitive but required in iBGP UPDATEs (RFC 4456 §8).
+                // MULTI_EXIT_DESC is sent to iBGP peers (export layer strips it
+                // for eBGP per BIRD/FRR convention).
                 // NEXTHOP is written below for traditional IPv4.
                 // MP_REACH/MP_UNREACH are synthesized below for MP paths.
-                // MED (optional non-transitive) is handled at the export layer.
                 for a in attr.as_ref() {
                     if a.flags & Attribute::FLAG_TRANSITIVE > 0
-                        || matches!(a.code(), Attribute::ORIGINATOR_ID | Attribute::CLUSTER_LIST)
+                        || matches!(
+                            a.code(),
+                            Attribute::ORIGINATOR_ID
+                                | Attribute::CLUSTER_LIST
+                                | Attribute::MULTI_EXIT_DESC
+                        )
                     {
                         attr_len += a.encode_wire(dst);
                     }

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -286,10 +286,10 @@ fn update_attr_origin_igp() {
 }
 
 #[test]
-fn update_attr_med_dropped_on_encode() {
-    // MED (MULTI_EXIT_DESC) is an optional non-transitive attribute.
-    // The encoder only includes transitive attributes, so MED is dropped.
-    // This is correct BGP behavior: MED is not propagated between ASes.
+fn update_attr_med_preserved_on_encode() {
+    // MED (MULTI_EXIT_DESC) is included by the encoder so iBGP peers receive
+    // it.  Stripping for eBGP peers is handled by export_attrs() before the
+    // message reaches the encoder, not inside the encoder itself.
     let med_value: u32 = 150;
     let mut attrs = (*ipv4_attrs("192.0.2.254".parse().unwrap())).clone();
     attrs.push(Attribute::new_with_value(Attribute::MULTI_EXIT_DESC, med_value).unwrap());
@@ -303,15 +303,13 @@ fn update_attr_med_dropped_on_encode() {
 
     match round_trip(&msg, ipv4_codec()) {
         ParsedMessage::Update(ParsedUpdate::Routes { attrs, reach, .. }) => {
-            // Routes should be present (not withdrawn)
             assert!(!reach.unwrap().entries.is_empty());
-            // MED is dropped because it's optional non-transitive
             assert!(
                 attrs
                     .iter()
-                    .find(|a| a.code() == Attribute::MULTI_EXIT_DESC)
-                    .is_none(),
-                "MED must be dropped on encode (non-transitive optional attribute)"
+                    .any(|a| a.code() == Attribute::MULTI_EXIT_DESC
+                        && a.value() == Some(med_value)),
+                "MED must be preserved by the encoder (eBGP stripping is export_attrs()'s job)"
             );
         }
         _ => panic!("expected Update"),


### PR DESCRIPTION
RFC 4271 ss5.1.4 says MED received over eBGP MAY be propagated to iBGP peers and MUST NOT be propagated to other neighboring ASes.  BIRD and FRR both implement this: pass MED through to iBGP, strip it on eBGP export.

RustyBGP encoded only FLAG_TRANSITIVE attributes, which silently dropped MED (FLAG_OPTIONAL) for all peer types.  Fix in two places:

packet: add MULTI_EXIT_DESC to the encoder exception list alongside ORIGINATOR_ID and CLUSTER_LIST so iBGP UPDATEs carry MED on the wire.

daemon: add MULTI_EXIT_DESC to the eBGP export_attrs() strip filter so MED received from an external peer is removed before the UPDATE is sent to another external peer, matching the MUST NOT requirement.

Add unit tests ebgp_export_strips_med and ibgp_export_keeps_med to lock in the expected behavior for both peer roles.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>