### PR TITLE
packet,daemon: fix Flowspec route reception and local injection

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -5590,4 +5590,57 @@ bgp-actions.set-next-hop = "self"
         };
         assert!(net_from_api(nlri, Family::IPV4).is_err());
     }
+
+    // --- attr_from_api: Flowspec MpReach ---
+
+    #[test]
+    fn attr_from_api_flowspec_mpreach_empty_nexthops_accepted() {
+        // RFC 8955 §4: Flowspec carries no nexthop.  gobgp sends MpReach with
+        // an empty next_hops list for locally injected Flowspec routes.
+        // Before the fix, attr_from_api() returned an error for empty next_hops.
+        let attr = api::Attribute {
+            attr: Some(api::attribute::Attr::MpReach(api::MpReachNlriAttribute {
+                family: Some(api::Family {
+                    afi: 1,    // IPv4
+                    safi: 133, // Flowspec
+                }),
+                next_hops: vec![],
+                nlris: vec![],
+            })),
+        };
+        let result = attr_from_api(attr);
+        assert!(
+            result.is_ok(),
+            "Flowspec MpReach with empty next_hops must succeed: {:?}",
+            result
+        );
+        let attribute = result.unwrap();
+        assert_eq!(attribute.code(), rustybgp_packet::Attribute::MP_REACH);
+        // Wire format: AFI(2) + SAFI(1) + nexthop_len=0(1) + reserved=0(1) = 5 bytes
+        let data = attribute.binary().expect("MP_REACH must have binary data");
+        assert_eq!(
+            data.len(),
+            5,
+            "Flowspec MP_REACH must encode as 5-byte header with nexthop_len=0"
+        );
+    }
+
+    #[test]
+    fn attr_from_api_flowspec_vpn_mpreach_empty_nexthops_accepted() {
+        // Same as above but for Flowspec VPN (SAFI 134).
+        let attr = api::Attribute {
+            attr: Some(api::attribute::Attr::MpReach(api::MpReachNlriAttribute {
+                family: Some(api::Family {
+                    afi: 1,
+                    safi: 134, // Flowspec VPN
+                }),
+                next_hops: vec![],
+                nlris: vec![],
+            })),
+        };
+        assert!(
+            attr_from_api(attr).is_ok(),
+            "Flowspec VPN MpReach with empty next_hops must succeed"
+        );
+    }
 }

--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -2167,6 +2167,18 @@ pub(crate) fn attr_from_api(a: api::Attribute) -> Result<Attribute, Error> {
             let family = m
                 .family
                 .ok_or_else(|| Error::InvalidArgument("mp_reach missing family".to_string()))?;
+            // RFC 8955 §4: Flowspec carries no nexthop; encode with nexthop_len=0.
+            // SAFI 133 = Flowspec, 134 = Flowspec VPN (IANA-assigned, stable).
+            let is_flowspec = matches!(family.safi as u8, 133 | 134);
+            if is_flowspec && m.next_hops.is_empty() {
+                let mut c = Cursor::new(Vec::with_capacity(5));
+                c.write_u16::<NetworkEndian>(family.afi as u16).unwrap();
+                c.write_u8(family.safi as u8).unwrap();
+                c.write_u8(0).unwrap(); // nexthop_len = 0
+                c.write_u8(0).unwrap(); // reserved
+                return Attribute::new_with_bin(Attribute::MP_REACH, c.into_inner())
+                    .ok_or(Error::InvalidArgument("unsupported attribute".to_string()));
+            }
             let nh_str = m.next_hops.first().ok_or_else(|| {
                 Error::InvalidArgument("mp_reach must carry at least one nexthop".to_string())
             })?;

--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -2168,8 +2168,15 @@ pub(crate) fn attr_from_api(a: api::Attribute) -> Result<Attribute, Error> {
                 .family
                 .ok_or_else(|| Error::InvalidArgument("mp_reach missing family".to_string()))?;
             // RFC 8955 §4: Flowspec carries no nexthop; encode with nexthop_len=0.
-            // SAFI 133 = Flowspec, 134 = Flowspec VPN (IANA-assigned, stable).
-            let is_flowspec = matches!(family.safi as u8, 133 | 134);
+            let pkt_family =
+                rustybgp_packet::Family::new((family.afi as u32) << 16 | family.safi as u32);
+            let is_flowspec = matches!(
+                pkt_family,
+                rustybgp_packet::Family::IPV4_FLOWSPEC
+                    | rustybgp_packet::Family::IPV6_FLOWSPEC
+                    | rustybgp_packet::Family::IPV4_FLOWSPEC_VPN
+                    | rustybgp_packet::Family::IPV6_FLOWSPEC_VPN
+            );
             if is_flowspec && m.next_hops.is_empty() {
                 let mut c = Cursor::new(Vec::with_capacity(5));
                 c.write_u16::<NetworkEndian>(family.afi as u16).unwrap();

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -1828,8 +1828,11 @@ fn validate_update(update: ParsedUpdate, is_ebgp: bool) -> Result<Vec<Message>, 
             let mp_reach_missing_nexthop = mp_reach.as_ref().is_some_and(|r| {
                 r.nexthop.is_none()
                     && !matches!(
-                        r.family.safi(),
-                        Family::SAFI_FLOWSPEC | Family::SAFI_FLOWSPEC_VPN
+                        r.family,
+                        Family::IPV4_FLOWSPEC
+                            | Family::IPV6_FLOWSPEC
+                            | Family::IPV4_FLOWSPEC_VPN
+                            | Family::IPV6_FLOWSPEC_VPN
                     )
             });
             let missing_mandatory = (reach.is_some() || mp_reach.is_some())
@@ -2093,8 +2096,11 @@ impl PeerCodec {
         // §4.3.2); other families pad IPv4 to 16 bytes for MP_REACH.
         let nh_bytes = nexthop.map(|nh| nh.to_bytes()).unwrap_or_default();
         if matches!(
-            family.safi(),
-            Family::SAFI_FLOWSPEC | Family::SAFI_FLOWSPEC_VPN
+            *family,
+            Family::IPV4_FLOWSPEC
+                | Family::IPV6_FLOWSPEC
+                | Family::IPV4_FLOWSPEC_VPN
+                | Family::IPV6_FLOWSPEC_VPN
         ) {
             // Flowspec carries no nexthop (RFC 8955 §4): nexthop_len=0.
             dst.put_u8(0);
@@ -2718,8 +2724,11 @@ impl PeerCodec {
                         // FlowSpec carries no nexthop (RFC 8955 §4). Any other
                         // family with nexthop_len=0 is malformed.
                         0 if matches!(
-                            family.safi(),
-                            Family::SAFI_FLOWSPEC | Family::SAFI_FLOWSPEC_VPN
+                            family,
+                            Family::IPV4_FLOWSPEC
+                                | Family::IPV6_FLOWSPEC
+                                | Family::IPV4_FLOWSPEC_VPN
+                                | Family::IPV6_FLOWSPEC_VPN
                         ) =>
                         {
                             None

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -1824,11 +1824,19 @@ fn validate_update(update: ParsedUpdate, is_ebgp: bool) -> Result<Vec<Message>, 
             // NEXTHOP is extracted into reach.nexthop (from the NEXTHOP attribute
             // for traditional IPv4, or from MP_REACH_NLRI for other families) and
             // never appears in attrs, so its presence is checked via the ReachNlri.
+            // RFC 8955 §4: Flowspec routes carry no nexthop in MP_REACH_NLRI.
+            let mp_reach_missing_nexthop = mp_reach.as_ref().is_some_and(|r| {
+                r.nexthop.is_none()
+                    && !matches!(
+                        r.family.safi(),
+                        Family::SAFI_FLOWSPEC | Family::SAFI_FLOWSPEC_VPN
+                    )
+            });
             let missing_mandatory = (reach.is_some() || mp_reach.is_some())
                 && (!attrs.iter().any(|a| a.code() == Attribute::ORIGIN)
                     || !attrs.iter().any(|a| a.code() == Attribute::AS_PATH)
                     || reach.as_ref().is_some_and(|r| r.nexthop.is_none())
-                    || mp_reach.as_ref().is_some_and(|r| r.nexthop.is_none()));
+                    || mp_reach_missing_nexthop);
 
             // RFC 7606: classify each attribute error.
             // Optional non-transitive: attribute discard (already absent from attrs).

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -1557,3 +1557,49 @@ fn missing_nexthop_attr_with_mpreach_ok() {
         "IPv6 MP_REACH without NEXTHOP attribute must be accepted"
     );
 }
+
+#[test]
+fn flowspec_ipv4_no_nexthop_accepted() {
+    // RFC 8955 §4: Flowspec routes carry no nexthop in MP_REACH_NLRI.
+    // Before the fix, validate_update() treated nexthop=None as a missing
+    // mandatory attribute and converted the route to a withdrawal.
+    //
+    // Flowspec NLRI: length-prefixed component list (RFC 8955 §4).
+    //   nlri_len=3, type=1 (destination prefix), prefix_len=8, prefix=0x0a (10.0.0.0/8)
+    let flowspec_nlri: &[u8] = &[0x03, 0x01, 0x08, 0x0a];
+    let mp: Vec<u8> = {
+        let mut v = Vec::new();
+        v.extend_from_slice(&[0x00, 0x01]); // AFI = IPv4
+        v.push(133); // SAFI = Flowspec
+        v.push(0x00); // nexthop_len = 0 (RFC 8955 §4)
+        v.push(0x00); // reserved
+        v.extend_from_slice(flowspec_nlri);
+        v
+    };
+    let mut attr_bytes: Vec<u8> = Vec::new();
+    attr_bytes.extend_from_slice(&[0x40, 0x01, 0x01, 0x00]); // ORIGIN = IGP
+    attr_bytes.extend_from_slice(&[0x40, 0x02, 0x00]); // AS_PATH = empty
+    attr_bytes.push(0x80); // optional non-transitive
+    attr_bytes.push(0x0e); // type = MP_REACH_NLRI
+    attr_bytes.push(mp.len() as u8);
+    attr_bytes.extend_from_slice(&mp);
+
+    let attr_len = attr_bytes.len() as u16;
+    let total = 19u16 + 2 + 2 + attr_len;
+    let mut buf = vec![0xffu8; 16];
+    buf.extend_from_slice(&total.to_be_bytes());
+    buf.push(2); // UPDATE
+    buf.extend_from_slice(&0u16.to_be_bytes()); // withdrawn_len = 0
+    buf.extend_from_slice(&attr_len.to_be_bytes());
+    buf.extend_from_slice(&attr_bytes);
+
+    let mut codec = PeerCodec::new();
+    codec.set_family(Family::IPV4_FLOWSPEC, Default::default());
+    let parsed = codec.parse_message(&buf).expect("parse ok");
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
+    assert_eq!(msgs.len(), 1);
+    assert!(
+        matches!(&msgs[0], Message::Update(Update::Reach { .. })),
+        "Flowspec MP_REACH with nexthop_len=0 must be accepted, not treated as withdraw"
+    );
+}


### PR DESCRIPTION
Two bugs prevented Flowspec routes from working correctly:

1. validate_update() in packet/src/bgp.rs incorrectly treated Flowspec MP_REACH_NLRI as having a missing mandatory NEXTHOP attribute.  RFC 8955 section 4 explicitly states that Flowspec routes carry no nexthop.  The nexthop check now skips SAFI 133 and 134 so Flowspec updates are accepted instead of being converted to withdrawals.

2. attr_from_api() in daemon/src/convert.rs rejected MpReach attributes with an empty next_hops list.  When gobgp injects a local Flowspec route the gRPC AddPath request carries an MpReach with no nexthop entries; RFC 8955 requires nexthop_len=0 for Flowspec.  The handler now encodes nexthop_len=0 for SAFI 133/134 instead of returning an error.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>