### PR TITLE
tests/e2e: add RFC 4456 Route Reflector end-to-end test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,3 +136,25 @@ jobs:
           RUSTYBGP_BUILD_CONTEXT: /tmp/rustybgp-prebuilt
           RUSTYBGP_DOCKERFILE: Dockerfile
         run: ./run-test.sh
+
+  e2e-rfc4456:
+    name: RFC 4456 (Route Reflector) end-to-end
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: rustybgpd-musl
+          path: /tmp/rustybgp-prebuilt
+      - name: prepare prebuilt context
+        run: |
+          chmod +x /tmp/rustybgp-prebuilt/rustybgpd
+          cp tests/e2e/shared/Dockerfile.rustybgp-prebuilt /tmp/rustybgp-prebuilt/Dockerfile
+      - name: Run RFC 4456 e2e test
+        working-directory: tests/e2e/rfc4456
+        env:
+          RUSTYBGP_BUILD_CONTEXT: /tmp/rustybgp-prebuilt
+          RUSTYBGP_DOCKERFILE: Dockerfile
+        run: ./run-test.sh

--- a/tests/e2e/rfc4456/docker-compose.yml
+++ b/tests/e2e/rfc4456/docker-compose.yml
@@ -1,0 +1,73 @@
+networks:
+  ibgp-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.10.0/24
+          gateway: 172.30.10.254
+
+  ext-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.11.0/24
+          gateway: 172.30.11.254
+
+services:
+  rusty-rr:
+    build:
+      context: ${RUSTYBGP_BUILD_CONTEXT:-../../..}
+      dockerfile: ${RUSTYBGP_DOCKERFILE:-tests/e2e/shared/Dockerfile.rustybgp}
+      args:
+        RUST_TARGET: ${RUST_TARGET:-aarch64-unknown-linux-musl}
+    container_name: rusty-rr
+    privileged: true
+    sysctls:
+      - net.ipv4.ip_forward=1
+    networks:
+      ibgp-net:
+        ipv4_address: 172.30.10.1
+      ext-net:
+        ipv4_address: 172.30.11.1
+    volumes:
+      - ./rustybgp.yaml:/etc/rustybgp.yaml:ro
+      - ./entrypoint-rusty.sh:/entrypoint.sh:ro
+
+  frr-a:
+    image: quay.io/frrouting/frr:10.6.0
+    container_name: frr-a
+    privileged: true
+    volumes:
+      - ./frr-a/frr.conf:/etc/frr/frr.conf:ro
+      - ../shared/daemons:/etc/frr/daemons:ro
+    sysctls:
+      - net.ipv4.ip_forward=1
+    networks:
+      ibgp-net:
+        ipv4_address: 172.30.10.2
+
+  frr-b:
+    image: quay.io/frrouting/frr:10.6.0
+    container_name: frr-b
+    privileged: true
+    volumes:
+      - ./frr-b/frr.conf:/etc/frr/frr.conf:ro
+      - ../shared/daemons:/etc/frr/daemons:ro
+    sysctls:
+      - net.ipv4.ip_forward=1
+    networks:
+      ibgp-net:
+        ipv4_address: 172.30.10.3
+
+  frr-ext:
+    image: quay.io/frrouting/frr:10.6.0
+    container_name: frr-ext
+    privileged: true
+    volumes:
+      - ./frr-ext/frr.conf:/etc/frr/frr.conf:ro
+      - ../shared/daemons:/etc/frr/daemons:ro
+    sysctls:
+      - net.ipv4.ip_forward=1
+    networks:
+      ext-net:
+        ipv4_address: 172.30.11.2

--- a/tests/e2e/rfc4456/entrypoint-rusty.sh
+++ b/tests/e2e/rfc4456/entrypoint-rusty.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+sysctl -w net.ipv4.ip_forward=1 2>/dev/null || true
+
+rustybgpd -f /etc/rustybgp.yaml &
+BGPD_PID=$!
+
+MAX_ATTEMPTS=30
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    if gobgp global 2>/dev/null; then
+        echo "rustybgpd gRPC API is ready"
+        break
+    fi
+    if [ "$i" -eq "$MAX_ATTEMPTS" ]; then
+        echo "rustybgpd gRPC API not ready after $MAX_ATTEMPTS attempts"
+        exit 1
+    fi
+    sleep 1
+done
+
+wait $BGPD_PID

--- a/tests/e2e/rfc4456/frr-a/frr.conf
+++ b/tests/e2e/rfc4456/frr-a/frr.conf
@@ -1,0 +1,16 @@
+frr defaults traditional
+hostname frr-a
+log syslog informational
+!
+router bgp 65001
+ bgp router-id 172.30.10.2
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 172.30.10.1 remote-as 65001
+ neighbor 172.30.10.1 update-source 172.30.10.2
+ !
+ address-family ipv4 unicast
+  neighbor 172.30.10.1 activate
+  network 10.0.1.0/24
+ exit-address-family
+!

--- a/tests/e2e/rfc4456/frr-b/frr.conf
+++ b/tests/e2e/rfc4456/frr-b/frr.conf
@@ -1,0 +1,16 @@
+frr defaults traditional
+hostname frr-b
+log syslog informational
+!
+router bgp 65001
+ bgp router-id 172.30.10.3
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 172.30.10.1 remote-as 65001
+ neighbor 172.30.10.1 update-source 172.30.10.3
+ !
+ address-family ipv4 unicast
+  neighbor 172.30.10.1 activate
+  network 10.0.2.0/24
+ exit-address-family
+!

--- a/tests/e2e/rfc4456/frr-ext/frr.conf
+++ b/tests/e2e/rfc4456/frr-ext/frr.conf
@@ -1,0 +1,15 @@
+frr defaults traditional
+hostname frr-ext
+log syslog informational
+!
+router bgp 65002
+ bgp router-id 172.30.11.2
+ no bgp ebgp-requires-policy
+ no bgp network import-check
+ neighbor 172.30.11.1 remote-as 65001
+ !
+ address-family ipv4 unicast
+  neighbor 172.30.11.1 activate
+  network 10.0.3.0/24
+ exit-address-family
+!

--- a/tests/e2e/rfc4456/run-test.sh
+++ b/tests/e2e/rfc4456/run-test.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Route Reflector End-to-End Test (RFC 4456)
+#
+# Topology:
+#   [frr-a (AS 65001, iBGP)] \
+#                             -- [rusty-rr (AS 65001, RR)] -- [frr-ext (AS 65002, eBGP)]
+#   [frr-b (AS 65001, iBGP)] /
+#
+# Networks:
+#   ibgp-net: 172.30.10.0/24  (rusty-rr .1, frr-a .2, frr-b .3)
+#   ext-net:  172.30.11.0/24  (rusty-rr .1, frr-ext .2)
+#
+# Test scenarios:
+#   1. iBGP sessions established (frr-a and frr-b to rusty-rr)
+#   2. eBGP session established (frr-ext to rusty-rr)
+#   3. frr-a's prefix (10.0.1.0/24) is reflected to frr-b
+#   4. frr-b's prefix (10.0.2.0/24) is reflected to frr-a
+#   5. frr-ext's prefix (10.0.3.0/24) reaches frr-a and frr-b
+#   6. Reflected routes carry ORIGINATOR_ID (RFC 4456 §8)
+#   7. Reflected routes carry CLUSTER_LIST (RFC 4456 §8)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+source ../shared/helpers.sh
+
+PASS=0
+FAIL=0
+
+pass() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    docker compose down --volumes --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== Route Reflector (RFC 4456) End-to-End Test ==="
+echo ""
+
+echo "Building and starting containers..."
+docker compose up -d --build --force-recreate 2>&1
+
+echo "Waiting for BGP convergence..."
+MAX_WAIT=60
+A_OK=false
+B_OK=false
+EXT_OK=false
+
+for i in $(seq 1 $MAX_WAIT); do
+    if ! $A_OK && [ "$(frr_bgp_state frr-a 172.30.10.1)" = "Established" ]; then
+        A_OK=true
+        echo "  frr-a <-> rusty-rr established after ${i}s"
+    fi
+    if ! $B_OK && [ "$(frr_bgp_state frr-b 172.30.10.1)" = "Established" ]; then
+        B_OK=true
+        echo "  frr-b <-> rusty-rr established after ${i}s"
+    fi
+    if ! $EXT_OK && [ "$(frr_bgp_state frr-ext 172.30.11.1)" = "Established" ]; then
+        EXT_OK=true
+        echo "  frr-ext <-> rusty-rr established after ${i}s"
+    fi
+    if $A_OK && $B_OK && $EXT_OK; then
+        break
+    fi
+    if [ "$i" -eq "$MAX_WAIT" ]; then
+        echo "BGP sessions did not fully establish within ${MAX_WAIT}s"
+        echo ""
+        echo "--- frr-a BGP summary ---"
+        docker exec frr-a vtysh -c "show bgp summary" 2>/dev/null || true
+        echo "--- frr-b BGP summary ---"
+        docker exec frr-b vtysh -c "show bgp summary" 2>/dev/null || true
+        echo "--- frr-ext BGP summary ---"
+        docker exec frr-ext vtysh -c "show bgp summary" 2>/dev/null || true
+        echo "--- rusty-rr logs ---"
+        docker logs rusty-rr 2>&1 | tail -20
+    fi
+    sleep 1
+done
+
+# Allow additional convergence time for route propagation
+sleep 3
+
+echo ""
+echo "--- Test Results ---"
+
+# Test 1: frr-a iBGP session established
+if $A_OK; then
+    pass "frr-a <-> rusty-rr iBGP session established"
+else
+    fail "frr-a <-> rusty-rr iBGP session established"
+fi
+
+# Test 2: frr-b iBGP session established
+if $B_OK; then
+    pass "frr-b <-> rusty-rr iBGP session established"
+else
+    fail "frr-b <-> rusty-rr iBGP session established"
+fi
+
+# Test 3: frr-ext eBGP session established
+if $EXT_OK; then
+    pass "frr-ext <-> rusty-rr eBGP session established"
+else
+    fail "frr-ext <-> rusty-rr eBGP session established"
+fi
+
+# Test 4: frr-a's prefix (10.0.1.0/24) is reflected to frr-b
+PATHS_B=$(docker exec frr-b vtysh -c "show bgp ipv4 unicast 10.0.1.0/24 json" 2>/dev/null \
+    | jq '.paths | length' 2>/dev/null || echo "0")
+if [ "$PATHS_B" -ge 1 ]; then
+    pass "frr-b received frr-a's prefix 10.0.1.0/24 via RR"
+else
+    fail "frr-b received frr-a's prefix 10.0.1.0/24 via RR"
+    echo "    Debug: frr-b RIB for 10.0.1.0/24:"
+    docker exec frr-b vtysh -c "show bgp ipv4 unicast 10.0.1.0/24" 2>/dev/null || true
+fi
+
+# Test 5: frr-b's prefix (10.0.2.0/24) is reflected to frr-a
+PATHS_A=$(docker exec frr-a vtysh -c "show bgp ipv4 unicast 10.0.2.0/24 json" 2>/dev/null \
+    | jq '.paths | length' 2>/dev/null || echo "0")
+if [ "$PATHS_A" -ge 1 ]; then
+    pass "frr-a received frr-b's prefix 10.0.2.0/24 via RR"
+else
+    fail "frr-a received frr-b's prefix 10.0.2.0/24 via RR"
+    echo "    Debug: frr-a RIB for 10.0.2.0/24:"
+    docker exec frr-a vtysh -c "show bgp ipv4 unicast 10.0.2.0/24" 2>/dev/null || true
+fi
+
+# Test 6: frr-ext's prefix (10.0.3.0/24) reaches frr-a
+PATHS_A_EXT=$(docker exec frr-a vtysh -c "show bgp ipv4 unicast 10.0.3.0/24 json" 2>/dev/null \
+    | jq '.paths | length' 2>/dev/null || echo "0")
+if [ "$PATHS_A_EXT" -ge 1 ]; then
+    pass "frr-a received frr-ext's prefix 10.0.3.0/24"
+else
+    fail "frr-a received frr-ext's prefix 10.0.3.0/24"
+fi
+
+# Test 7: frr-ext's prefix (10.0.3.0/24) reaches frr-b
+PATHS_B_EXT=$(docker exec frr-b vtysh -c "show bgp ipv4 unicast 10.0.3.0/24 json" 2>/dev/null \
+    | jq '.paths | length' 2>/dev/null || echo "0")
+if [ "$PATHS_B_EXT" -ge 1 ]; then
+    pass "frr-b received frr-ext's prefix 10.0.3.0/24"
+else
+    fail "frr-b received frr-ext's prefix 10.0.3.0/24"
+fi
+
+# Test 8: Reflected routes carry ORIGINATOR_ID (RFC 4456 §8)
+# frr-b receives frr-a's route (10.0.1.0/24); the RR must set ORIGINATOR_ID = frr-a's router-id
+ORIGINATOR=$(docker exec frr-b vtysh -c "show bgp ipv4 unicast 10.0.1.0/24 json" 2>/dev/null \
+    | jq -r '.paths[0].originatorId // empty' 2>/dev/null || echo "")
+if [ -n "$ORIGINATOR" ]; then
+    pass "ORIGINATOR_ID present on reflected route (value: $ORIGINATOR)"
+else
+    fail "ORIGINATOR_ID missing on reflected route 10.0.1.0/24 at frr-b"
+    echo "    Debug: frr-b path details:"
+    docker exec frr-b vtysh -c "show bgp ipv4 unicast 10.0.1.0/24 json" 2>/dev/null \
+        | jq '.' 2>/dev/null || true
+fi
+
+# Test 9: Reflected routes carry CLUSTER_LIST (RFC 4456 §8)
+CLUSTER=$(docker exec frr-b vtysh -c "show bgp ipv4 unicast 10.0.1.0/24 json" 2>/dev/null \
+    | jq '.paths[0].clusterList | length' 2>/dev/null || echo "0")
+if [ "$CLUSTER" -ge 1 ]; then
+    pass "CLUSTER_LIST present on reflected route (length: $CLUSTER)"
+else
+    fail "CLUSTER_LIST missing on reflected route 10.0.1.0/24 at frr-b"
+fi
+
+echo ""
+echo "--- BGP Tables ---"
+echo ""
+echo "frr-a RIB:"
+docker exec frr-a vtysh -c "show bgp ipv4 unicast" 2>/dev/null || true
+echo ""
+echo "frr-b RIB:"
+docker exec frr-b vtysh -c "show bgp ipv4 unicast" 2>/dev/null || true
+echo ""
+echo "frr-ext RIB:"
+docker exec frr-ext vtysh -c "show bgp ipv4 unicast" 2>/dev/null || true
+echo ""
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/e2e/rfc4456/rustybgp.yaml
+++ b/tests/e2e/rfc4456/rustybgp.yaml
@@ -1,0 +1,32 @@
+global:
+  config:
+    as: 65001
+    router-id: "172.30.10.1"
+
+neighbors:
+  - config:
+      neighbor-address: "172.30.10.2"
+      peer-as: 65001
+    route-reflector:
+      config:
+        route-reflector-client: true
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast
+
+  - config:
+      neighbor-address: "172.30.10.3"
+      peer-as: 65001
+    route-reflector:
+      config:
+        route-reflector-client: true
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast
+
+  - config:
+      neighbor-address: "172.30.11.2"
+      peer-as: 65002
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast


### PR DESCRIPTION
Adds an e2e test for Route Reflector functionality (RFC 4456) using a Docker Compose topology with four containers: rusty-rr acting as the RR (AS 65001), frr-a and frr-b as iBGP RR clients (AS 65001), and frr-ext as an eBGP peer (AS 65002).

The test verifies:
- iBGP sessions between frr-a/frr-b and rusty-rr establish correctly
- eBGP session between frr-ext and rusty-rr establishes correctly
- iBGP split-horizon relaxation: frr-a's prefix reaches frr-b and vice versa
- eBGP-to-iBGP distribution: frr-ext's prefix reaches both RR clients
- ORIGINATOR_ID is set on reflected routes (RFC 4456 ss8)
- CLUSTER_LIST is populated on reflected routes (RFC 4456 ss8)

Two bugs were found and fixed in the daemon in an accompanying commit: missing LOCAL_PREF injection for eBGP-to-iBGP distribution (RFC 4271 ss5.1.5) and ORIGINATOR_ID/CLUSTER_LIST not reaching the wire (encoding filter too narrow).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>