### PR TITLE
packet: remove attribute filter from encoder; delegate to export_attrs

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -9405,6 +9405,98 @@ mod tests {
             );
         }
 
+        fn attr_with_originator_id() -> Arc<Vec<packet::Attribute>> {
+            Arc::new(vec![
+                packet::Attribute::new_with_value(packet::Attribute::ORIGIN, 0).unwrap(),
+                packet::Attribute::new_with_value(packet::Attribute::ORIGINATOR_ID, 0x0a000001)
+                    .unwrap(),
+            ])
+        }
+
+        fn attr_with_cluster_list() -> Arc<Vec<packet::Attribute>> {
+            Arc::new(vec![
+                packet::Attribute::new_with_value(packet::Attribute::ORIGIN, 0).unwrap(),
+                packet::Attribute::new_with_bin(
+                    packet::Attribute::CLUSTER_LIST,
+                    vec![0x00, 0x00, 0xff, 0x01],
+                )
+                .unwrap(),
+            ])
+        }
+
+        #[test]
+        fn ebgp_export_strips_originator_id() {
+            let ctx = ebgp_ctx();
+            let exported = ctx.export_attrs(&attr_with_originator_id());
+            assert!(
+                exported
+                    .iter()
+                    .all(|a| a.code() != packet::Attribute::ORIGINATOR_ID),
+                "ORIGINATOR_ID must be stripped for eBGP"
+            );
+        }
+
+        #[test]
+        fn ebgp_export_strips_cluster_list() {
+            let ctx = ebgp_ctx();
+            let exported = ctx.export_attrs(&attr_with_cluster_list());
+            assert!(
+                exported
+                    .iter()
+                    .all(|a| a.code() != packet::Attribute::CLUSTER_LIST),
+                "CLUSTER_LIST must be stripped for eBGP"
+            );
+        }
+
+        #[test]
+        fn ibgp_export_keeps_originator_id() {
+            let ctx = ibgp_ctx();
+            let exported = ctx.export_attrs(&attr_with_originator_id());
+            assert!(
+                exported
+                    .iter()
+                    .any(|a| a.code() == packet::Attribute::ORIGINATOR_ID),
+                "ORIGINATOR_ID must be preserved for iBGP"
+            );
+        }
+
+        #[test]
+        fn ibgp_export_keeps_cluster_list() {
+            let ctx = ibgp_ctx();
+            let exported = ctx.export_attrs(&attr_with_cluster_list());
+            assert!(
+                exported
+                    .iter()
+                    .any(|a| a.code() == packet::Attribute::CLUSTER_LIST),
+                "CLUSTER_LIST must be preserved for iBGP"
+            );
+        }
+
+        #[test]
+        fn rs_client_export_passes_attrs_unchanged() {
+            let ctx = rs_client_ctx();
+            // RS client must pass attrs as-is: no stripping, no LOCAL_PREF injection.
+            let attrs = attr_with_originator_id();
+            let exported = ctx.export_attrs(&attrs);
+            assert_eq!(
+                exported.len(),
+                attrs.len(),
+                "RS client must not add or remove any attributes"
+            );
+            assert!(
+                exported
+                    .iter()
+                    .any(|a| a.code() == packet::Attribute::ORIGINATOR_ID),
+                "RS client must preserve ORIGINATOR_ID"
+            );
+            assert!(
+                exported
+                    .iter()
+                    .all(|a| a.code() != packet::Attribute::LOCAL_PREF),
+                "RS client must not inject LOCAL_PREF"
+            );
+        }
+
         #[test]
         fn ebgp_export_rewrites_nexthop() {
             let ctx = ebgp_ctx(); // local_addr = 127.0.0.1

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -2236,24 +2236,12 @@ impl PeerCodec {
                 dst.put_u16(0);
                 let mut attr_len: u16 = 0;
 
-                // Write path attributes.  Encode transitive attrs plus
-                // ORIGINATOR_ID and CLUSTER_LIST, which are optional
-                // non-transitive but required in iBGP UPDATEs (RFC 4456 §8).
-                // MULTI_EXIT_DESC is sent to iBGP peers (export layer strips it
-                // for eBGP per BIRD/FRR convention).
+                // Write path attributes.  The export layer (export_attrs) is
+                // responsible for attribute selection; encode everything given.
                 // NEXTHOP is written below for traditional IPv4.
                 // MP_REACH/MP_UNREACH are synthesized below for MP paths.
                 for a in attr.as_ref() {
-                    if a.flags & Attribute::FLAG_TRANSITIVE > 0
-                        || matches!(
-                            a.code(),
-                            Attribute::ORIGINATOR_ID
-                                | Attribute::CLUSTER_LIST
-                                | Attribute::MULTI_EXIT_DESC
-                        )
-                    {
-                        attr_len += a.encode_wire(dst);
-                    }
+                    attr_len += a.encode_wire(dst);
                 }
 
                 if *family == Family::IPV4 && !ipv4_via_mp {


### PR DESCRIPTION
The encoder was filtering out optional non-transitive attributes (keeping only FLAG_TRANSITIVE ones, with explicit exceptions for ORIGINATOR_ID, CLUSTER_LIST, and MULTI_EXIT_DESC).  This split the "what to send" decision across two layers.

Unknown optional attributes are already silently dropped by the decoder (validate_message), so Path.attrs never contains them.  All role-based filtering (iBGP/eBGP/ConfedEBGP) is already handled by export_attrs() in the daemon before the message reaches the encoder. The encoder's filter was therefore redundant and a source of confusion.

The encoder now writes every attribute it receives, making it a pure serializer.  export_attrs() is the single place that decides which attributes go to which peer type.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>