### PR TITLE
packet,daemon: store and forward unknown optional transitive attrs (R…

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -4836,7 +4836,7 @@ impl PeerExportContext {
     /// all UPDATE messages to internal peers).
     /// RS client: pass through unchanged.
     fn export_attrs(&self, attrs: &Arc<Vec<bgp::Attribute>>) -> Arc<Vec<bgp::Attribute>> {
-        match self.role {
+        let exported = match self.role {
             PeerRole::RsClient => attrs.clone(),
             PeerRole::Ibgp | PeerRole::IbgpRrClient => {
                 inject_local_pref_if_absent(Arc::clone(attrs))
@@ -4894,7 +4894,29 @@ impl PeerExportContext {
                 }
                 Arc::new(new_attrs)
             }
+        };
+
+        // RFC 4271 §5.1.4: apply opaque attr policy uniformly across all roles.
+        // Unknown optional transitive attrs are forwarded with PARTIAL bit set;
+        // unknown optional non-transitive attrs are discarded.
+        // Skip the allocation when no opaque attrs are present (common case).
+        if !exported.iter().any(|a| a.is_opaque()) {
+            return exported;
         }
+        Arc::new(
+            exported
+                .iter()
+                .filter_map(|a| {
+                    if !a.is_opaque() {
+                        Some(a.clone())
+                    } else if a.is_transitive() {
+                        Some(a.with_partial_bit())
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        )
     }
 
     /// Apply per-peer nexthop transformation to an outgoing route nexthop.
@@ -9495,6 +9517,65 @@ mod tests {
                     .all(|a| a.code() != packet::Attribute::LOCAL_PREF),
                 "RS client must not inject LOCAL_PREF"
             );
+        }
+
+        fn attr_with_opaque_transitive() -> Arc<Vec<packet::Attribute>> {
+            Arc::new(vec![
+                packet::Attribute::new_with_value(packet::Attribute::ORIGIN, 0).unwrap(),
+                // Unknown optional transitive (code=200, flags=optional|transitive)
+                packet::Attribute::new_opaque(
+                    200,
+                    packet::Attribute::FLAG_PARTIAL
+                        | 0x40 /* transitive */
+                        | 0x80, /* optional */
+                    vec![0x01, 0x02, 0x03],
+                ),
+            ])
+        }
+
+        fn attr_with_opaque_non_transitive() -> Arc<Vec<packet::Attribute>> {
+            Arc::new(vec![
+                packet::Attribute::new_with_value(packet::Attribute::ORIGIN, 0).unwrap(),
+                // Unknown optional non-transitive (code=201, flags=optional only)
+                packet::Attribute::new_opaque(
+                    201,
+                    0x80, /* optional */
+                    vec![0x04, 0x05, 0x06],
+                ),
+            ])
+        }
+
+        #[test]
+        fn opaque_transitive_attr_forwarded_with_partial_bit() {
+            // RFC 4271 §5.1.4: unknown optional transitive attrs are forwarded
+            // with PARTIAL bit set, for every peer role.
+            for ctx in [ebgp_ctx(), ibgp_ctx(), rs_client_ctx()] {
+                let exported = ctx.export_attrs(&attr_with_opaque_transitive());
+                let opaque = exported.iter().find(|a| a.code() == 200);
+                assert!(
+                    opaque.is_some(),
+                    "unknown optional transitive attr must be forwarded (role: {:?})",
+                    ctx.role
+                );
+                assert!(
+                    opaque.unwrap().flags() & packet::Attribute::FLAG_PARTIAL != 0,
+                    "PARTIAL bit must be set on forwarded unknown transitive attr (role: {:?})",
+                    ctx.role
+                );
+            }
+        }
+
+        #[test]
+        fn opaque_non_transitive_attr_discarded() {
+            // RFC 4271 §5.1.4: unknown optional non-transitive attrs are discarded.
+            for ctx in [ebgp_ctx(), ibgp_ctx(), rs_client_ctx()] {
+                let exported = ctx.export_attrs(&attr_with_opaque_non_transitive());
+                assert!(
+                    exported.iter().all(|a| a.code() != 201),
+                    "unknown optional non-transitive attr must be discarded (role: {:?})",
+                    ctx.role
+                );
+            }
         }
 
         #[test]

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -1181,6 +1181,8 @@ impl<'a> Iterator for AsPathIter<'a> {
 enum AttributeData {
     Val(u32),
     Bin(Vec<u8>),
+    /// Raw bytes for an unknown optional attribute (RFC 4271 §5.1.4).
+    Opaque(Vec<u8>),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -1193,7 +1195,7 @@ pub struct Attribute {
 impl Attribute {
     pub const ORIGIN_INCOMPLETE: u8 = 2;
     const FLAG_EXTENDED: u8 = 1 << 4;
-    // const FLAG_PARTIAL: u8 = 1 << 5;
+    pub const FLAG_PARTIAL: u8 = 1 << 5;
     const FLAG_TRANSITIVE: u8 = 1 << 6;
     const FLAG_OPTIONAL: u8 = 1 << 7;
 
@@ -1259,14 +1261,45 @@ impl Attribute {
     pub fn value(&self) -> Option<u32> {
         match self.data {
             AttributeData::Val(v) => Some(v),
-            AttributeData::Bin(_) => None,
+            AttributeData::Bin(_) | AttributeData::Opaque(_) => None,
         }
     }
 
     pub fn binary(&self) -> Option<&Vec<u8>> {
         match &self.data {
             AttributeData::Val(_) => None,
-            AttributeData::Bin(v) => Some(v),
+            AttributeData::Bin(v) | AttributeData::Opaque(v) => Some(v),
+        }
+    }
+
+    /// Constructs an opaque attribute from raw wire bytes.
+    /// Used to preserve unknown optional transitive attributes (RFC 4271 §5.1.4).
+    /// Unlike `new_with_bin`, `flags` is stored as-is without consulting `canonical_flags`.
+    pub fn new_opaque(code: u8, flags: u8, data: Vec<u8>) -> Self {
+        Attribute {
+            code,
+            flags,
+            data: AttributeData::Opaque(data),
+        }
+    }
+
+    /// Returns true if this attribute was received as an unknown opaque blob.
+    pub fn is_opaque(&self) -> bool {
+        matches!(self.data, AttributeData::Opaque(_))
+    }
+
+    /// Returns true if the TRANSITIVE flag is set in the wire flags.
+    pub fn is_transitive(&self) -> bool {
+        self.flags & Self::FLAG_TRANSITIVE != 0
+    }
+
+    /// Returns a clone of this attribute with the PARTIAL bit set.
+    /// Used when forwarding an unrecognized optional transitive attribute.
+    pub fn with_partial_bit(&self) -> Self {
+        Attribute {
+            code: self.code,
+            flags: self.flags | Self::FLAG_PARTIAL,
+            data: self.data.clone(),
         }
     }
 
@@ -2607,12 +2640,26 @@ impl PeerCodec {
                         }
                         None => {
                             if flags & Attribute::FLAG_OPTIONAL == 0 {
+                                // Unknown well-known: treat-as-withdraw (RFC 4271 §6.3).
                                 error_attrs.push(AttributeError {
                                     attr_code: code,
                                     attr_flags: flags,
                                 });
+                                c.set_position(c.position() + alen as u64);
+                            } else if flags & Attribute::FLAG_TRANSITIVE != 0 {
+                                // Unknown optional transitive: store as opaque blob (RFC 4271 §5.1.4).
+                                let pos = c.position() as usize;
+                                let end = pos + alen as usize;
+                                if end > c.get_ref().len() {
+                                    return Err(malformed());
+                                }
+                                let raw = (*c.get_ref())[pos..end].to_vec();
+                                c.set_position(end as u64);
+                                attr.push(Attribute::new_opaque(code, flags, raw));
+                            } else {
+                                // Unknown optional non-transitive: silently discard (RFC 4271 §5.1.4).
+                                c.set_position(c.position() + alen as u64);
                             }
-                            c.set_position(c.position() + alen as u64);
                         }
                     }
                 }

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -1602,3 +1602,67 @@ fn flowspec_ipv4_no_nexthop_accepted() {
         "Flowspec MP_REACH with nexthop_len=0 must be accepted, not treated as withdraw"
     );
 }
+
+/// Build a minimal IPv4 UPDATE containing ORIGIN + AS_PATH + NEXTHOP plus two
+/// unknown optional attributes: one transitive (code 200) and one
+/// non-transitive (code 201), followed by a single /24 NLRI.
+fn update_with_unknown_optional_attrs() -> Vec<u8> {
+    let attrs: &[u8] = &[
+        0x40, 0x01, 0x01, 0x00, // ORIGIN IGP (transitive)
+        0x40, 0x02, 0x00, // AS_PATH empty (transitive)
+        0x40, 0x03, 0x04, 0x0a, 0x00, 0x00, 0x01, // NEXTHOP 10.0.0.1
+        // Unknown optional transitive (code=200, flags=0xC0, len=3, data=[1,2,3])
+        0xC0, 0xC8, 0x03, 0x01, 0x02, 0x03,
+        // Unknown optional non-transitive (code=201, flags=0x80, len=3, data=[4,5,6])
+        0x80, 0xC9, 0x03, 0x04, 0x05, 0x06,
+    ];
+    let nlri: &[u8] = &[0x18, 0x0a, 0x01, 0x02]; // 10.1.2.0/24
+    let attr_len = attrs.len() as u16;
+    let total = 19u16 + 2 + 2 + attr_len + nlri.len() as u16;
+    let mut buf = vec![0xffu8; 16];
+    buf.extend_from_slice(&total.to_be_bytes());
+    buf.push(2); // UPDATE
+    buf.extend_from_slice(&0u16.to_be_bytes()); // withdrawn_len = 0
+    buf.extend_from_slice(&attr_len.to_be_bytes());
+    buf.extend_from_slice(attrs);
+    buf.extend_from_slice(nlri);
+    buf
+}
+
+#[test]
+fn unknown_optional_transitive_attr_is_stored() {
+    // RFC 4271 §5.1.4: unknown optional transitive attrs must be stored.
+    let mut codec = ipv4_codec();
+    let buf = update_with_unknown_optional_attrs();
+    let parsed = codec.parse_message(&buf).expect("parse ok");
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
+    let attr = match &msgs[0] {
+        Message::Update(Update::Reach { attr, .. }) => attr,
+        _ => panic!("expected Reach message"),
+    };
+    let opaque = attr.iter().find(|a| a.code() == 200);
+    assert!(
+        opaque.is_some(),
+        "unknown optional transitive attr must be stored"
+    );
+    let opaque = opaque.unwrap();
+    assert!(opaque.is_opaque());
+    assert_eq!(opaque.binary().unwrap(), &vec![0x01, 0x02, 0x03]);
+}
+
+#[test]
+fn unknown_optional_non_transitive_attr_is_discarded() {
+    // RFC 4271 §5.1.4: unknown optional non-transitive attrs must be silently discarded.
+    let mut codec = ipv4_codec();
+    let buf = update_with_unknown_optional_attrs();
+    let parsed = codec.parse_message(&buf).expect("parse ok");
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
+    let attr = match &msgs[0] {
+        Message::Update(Update::Reach { attr, .. }) => attr,
+        _ => panic!("expected Reach message"),
+    };
+    assert!(
+        attr.iter().all(|a| a.code() != 201),
+        "unknown optional non-transitive attr must not be stored"
+    );
+}


### PR DESCRIPTION
…FC 4271 §5.1.4)

RFC 4271 §5.1.4 requires that unrecognized optional transitive path attributes be stored and forwarded with the PARTIAL bit (0x20) set. Previously, RustyBGP silently discarded all unrecognized optional attributes regardless of the transitive flag.

Decoder (packet):
- Unknown optional transitive attrs are now stored as AttributeData::Opaque blobs with the original wire flags preserved in the RIB.
- Unknown optional non-transitive attrs continue to be silently discarded.
- Unknown well-known (non-optional) attrs continue to trigger treat-as-withdraw.

New Attribute API:
- new_opaque(code, flags, data): store raw wire bytes without consulting canonical_flags(); flags field holds the received wire value as-is.
- is_opaque() -> bool: identifies attrs stored as opaque blobs.
- is_transitive() -> bool: checks the TRANSITIVE flag bit.
- with_partial_bit() -> Self: clones with FLAG_PARTIAL OR'd into flags.
- FLAG_PARTIAL is now pub (was commented out).

export_attrs (daemon):
- After per-role transformations, a common post-pass applies RFC §5.1.4 policy to all roles: unknown transitive attrs are forwarded with PARTIAL bit set; unknown non-transitive attrs are dropped.
- The post-pass short-circuits when no opaque attrs are present (common case).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>