### PR TITLE
packet: change Family::new to take (afi: u16, safi: u8) and make it c…

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -1793,7 +1793,7 @@ fn ensure_u16(name: &str, v: u32) -> Result<u16, Error> {
 }
 
 pub(crate) fn family_from_api(f: &api::Family) -> Family {
-    Family::new((f.afi as u32) << 16 | f.safi as u32)
+    Family::new(f.afi as u16, f.safi as u8)
 }
 
 pub(crate) fn family_from_config(f: &config::generate::AfiSafiType) -> Result<Family, ()> {
@@ -2168,8 +2168,7 @@ pub(crate) fn attr_from_api(a: api::Attribute) -> Result<Attribute, Error> {
                 .family
                 .ok_or_else(|| Error::InvalidArgument("mp_reach missing family".to_string()))?;
             // RFC 8955 §4: Flowspec carries no nexthop; encode with nexthop_len=0.
-            let pkt_family =
-                rustybgp_packet::Family::new((family.afi as u32) << 16 | family.safi as u32);
+            let pkt_family = rustybgp_packet::Family::new(family.afi as u16, family.safi as u8);
             let is_flowspec = matches!(
                 pkt_family,
                 rustybgp_packet::Family::IPV4_FLOWSPEC
@@ -3144,7 +3143,7 @@ pub(crate) fn conditions_from_api(
         let families: Vec<rustybgp_packet::Family> = conditions
             .afi_safi_in
             .iter()
-            .map(|f| rustybgp_packet::Family::new((f.afi as u32) << 16 | f.safi as u32))
+            .map(|f| rustybgp_packet::Family::new(f.afi as u16, f.safi as u8))
             .collect();
         v.push(ConditionConfig::AfiSafiIn(families));
     }

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -369,7 +369,7 @@ impl Family {
     pub const IPV6_FLOWSPEC: Family = Family::new(Family::AFI_IP6, Family::SAFI_FLOWSPEC);
     pub const IPV4_FLOWSPEC_VPN: Family = Family::new(Family::AFI_IP, Family::SAFI_FLOWSPEC_VPN);
     pub const IPV6_FLOWSPEC_VPN: Family = Family::new(Family::AFI_IP6, Family::SAFI_FLOWSPEC_VPN);
-    pub const BGP_LS: Family = Family::new(Family::AFI_LS, Family::SAFI_LS);
+    pub const LS: Family = Family::new(Family::AFI_LS, Family::SAFI_LS);
 
     pub const fn new(afi: u16, safi: u8) -> Self {
         Family((afi as u32) << 16 | safi as u32)
@@ -596,7 +596,7 @@ impl Nlri {
             Family::IPV6_FLOWSPEC_VPN => crate::flowspec::FlowspecVpnV6Nlri::decode(c, len)
                 .map(Nlri::FlowspecVpnV6)
                 .map_err(|_| Notification::UpdateMalformedAttributeList),
-            Family::BGP_LS => crate::bgp_ls::BgpLsNlri::decode(c)
+            Family::LS => crate::bgp_ls::BgpLsNlri::decode(c)
                 .map(Nlri::Ls)
                 .ok_or(Notification::UpdateMalformedAttributeList),
             _ => Err(Notification::UpdateMalformedAttributeList),

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -347,12 +347,12 @@ impl Family {
     const SAFI_UNICAST: u8 = 1;
     const SAFI_MULTICAST: u8 = 2;
     const SAFI_LABELED_UNICAST: u8 = 4;
+    const SAFI_LS: u8 = 71;
     const SAFI_MUP: u8 = 85;
-    const SAFI_FLOWSPEC: u8 = 133;
-    const SAFI_FLOWSPEC_VPN: u8 = 134;
     const SAFI_MPLS_VPN: u8 = 128;
     const SAFI_MPLS_VPN6: u8 = 129;
-    const SAFI_LS: u8 = 71;
+    const SAFI_FLOWSPEC: u8 = 133;
+    const SAFI_FLOWSPEC_VPN: u8 = 134;
 
     pub const EMPTY: Family = Family::new(0, 0);
     pub const IPV4: Family = Family::new(Family::AFI_IP, Family::SAFI_UNICAST);
@@ -361,6 +361,7 @@ impl Family {
     pub const IPV6_MC: Family = Family::new(Family::AFI_IP6, Family::SAFI_MULTICAST);
     pub const IPV4_MPLS: Family = Family::new(Family::AFI_IP, Family::SAFI_LABELED_UNICAST);
     pub const IPV6_MPLS: Family = Family::new(Family::AFI_IP6, Family::SAFI_LABELED_UNICAST);
+    pub const LS: Family = Family::new(Family::AFI_LS, Family::SAFI_LS);
     pub const IPV4_MUP: Family = Family::new(Family::AFI_IP, Family::SAFI_MUP);
     pub const IPV6_MUP: Family = Family::new(Family::AFI_IP6, Family::SAFI_MUP);
     pub const IPV4_VPN: Family = Family::new(Family::AFI_IP, Family::SAFI_MPLS_VPN);
@@ -369,7 +370,6 @@ impl Family {
     pub const IPV6_FLOWSPEC: Family = Family::new(Family::AFI_IP6, Family::SAFI_FLOWSPEC);
     pub const IPV4_FLOWSPEC_VPN: Family = Family::new(Family::AFI_IP, Family::SAFI_FLOWSPEC_VPN);
     pub const IPV6_FLOWSPEC_VPN: Family = Family::new(Family::AFI_IP6, Family::SAFI_FLOWSPEC_VPN);
-    pub const LS: Family = Family::new(Family::AFI_LS, Family::SAFI_LS);
 
     pub const fn new(afi: u16, safi: u8) -> Self {
         Family((afi as u32) << 16 | safi as u32)

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -354,35 +354,25 @@ impl Family {
     const SAFI_MPLS_VPN6: u8 = 129;
     const SAFI_LS: u8 = 71;
 
-    pub const EMPTY: Family = Family(0);
-    pub const IPV4: Family = Family((Family::AFI_IP as u32) << 16 | Family::SAFI_UNICAST as u32);
-    pub const IPV6: Family = Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_UNICAST as u32);
-    pub const IPV4_MC: Family =
-        Family((Family::AFI_IP as u32) << 16 | Family::SAFI_MULTICAST as u32);
-    pub const IPV6_MC: Family =
-        Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_MULTICAST as u32);
-    pub const IPV4_MPLS: Family =
-        Family((Family::AFI_IP as u32) << 16 | Family::SAFI_LABELED_UNICAST as u32);
-    pub const IPV6_MPLS: Family =
-        Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_LABELED_UNICAST as u32);
-    pub const IPV4_MUP: Family = Family((Family::AFI_IP as u32) << 16 | Family::SAFI_MUP as u32);
-    pub const IPV6_MUP: Family = Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_MUP as u32);
-    pub const IPV4_VPN: Family =
-        Family((Family::AFI_IP as u32) << 16 | Family::SAFI_MPLS_VPN as u32);
-    pub const IPV6_VPN: Family =
-        Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_MPLS_VPN6 as u32);
-    pub const IPV4_FLOWSPEC: Family =
-        Family((Family::AFI_IP as u32) << 16 | Family::SAFI_FLOWSPEC as u32);
-    pub const IPV6_FLOWSPEC: Family =
-        Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_FLOWSPEC as u32);
-    pub const IPV4_FLOWSPEC_VPN: Family =
-        Family((Family::AFI_IP as u32) << 16 | Family::SAFI_FLOWSPEC_VPN as u32);
-    pub const IPV6_FLOWSPEC_VPN: Family =
-        Family((Family::AFI_IP6 as u32) << 16 | Family::SAFI_FLOWSPEC_VPN as u32);
-    pub const BGP_LS: Family = Family((Family::AFI_LS as u32) << 16 | Family::SAFI_LS as u32);
+    pub const EMPTY: Family = Family::new(0, 0);
+    pub const IPV4: Family = Family::new(Family::AFI_IP, Family::SAFI_UNICAST);
+    pub const IPV6: Family = Family::new(Family::AFI_IP6, Family::SAFI_UNICAST);
+    pub const IPV4_MC: Family = Family::new(Family::AFI_IP, Family::SAFI_MULTICAST);
+    pub const IPV6_MC: Family = Family::new(Family::AFI_IP6, Family::SAFI_MULTICAST);
+    pub const IPV4_MPLS: Family = Family::new(Family::AFI_IP, Family::SAFI_LABELED_UNICAST);
+    pub const IPV6_MPLS: Family = Family::new(Family::AFI_IP6, Family::SAFI_LABELED_UNICAST);
+    pub const IPV4_MUP: Family = Family::new(Family::AFI_IP, Family::SAFI_MUP);
+    pub const IPV6_MUP: Family = Family::new(Family::AFI_IP6, Family::SAFI_MUP);
+    pub const IPV4_VPN: Family = Family::new(Family::AFI_IP, Family::SAFI_MPLS_VPN);
+    pub const IPV6_VPN: Family = Family::new(Family::AFI_IP6, Family::SAFI_MPLS_VPN6);
+    pub const IPV4_FLOWSPEC: Family = Family::new(Family::AFI_IP, Family::SAFI_FLOWSPEC);
+    pub const IPV6_FLOWSPEC: Family = Family::new(Family::AFI_IP6, Family::SAFI_FLOWSPEC);
+    pub const IPV4_FLOWSPEC_VPN: Family = Family::new(Family::AFI_IP, Family::SAFI_FLOWSPEC_VPN);
+    pub const IPV6_FLOWSPEC_VPN: Family = Family::new(Family::AFI_IP6, Family::SAFI_FLOWSPEC_VPN);
+    pub const BGP_LS: Family = Family::new(Family::AFI_LS, Family::SAFI_LS);
 
-    pub fn new(v: u32) -> Self {
-        Family(v)
+    pub const fn new(afi: u16, safi: u8) -> Self {
+        Family((afi as u32) << 16 | safi as u32)
     }
 
     pub fn afi(&self) -> u16 {
@@ -873,8 +863,7 @@ fn nlri_decode_unsupported_family() {
     let buf = vec![24, 10, 0, 0];
     let len = buf.len();
     let mut c = BgpReader::<UpdateCtx>::new(&buf);
-    let mup_ipv4 = Family::new((Family::AFI_IP as u32) << 16 | 85);
-    assert!(Nlri::decode(mup_ipv4, &mut c, len, true).is_err());
+    assert!(Nlri::decode(Family::IPV4_MUP, &mut c, len, true).is_err());
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -752,10 +752,9 @@ fn mp_reach_zero_nexthop_non_flowspec_is_error() {
 #[test]
 fn mp_reach_zero_nexthop_flowspec_is_ok() {
     // nexthop_len=0 is valid for FlowSpec (RFC 8955 §4).
-    let ipv4_flowspec = Family::new((Family::AFI_IP as u32) << 16 | 133);
     let buf = mp_reach_zero_nexthop_update(Family::AFI_IP, 133);
     let mut codec = PeerCodec::new();
-    codec.set_family(ipv4_flowspec, FamilyState::default());
+    codec.set_family(Family::IPV4_FLOWSPEC, FamilyState::default());
     assert!(
         codec.parse_message(&buf).is_ok(),
         "FlowSpec nexthop_len=0 must be accepted"

--- a/table/src/policy.rs
+++ b/table/src/policy.rs
@@ -555,7 +555,7 @@ fn nlri_family(net: &packet::Nlri) -> bgp::Family {
         packet::Nlri::FlowspecV6(_) => bgp::Family::IPV6_FLOWSPEC,
         packet::Nlri::FlowspecVpnV4(_) => bgp::Family::IPV4_FLOWSPEC_VPN,
         packet::Nlri::FlowspecVpnV6(_) => bgp::Family::IPV6_FLOWSPEC_VPN,
-        packet::Nlri::Ls(_) => bgp::Family::BGP_LS,
+        packet::Nlri::Ls(_) => bgp::Family::LS,
     }
 }
 


### PR DESCRIPTION
…onst fn

Family::new previously accepted a raw u32, requiring callers to perform the AFI/SAFI bit-packing themselves.  Separating the parameters makes the intent obvious at each call site and eliminates ad-hoc shifts.

Making the function const fn allows the public Family constants (IPV4, IPV6, IPV4_FLOWSPEC, etc.) to be expressed via Family::new instead of the raw Family(expr) tuple constructor, keeping the bit-layout in one place.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>