### PR TITLE
packet,daemon: fix AIGP flag to optional non-transitive (RFC 7311 §2.1)

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -4879,6 +4879,7 @@ impl PeerExportContext {
                                 | bgp::Attribute::ORIGINATOR_ID
                                 | bgp::Attribute::CLUSTER_LIST
                                 | bgp::Attribute::MULTI_EXIT_DESC
+                                | bgp::Attribute::AIGP
                         )
                     })
                     .map(|a| {
@@ -9576,6 +9577,34 @@ mod tests {
                     ctx.role
                 );
             }
+        }
+
+        fn aigp_attr() -> Arc<Vec<bgp::Attribute>> {
+            // AIGP TLV: type=1, len=11, value=8-byte metric (all zeros)
+            let aigp_tlv: Vec<u8> = vec![1, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0];
+            Arc::new(vec![
+                bgp::Attribute::new_with_bin(bgp::Attribute::AIGP, aigp_tlv).unwrap(),
+            ])
+        }
+
+        #[test]
+        fn ebgp_export_strips_aigp() {
+            // AIGP is optional non-transitive (RFC 7311 §2.1); must not cross AS boundaries.
+            let exported = ebgp_ctx().export_attrs(&aigp_attr());
+            assert!(
+                exported.iter().all(|a| a.code() != bgp::Attribute::AIGP),
+                "eBGP export must strip AIGP"
+            );
+        }
+
+        #[test]
+        fn ibgp_export_keeps_aigp() {
+            // AIGP is iBGP-safe: non-transitive attrs are forwarded within the AS.
+            let exported = ibgp_ctx().export_attrs(&aigp_attr());
+            assert!(
+                exported.iter().any(|a| a.code() == bgp::Attribute::AIGP),
+                "iBGP export must keep AIGP"
+            );
         }
 
         #[test]

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -1321,7 +1321,7 @@ impl Attribute {
             Self::EXTENDED_COMMUNITY => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
             Self::AS4_PATH => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
             Self::AS4_AGGREGATOR => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
-            Self::AIGP => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
+            Self::AIGP => Some(Self::FLAG_OPTIONAL),
             Self::LARGE_COMMUNITY => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
             Self::PREFIX_SID => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
             Self::LS => Some(Self::FLAG_OPTIONAL),
@@ -2605,7 +2605,6 @@ impl PeerCodec {
                                 & (Attribute::FLAG_TRANSITIVE | Attribute::FLAG_OPTIONAL)
                                 > 0
                             {
-                                // FIXME: handle aigp case
                                 c.set_position(c.position() + alen as u64);
                                 error_attrs.push(AttributeError {
                                     attr_code: code,

--- a/packet/tests/bgp_update.rs
+++ b/packet/tests/bgp_update.rs
@@ -1629,6 +1629,61 @@ fn update_with_unknown_optional_attrs() -> Vec<u8> {
     buf
 }
 
+fn update_with_aigp(aigp_flags: u8) -> Vec<u8> {
+    // AIGP TLV type=1, len=11, 8-byte metric
+    let aigp_value: Vec<u8> = vec![1, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0];
+    let mut attrs: Vec<u8> = vec![
+        0x40, 0x01, 0x01, 0x00, // ORIGIN IGP
+        0x40, 0x02, 0x00, // AS_PATH empty
+        0x40, 0x03, 0x04, 0x0a, 0x00, 0x00, 0x01, // NEXTHOP 10.0.0.1
+    ];
+    attrs.push(aigp_flags);
+    attrs.push(Attribute::AIGP);
+    attrs.push(aigp_value.len() as u8);
+    attrs.extend_from_slice(&aigp_value);
+
+    let nlri: &[u8] = &[0x18, 0x0a, 0x01, 0x02]; // 10.1.2.0/24
+    let attr_len = attrs.len() as u16;
+    let total = 19u16 + 2 + 2 + attr_len + nlri.len() as u16;
+    let mut buf = vec![0xffu8; 16];
+    buf.extend_from_slice(&total.to_be_bytes());
+    buf.push(2); // UPDATE
+    buf.extend_from_slice(&0u16.to_be_bytes()); // withdrawn_len = 0
+    buf.extend_from_slice(&attr_len.to_be_bytes());
+    buf.extend_from_slice(&attrs);
+    buf.extend_from_slice(nlri);
+    buf
+}
+
+#[test]
+fn aigp_with_correct_flags_is_accepted() {
+    // AIGP with FLAG_OPTIONAL (0x80) only: correct per RFC 7311 §2.1.
+    let mut codec = ipv4_codec();
+    let buf = update_with_aigp(0x80);
+    let parsed = codec.parse_message(&buf).expect("parse ok");
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
+    assert!(
+        msgs.iter()
+            .any(|m| matches!(m, Message::Update(Update::Reach { .. }))),
+        "AIGP with correct flags (0x80) must yield a Reach message"
+    );
+}
+
+#[test]
+fn aigp_with_wrong_flags_treat_as_withdraw() {
+    // AIGP with FLAG_OPTIONAL | FLAG_TRANSITIVE (0xC0): wrong per RFC 7311 §2.1.
+    // RFC 7606: flag mismatch on optional transitive -> treat-as-withdraw.
+    let mut codec = ipv4_codec();
+    let buf = update_with_aigp(0xC0);
+    let parsed = codec.parse_message(&buf).expect("parse ok");
+    let msgs: Vec<Message> = validate_message(parsed, false).unwrap().collect();
+    assert!(
+        msgs.iter()
+            .all(|m| matches!(m, Message::Update(Update::Unreach { .. }))),
+        "AIGP with wrong flags (0xC0) must yield only Unreach (treat-as-withdraw)"
+    );
+}
+
 #[test]
 fn unknown_optional_transitive_attr_is_stored() {
     // RFC 4271 §5.1.4: unknown optional transitive attrs must be stored.


### PR DESCRIPTION
RFC 7311 §2.1 defines AIGP as optional and non-transitive (flags=0x80). The previous canonical_flags() entry incorrectly set FLAG_TRANSITIVE as well (0xC0), which would have accepted AIGP from eBGP peers and forwarded it across AS boundaries.

Fix canonical_flags(AIGP) to return FLAG_OPTIONAL only.  As a consequence, AIGP with the wrong 0xC0 flags is now rejected at decode time via the existing flag-mismatch -> treat-as-withdraw path, matching BIRD's strict behavior.

On the export side, add AIGP to the eBGP attribute strip list in export_attrs() so AIGP is not propagated across AS boundaries even when stored with correct flags.  iBGP peers continue to receive AIGP as before.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>