### PR TITLE
daemon: replace tokio::sync::Mutex with std::sync::Mutex for shards a…

### DIFF
--- a/daemon/src/bmp.rs
+++ b/daemon/src/bmp.rs
@@ -245,9 +245,7 @@ impl BmpClient {
             .await;
 
         let mut snapshot: SnapshotMap = FnvHashMap::default();
-        let subscription = tables
-            .subscribe_with(|change| apply_snapshot(&mut snapshot, change))
-            .await;
+        let subscription = tables.subscribe_with(|change| apply_snapshot(&mut snapshot, change));
         let rx = subscription.rx;
 
         // Send PeerUp for all established peers.
@@ -257,7 +255,7 @@ impl BmpClient {
         for peer in global.read().await.peers.values() {
             if let Some((addr, peer_header, msg)) = peer.bmp_peer_up(local_id) {
                 if !send_peer_up(&mut sent_peer_up, &mut lines, addr, &msg).await {
-                    tables.unsubscribe(subscription.id).await;
+                    tables.unsubscribe(subscription.id);
                     return;
                 }
                 established_peers.push((addr, peer_header));
@@ -268,7 +266,7 @@ impl BmpClient {
         for (addr, peer_header) in &established_peers {
             for msg in flush_peer_snapshot(&mut snapshot, *addr, peer_header) {
                 if lines.send(&msg).await.is_err() {
-                    tables.unsubscribe(subscription.id).await;
+                    tables.unsubscribe(subscription.id);
                     return;
                 }
             }
@@ -354,7 +352,7 @@ impl BmpClient {
                 _ = cancel.cancelled() => break,
             }
         }
-        tables.unsubscribe(subscription.id).await;
+        tables.unsubscribe(subscription.id);
     }
 
     pub(crate) fn try_connect(

--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -1879,7 +1879,7 @@ impl GoBgpService for GrpcService {
         };
 
         let addrs: Vec<IpAddr> = peers.keys().copied().collect();
-        let all_stats = self.tables.collect_peer_stats(&addrs).await;
+        let all_stats = self.tables.collect_peer_stats(&addrs);
         for (addr, peer) in &mut peers {
             if let Some(stats) = all_stats.get(addr) {
                 peer.update_stats(stats.clone());
@@ -2103,10 +2103,10 @@ impl GoBgpService for GrpcService {
         }
 
         if do_in {
-            self.tables.soft_reset_in(peer_addr).await;
+            self.tables.soft_reset_in(peer_addr);
         }
         if do_out {
-            self.tables.soft_reset_out(peer_addr).await;
+            self.tables.soft_reset_out(peer_addr);
         }
         Ok(tonic::Response::new(api::ResetPeerResponse {}))
     }
@@ -2199,7 +2199,7 @@ impl GoBgpService for GrpcService {
     ) -> Result<tonic::Response<Self::WatchEventStream>, tonic::Status> {
         let tables2 = self.tables.clone();
         let global2 = self.global.clone();
-        let subscription = self.tables.subscribe_live().await;
+        let subscription = self.tables.subscribe_live();
         let sub_id = subscription.id;
         let (tx, rx) = mpsc::channel(1024);
         let cancel = CancellationToken::new();
@@ -2286,7 +2286,7 @@ impl GoBgpService for GrpcService {
                     break;
                 }
             }
-            tables2.unsubscribe(sub_id).await;
+            tables2.unsubscribe(sub_id);
             global2.write().await.watch_event_cancels.remove(&sub_id);
         });
         Ok(tonic::Response::new(Box::pin(
@@ -2524,7 +2524,6 @@ impl GoBgpService for GrpcService {
             let vrf = self
                 .tables
                 .list_vrfs(Some(&vrf_id))
-                .await
                 .into_iter()
                 .next()
                 .ok_or_else(|| tonic::Status::not_found(format!("VRF '{}' not found", vrf_id)))?;
@@ -2539,17 +2538,15 @@ impl GoBgpService for GrpcService {
         let source = table::Source::local();
         if let Some(attrs) = insert_attrs {
             for net in insert_nets {
-                self.tables
-                    .insert_route(
-                        source.clone(),
-                        family,
-                        net,
-                        nexthop,
-                        attrs.clone(),
-                        None,
-                        timestamp,
-                    )
-                    .await;
+                self.tables.insert_route(
+                    source.clone(),
+                    family,
+                    net,
+                    nexthop,
+                    attrs.clone(),
+                    None,
+                    timestamp,
+                );
             }
         }
         let id = uuid::Uuid::new_v4();
@@ -2584,8 +2581,7 @@ impl GoBgpService for GrpcService {
         let source = table::Source::local();
         for net in nets {
             self.tables
-                .remove_route(source.clone(), family, net, None, timestamp)
-                .await;
+                .remove_route(source.clone(), family, net, None, timestamp);
         }
         Ok(tonic::Response::new(api::DeletePathResponse {}))
     }
@@ -2679,7 +2675,6 @@ impl GoBgpService for GrpcService {
                     let entries = self
                         .tables
                         .collect_vrf_paths(&vrf_name, family, prefixes, enable_filtered)
-                        .await
                         .ok_or_else(|| {
                             tonic::Status::not_found(format!("VRF '{}' not found", vrf_name))
                         })?;
@@ -2734,7 +2729,7 @@ impl GoBgpService for GrpcService {
                         )));
                     };
                     let export_policy = self.tables.export_policy.load_full();
-                    let changes = self.tables.collect_loc_rib_paths(family).await;
+                    let changes = self.tables.collect_loc_rib_paths(family);
                     let mut sink = AdjOutSink::default();
                     let mut export_map = ExportMap::new();
                     for change in changes {
@@ -2787,7 +2782,6 @@ impl GoBgpService for GrpcService {
         let v: Vec<_> = self
             .tables
             .collect_paths(query, family, prefixes, enable_filtered)
-            .await
             .into_iter()
             .take_while(|d| {
                 if batch_size == 0 {
@@ -2826,17 +2820,15 @@ impl GoBgpService for GrpcService {
                 {
                     let timestamp = std::time::SystemTime::now();
                     for net in nets {
-                        self.tables
-                            .insert_route(
-                                source.clone(),
-                                family,
-                                net,
-                                nexthop,
-                                attrs.clone(),
-                                None,
-                                timestamp,
-                            )
-                            .await;
+                        self.tables.insert_route(
+                            source.clone(),
+                            family,
+                            net,
+                            nexthop,
+                            attrs.clone(),
+                            None,
+                            timestamp,
+                        );
                     }
                 }
             }
@@ -2852,7 +2844,7 @@ impl GoBgpService for GrpcService {
             Some(family) => convert::family_from_api(&family),
             None => Family::IPV4,
         };
-        let info = self.tables.table_state(family).await;
+        let info = self.tables.table_state(family);
         Ok(tonic::Response::new(convert::routing_table_state_to_api(
             info,
         )))
@@ -2884,7 +2876,6 @@ impl GoBgpService for GrpcService {
             .collect::<Result<Vec<_>, _>>()?;
         self.tables
             .add_vrf(name, rd, import_rt, export_rt, vrf.id)
-            .await
             .map_err(Error::Table)?;
         Ok(tonic::Response::new(api::AddVrfResponse {}))
     }
@@ -2898,7 +2889,7 @@ impl GoBgpService for GrpcService {
         if name.is_empty() {
             return Err(Error::InvalidArgument("vrf name is empty".to_string()).into());
         }
-        self.tables.delete_vrf(&name).await.map_err(Error::Table)?;
+        self.tables.delete_vrf(&name).map_err(Error::Table)?;
         Ok(tonic::Response::new(api::DeleteVrfResponse {}))
     }
 
@@ -2917,7 +2908,7 @@ impl GoBgpService for GrpcService {
         } else {
             Some(name_filter.as_str())
         };
-        let vrfs = self.tables.list_vrfs(filter).await;
+        let vrfs = self.tables.list_vrfs(filter);
         let responses: Vec<_> = vrfs
             .iter()
             .map(|v| {
@@ -3346,7 +3337,7 @@ impl GoBgpService for GrpcService {
         }
 
         for (addr, r) in v.iter_mut() {
-            let s = self.tables.rpki_state(addr).await;
+            let s = self.tables.rpki_state(addr);
             r.state.as_mut().unwrap().record_ipv4 = s.num_records_v4;
             r.state.as_mut().unwrap().record_ipv6 = s.num_records_v6;
             r.state.as_mut().unwrap().prefix_ipv4 = s.num_prefixes_v4;
@@ -3472,7 +3463,7 @@ impl GoBgpService for GrpcService {
                 }
             }
         };
-        self.tables.rpki_drop_all(Arc::new(addr)).await;
+        self.tables.rpki_drop_all(Arc::new(addr));
         if !disabled {
             RpkiClient::try_connect(sockaddr, cancel, soft_reset, state, self.tables.clone());
         }
@@ -3498,7 +3489,6 @@ impl GoBgpService for GrpcService {
         let v: Vec<api::ListRpkiTableResponse> = self
             .tables
             .collect_roa(family)
-            .await
             .into_iter()
             .map(|(net, roa)| api::ListRpkiTableResponse {
                 roa: Some(convert::roa_to_api(&net, &roa)),
@@ -4449,7 +4439,7 @@ impl Global {
             if !deferral.is_completed() {
                 for output in &init_outputs {
                     if let crate::gr::RestartingOutput::DeferFamilies(families) = output {
-                        tables.start_deferral_families(families).await;
+                        tables.start_deferral_families(families);
                     }
                 }
                 global.write().await.selection_deferral = Some(deferral);
@@ -4547,16 +4537,16 @@ impl Global {
                     event = kernel_event_rx.recv().fuse() => {
                         match event {
                             Some(kernel::KernelEvent::Route(kernel::KernelRouteEvent::Add(kr))) => {
-                                tables.inject_kernel_route(kr).await;
+                                tables.inject_kernel_route(kr);
                             }
                             Some(kernel::KernelEvent::Route(kernel::KernelRouteEvent::Delete(kr))) => {
-                                tables.withdraw_kernel_route(kr.dst, kr.prefix_len).await;
+                                tables.withdraw_kernel_route(kr.dst, kr.prefix_len);
                             }
                             Some(kernel::KernelEvent::NexthopUpdate { addr, reachable }) => {
-                                tables.update_nexthop_validity(addr, reachable).await;
+                                tables.update_nexthop_validity(addr, reachable);
                             }
                             Some(kernel::KernelEvent::Address(addr_event)) => {
-                                tables.handle_address_event(addr_event).await;
+                                tables.handle_address_event(addr_event);
                             }
                             None => {}
                         }
@@ -4709,12 +4699,12 @@ async fn process_restarting_outputs(
     }
 
     if !complete_families.is_empty() {
-        tables.end_deferral_families(&complete_families).await;
+        tables.end_deferral_families(&complete_families);
     }
 
     if let Some(remaining) = end_remaining {
         if !remaining.is_empty() {
-            tables.end_deferral_families(&remaining).await;
+            tables.end_deferral_families(&remaining);
         }
         let mut server = global.write().await;
         if let Some(h) = server.selection_deferral_timer.take() {
@@ -4857,7 +4847,7 @@ async fn gr_restart_timer_expired(
         collect_delete_families(&outputs)
     };
     if !families.is_empty() {
-        tables.drop_families(addr, &families).await;
+        tables.drop_families(addr, &families);
     }
 }
 
@@ -5443,36 +5433,33 @@ impl PeerSession {
                         );
                     }
                 }
-            })
-            .await;
+            });
         self.peer_event_rx = Some(UnboundedReceiverStream::new(peer_event_rx));
         let remote_holdtime = HoldTime::new(self.state.remote_holdtime.load(Ordering::Relaxed))
             .unwrap_or(HoldTime::DISABLED);
-        self.tables
-            .peer_up(PeerUpData {
-                peer_addr: remote_sockaddr.ip(),
-                peer_asn: remote_asn,
-                peer_id: self.state.remote_id.load(Ordering::Relaxed),
-                uptime,
-                local_addr: self.export_ctx.local_addr,
-                local_port: local_sockaddr.port(),
-                remote_port: remote_sockaddr.port(),
-                sent_open: bgp::Message::Open(bgp::Open {
-                    as_number: remote_asn,
-                    holdtime: remote_holdtime,
-                    router_id: self.state.remote_id.load(Ordering::Relaxed),
-                    capability: self.local_cap.to_owned(),
-                }),
-                received_open: bgp::Message::Open(bgp::Open {
-                    as_number: remote_asn,
-                    holdtime: remote_holdtime,
-                    router_id: self.state.remote_id.load(Ordering::Relaxed),
-                    // Safe to unwrap: called from on_established() where
-                    // remote_cap has just been set by apply_outputs().
-                    capability: self.state.remote_cap.load().as_deref().cloned().unwrap(),
-                }),
-            })
-            .await;
+        self.tables.peer_up(PeerUpData {
+            peer_addr: remote_sockaddr.ip(),
+            peer_asn: remote_asn,
+            peer_id: self.state.remote_id.load(Ordering::Relaxed),
+            uptime,
+            local_addr: self.export_ctx.local_addr,
+            local_port: local_sockaddr.port(),
+            remote_port: remote_sockaddr.port(),
+            sent_open: bgp::Message::Open(bgp::Open {
+                as_number: remote_asn,
+                holdtime: remote_holdtime,
+                router_id: self.state.remote_id.load(Ordering::Relaxed),
+                capability: self.local_cap.to_owned(),
+            }),
+            received_open: bgp::Message::Open(bgp::Open {
+                as_number: remote_asn,
+                holdtime: remote_holdtime,
+                router_id: self.state.remote_id.load(Ordering::Relaxed),
+                // Safe to unwrap: called from on_established() where
+                // remote_cap has just been set by apply_outputs().
+                capability: self.state.remote_cap.load().as_deref().cloned().unwrap(),
+            }),
+        });
     }
 
     async fn do_route_refresh(&mut self, family: Family) {
@@ -5482,7 +5469,7 @@ impl PeerSession {
         let export_policy = self.tables.export_policy.load_full();
         let effective_max =
             conn_effective_max(&self.conn_arbiter.lock().unwrap(), Some(self.role), family);
-        let changes = self.tables.collect_loc_rib_paths(family).await;
+        let changes = self.tables.collect_loc_rib_paths(family);
         self.export_map.clear_family(family);
         for change in changes {
             let Some(pending) = self.pending.get_mut(&change.family) else {
@@ -5654,8 +5641,7 @@ impl PeerSession {
                         };
                         if !delete_families.is_empty() {
                             self.tables
-                                .drop_stale_families(self.remote_addr, &delete_families)
-                                .await;
+                                .drop_stale_families(self.remote_addr, &delete_families);
                         }
                     }
                 }
@@ -5685,8 +5671,7 @@ impl PeerSession {
                     };
                     if !delete_families.is_empty() {
                         self.tables
-                            .drop_stale_families(self.remote_addr, &delete_families)
-                            .await;
+                            .drop_stale_families(self.remote_addr, &delete_families);
                     }
                 }
             }
@@ -5805,19 +5790,15 @@ impl PeerSession {
                 .get(&family)
                 .map(|(max, counter)| (*max, Arc::clone(counter)));
             for net in s.entries {
-                if self
-                    .tables
-                    .insert_route(
-                        source.clone(),
-                        family,
-                        net,
-                        nexthop,
-                        attr.clone(),
-                        prefix_limit.clone(),
-                        timestamp,
-                    )
-                    .await
-                {
+                if self.tables.insert_route(
+                    source.clone(),
+                    family,
+                    net,
+                    nexthop,
+                    attr.clone(),
+                    prefix_limit.clone(),
+                    timestamp,
+                ) {
                     return true;
                 }
             }
@@ -5830,15 +5811,13 @@ impl PeerSession {
                 .get(&family)
                 .map(|(_, counter)| Arc::clone(counter));
             for net in s.entries {
-                self.tables
-                    .remove_route(
-                        source.clone(),
-                        family,
-                        net,
-                        prefix_counter.clone(),
-                        timestamp,
-                    )
-                    .await;
+                self.tables.remove_route(
+                    source.clone(),
+                    family,
+                    net,
+                    prefix_counter.clone(),
+                    timestamp,
+                );
             }
         }
         false
@@ -6167,17 +6146,14 @@ impl PeerSession {
             let bmp_reason = crate::bmp::session_down_to_bmp(self.shutdown.take());
             self.peer_event_rx = None;
             self.tables
-                .unregister_peer(self.remote_addr, &drop_families, &stale_families)
-                .await;
-            self.tables
-                .peer_down(PeerDownData {
-                    peer_addr: any_source.remote_addr,
-                    peer_asn: any_source.remote_asn,
-                    peer_id: any_source.router_id,
-                    uptime: self.state.peer_up_at.load(Ordering::Relaxed),
-                    reason: bmp_reason,
-                })
-                .await;
+                .unregister_peer(self.remote_addr, &drop_families, &stale_families);
+            self.tables.peer_down(PeerDownData {
+                peer_addr: any_source.remote_addr,
+                peer_asn: any_source.remote_asn,
+                peer_id: any_source.router_id,
+                uptime: self.state.peer_up_at.load(Ordering::Relaxed),
+                reason: bmp_reason,
+            });
         }
         disconnect.export_map = std::mem::take(&mut self.export_map);
 
@@ -8478,7 +8454,7 @@ mod tests {
 
         // Insert one IPv4 route and one IPv6 route for the peer.
         {
-            let mut t = tables.shards[0].lock().await;
+            let mut t = tables.shards[0].lock().unwrap();
             let _ = t.rtable.insert(
                 source.clone(),
                 Family::IPV4,
@@ -8516,9 +8492,9 @@ mod tests {
         let session_families = [Family::IPV4, Family::IPV6];
         let drop_families =
             families_to_drop_on_disconnect(session_families.iter(), Some(&negotiated_gr));
-        tables.drop_families(remote_addr, &drop_families).await;
+        tables.drop_families(remote_addr, &drop_families);
 
-        let t = tables.shards[0].lock().await;
+        let t = tables.shards[0].lock().unwrap();
         // IPv4 route (GR family) must still be in the table.
         assert_eq!(t.rtable.collect_loc_rib_paths(&Family::IPV4).len(), 1);
         // IPv6 route (non-GR family) must have been removed.
@@ -8545,7 +8521,7 @@ mod tests {
         let nh4 = packet::bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 3));
 
         {
-            let mut t = tables.shards[0].lock().await;
+            let mut t = tables.shards[0].lock().unwrap();
             t.rtable.insert(
                 source,
                 Family::IPV4,
@@ -8563,7 +8539,7 @@ mod tests {
         assert_eq!(
             tables.shards[0]
                 .lock()
-                .await
+                .unwrap()
                 .rtable
                 .collect_loc_rib_paths(&Family::IPV4)
                 .len(),
@@ -8573,12 +8549,12 @@ mod tests {
         // No GR: all families dropped.
         let session_families = [Family::IPV4];
         let drop_families = families_to_drop_on_disconnect(session_families.iter(), None);
-        tables.drop_families(remote_addr, &drop_families).await;
+        tables.drop_families(remote_addr, &drop_families);
 
         assert!(
             tables.shards[0]
                 .lock()
-                .await
+                .unwrap()
                 .rtable
                 .collect_loc_rib_paths(&Family::IPV4)
                 .is_empty()
@@ -10478,7 +10454,7 @@ mod tests {
             ..Default::default()
         });
         svc.add_path(req).await.unwrap();
-        let t = svc.tables.shards[0].lock().await;
+        let t = svc.tables.shards[0].lock().unwrap();
         assert_eq!(t.rtable.collect_loc_rib_paths(&Family::IPV4).len(), 1);
     }
 
@@ -10492,7 +10468,7 @@ mod tests {
         });
         let uuid = svc.add_path(add_req).await.unwrap().into_inner().uuid;
         {
-            let t = svc.tables.shards[0].lock().await;
+            let t = svc.tables.shards[0].lock().unwrap();
             assert_eq!(t.rtable.collect_loc_rib_paths(&Family::IPV4).len(), 1);
         }
 
@@ -10501,7 +10477,7 @@ mod tests {
             ..Default::default()
         });
         svc.delete_path(del_req).await.unwrap();
-        let t = svc.tables.shards[0].lock().await;
+        let t = svc.tables.shards[0].lock().unwrap();
         assert!(t.rtable.collect_loc_rib_paths(&Family::IPV4).is_empty());
     }
 
@@ -10571,7 +10547,7 @@ mod tests {
             ..Default::default()
         });
         svc.add_path(req).await.unwrap();
-        let t = svc.tables.shards[0].lock().await;
+        let t = svc.tables.shards[0].lock().unwrap();
         assert_eq!(t.rtable.collect_loc_rib_paths(&Family::IPV4).len(), 1);
     }
 
@@ -10592,7 +10568,7 @@ mod tests {
         let uuid2 = svc.add_path(req2).await.unwrap().into_inner().uuid;
 
         {
-            let t = svc.tables.shards[0].lock().await;
+            let t = svc.tables.shards[0].lock().unwrap();
             let entries = t.rtable.collect_loc_rib_paths(&Family::IPV4);
             assert_eq!(entries.len(), 1);
             assert_eq!(
@@ -10609,7 +10585,7 @@ mod tests {
         .await
         .unwrap();
         {
-            let t = svc.tables.shards[0].lock().await;
+            let t = svc.tables.shards[0].lock().unwrap();
             let entries = t.rtable.collect_loc_rib_paths(&Family::IPV4);
             assert_eq!(
                 entries[0].current_paths.len(),
@@ -10624,7 +10600,7 @@ mod tests {
         }))
         .await
         .unwrap();
-        let t = svc.tables.shards[0].lock().await;
+        let t = svc.tables.shards[0].lock().unwrap();
         assert!(t.rtable.collect_loc_rib_paths(&Family::IPV4).is_empty());
     }
 
@@ -11254,7 +11230,7 @@ neighbor-address = "10.0.0.1"
             .await;
 
         assert!(!exceeded, "loop detection must not trigger CEASE");
-        let state = tables.table_state(Family::IPV4).await;
+        let state = tables.table_state(Family::IPV4);
         assert_eq!(state.num_destination, 0, "route must not be inserted");
     }
 
@@ -11281,7 +11257,7 @@ neighbor-address = "10.0.0.1"
             .await;
 
         assert!(!exceeded, "loop detection must not trigger CEASE");
-        let state = tables.table_state(Family::IPV4).await;
+        let state = tables.table_state(Family::IPV4);
         assert_eq!(state.num_destination, 0, "route must not be inserted");
     }
 
@@ -11313,7 +11289,7 @@ neighbor-address = "10.0.0.1"
             .await;
 
         assert!(!exceeded, "loop detection must not trigger CEASE");
-        let state = tables.table_state(Family::IPV4).await;
+        let state = tables.table_state(Family::IPV4);
         assert_eq!(state.num_destination, 0, "route must not be inserted");
     }
 

--- a/daemon/src/mrt.rs
+++ b/daemon/src/mrt.rs
@@ -81,9 +81,9 @@ impl MrtDumper {
         cancel: CancellationToken,
         tables: TableHandle,
     ) -> Result<(), Error> {
-        let subscription = tables.subscribe_live().await;
+        let subscription = tables.subscribe_live();
         let result = self.run_loop(&mut file, subscription.rx, cancel).await;
-        tables.unsubscribe(subscription.id).await;
+        tables.unsubscribe(subscription.id);
         result
     }
 

--- a/daemon/src/rpki.rs
+++ b/daemon/src/rpki.rs
@@ -182,20 +182,20 @@ impl RpkiClient {
                                 if end_of_data {
                                     tables
                                         .rpki_insert(vec![(prefix.net.clone(), roa)])
-                                        .await;
+                                        ;
                                 } else {
                                     v.push((prefix.net, roa));
                                 }
                             } else if end_of_data {
                                 tables
                                     .rpki_withdraw(vec![(prefix.net.clone(), roa)])
-                                    .await;
+                                    ;
                             }
                         }
                         rpki::Message::EndOfData { serial_number, .. } => {
                             end_of_data = true;
                             state.serial.store(serial_number, Ordering::Relaxed);
-                            tables.rpki_reset(remote_addr.clone(), v.to_owned()).await;
+                            tables.rpki_reset(remote_addr.clone(), v.to_owned());
                         }
                         _ => {}
                     }
@@ -210,7 +210,7 @@ impl RpkiClient {
                 .as_secs(),
             Ordering::Relaxed,
         );
-        tables.rpki_drop_all(remote_addr.clone()).await;
+        tables.rpki_drop_all(remote_addr.clone());
         Ok(())
     }
 

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -17,7 +17,8 @@ use fnv::{FnvHashMap, FnvHashSet, FnvHasher};
 use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 use std::sync::Arc;
-use tokio::sync::{Mutex, mpsc};
+use std::sync::Mutex;
+use tokio::sync::mpsc;
 
 use rustybgp_kernel as kernel;
 use rustybgp_packet::{self as packet, Family, bgp};
@@ -130,7 +131,7 @@ impl TableManager {
         )
     }
 
-    pub(crate) async fn add_vrf(
+    pub(crate) fn add_vrf(
         &self,
         name: String,
         rd: packet::rd::RouteDistinguisher,
@@ -164,7 +165,7 @@ impl TableManager {
         Ok(label)
     }
 
-    pub(crate) async fn delete_vrf(&self, name: &str) -> Result<(), table::TableError> {
+    pub(crate) fn delete_vrf(&self, name: &str) -> Result<(), table::TableError> {
         let current = self.vrfs.load_full();
         let id = current.get(name).ok_or(table::TableError::NotFound)?.id;
         let mut new_map = (*current).clone();
@@ -178,7 +179,7 @@ impl TableManager {
         Ok(())
     }
 
-    pub(crate) async fn list_vrfs(&self, name: Option<&str>) -> Vec<table::Vrf> {
+    pub(crate) fn list_vrfs(&self, name: Option<&str>) -> Vec<table::Vrf> {
         let vrfs = self.vrfs.load();
         match name {
             Some(n) => vrfs.get(n).cloned().into_iter().collect(),
@@ -188,7 +189,7 @@ impl TableManager {
 
     /// Collect paths from the global VPN table that can be imported into `vrf`.
     /// Returns destinations with the VPN wrapper stripped (plain V4/V6 NLRI).
-    pub(crate) async fn collect_vrf_paths(
+    pub(crate) fn collect_vrf_paths(
         &self,
         vrf_name: &str,
         family: Family,
@@ -203,7 +204,7 @@ impl TableManager {
         let vrf = self.vrfs.load().get(vrf_name)?.clone();
         let mut out = Vec::new();
         for shard in &self.shards {
-            let t = shard.lock().await;
+            let t = shard.lock().unwrap();
             for mut dest in t.rtable.destinations(
                 table::TableQuery::Global,
                 vpn_family,
@@ -244,7 +245,7 @@ impl TableManager {
     /// Returns `true` if the per-peer prefix limit (RFC 4486 §2) was exceeded.
     /// The caller must send a CEASE NOTIFICATION and close the session.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn insert_route(
+    pub(crate) fn insert_route(
         &self,
         source: Arc<table::Source>,
         family: Family,
@@ -258,7 +259,7 @@ impl TableManager {
         let kernel_handle = self.kernel_handle.load_full();
         let nht_set = self.nexthop_invalid.load();
         let idx = self.dealer(&net.nlri);
-        let mut t = self.shards[idx].lock().await;
+        let mut t = self.shards[idx].lock().unwrap();
         t.notify_adj_rib_in(
             source.clone(),
             family,
@@ -307,7 +308,7 @@ impl TableManager {
     }
 
     /// Remove a route from the appropriate shard and distribute changes to peers.
-    pub(crate) async fn remove_route(
+    pub(crate) fn remove_route(
         &self,
         source: Arc<table::Source>,
         family: Family,
@@ -317,7 +318,7 @@ impl TableManager {
     ) {
         let kernel_handle = self.kernel_handle.load_full();
         let idx = self.dealer(&net.nlri);
-        let mut t = self.shards[idx].lock().await;
+        let mut t = self.shards[idx].lock().unwrap();
         t.notify_adj_rib_in(
             source.clone(),
             family,
@@ -344,12 +345,12 @@ impl TableManager {
 
     /// Re-applies the current import policy to all non-stale paths from `peer`
     /// across every shard and distributes any routing changes to peers.
-    pub(crate) async fn soft_reset_in(&self, peer: IpAddr) {
+    pub(crate) fn soft_reset_in(&self, peer: IpAddr) {
         let import_policy = self.import_policy.load_full();
         let kernel_handle = self.kernel_handle.load_full();
         let nht_set = self.nexthop_invalid.load_full();
         for shard in &self.shards {
-            let mut t = shard.lock().await;
+            let mut t = shard.lock().unwrap();
             t.soft_reset_in(
                 peer,
                 import_policy.as_deref(),
@@ -367,12 +368,12 @@ impl TableManager {
     /// If the peer's session is not Established (e.g., peer is in GR helper
     /// mode and the session is down), the peer session's `do_route_refresh`
     /// exits early, making this a safe no-op.
-    pub(crate) async fn soft_reset_out(&self, peer: IpAddr) {
+    pub(crate) fn soft_reset_out(&self, peer: IpAddr) {
         // All shards register the same sender for each peer; shard 0 suffices
         // for the lookup.
         let tx = self.shards[0]
             .lock()
-            .await
+            .unwrap()
             .peer_event_tx
             .get(&peer)
             .cloned();
@@ -381,60 +382,60 @@ impl TableManager {
         }
     }
 
-    pub(crate) async fn drop_families(&self, addr: IpAddr, families: &[Family]) {
+    pub(crate) fn drop_families(&self, addr: IpAddr, families: &[Family]) {
         let kernel_handle = self.kernel_handle.load_full();
         for shard in &self.shards {
-            let mut t = shard.lock().await;
+            let mut t = shard.lock().unwrap();
             for &family in families {
                 t.disconnected(addr, family, kernel_handle.as_deref());
             }
         }
     }
 
-    pub(crate) async fn drop_stale_families(&self, addr: IpAddr, families: &[Family]) {
+    pub(crate) fn drop_stale_families(&self, addr: IpAddr, families: &[Family]) {
         let kernel_handle = self.kernel_handle.load_full();
         for shard in &self.shards {
-            let mut t = shard.lock().await;
+            let mut t = shard.lock().unwrap();
             for &family in families {
                 t.drop_stale(addr, family, kernel_handle.as_deref());
             }
         }
     }
 
-    pub(crate) async fn end_deferral_families(&self, families: &[Family]) {
+    pub(crate) fn end_deferral_families(&self, families: &[Family]) {
         let kernel_handle = self.kernel_handle.load_full();
         for shard in &self.shards {
-            let mut t = shard.lock().await;
+            let mut t = shard.lock().unwrap();
             for &family in families {
                 t.end_deferral(family, kernel_handle.as_deref());
             }
         }
     }
 
-    pub(crate) async fn start_deferral_families(&self, families: &[Family]) {
+    pub(crate) fn start_deferral_families(&self, families: &[Family]) {
         for shard in &self.shards {
-            let mut t = shard.lock().await;
+            let mut t = shard.lock().unwrap();
             for &family in families {
                 t.rtable.start_deferral(family);
             }
         }
     }
 
-    pub(crate) async fn rpki_insert(&self, roas: Vec<(packet::IpNet, Arc<table::Roa>)>) {
+    pub(crate) fn rpki_insert(&self, roas: Vec<(packet::IpNet, Arc<table::Roa>)>) {
         let mut rpki = self.rpki.write().unwrap();
         for (net, roa) in roas {
             rpki.insert(net, roa);
         }
     }
 
-    pub(crate) async fn rpki_withdraw(&self, roas: Vec<(packet::IpNet, Arc<table::Roa>)>) {
+    pub(crate) fn rpki_withdraw(&self, roas: Vec<(packet::IpNet, Arc<table::Roa>)>) {
         let mut rpki = self.rpki.write().unwrap();
         for (net, roa) in roas {
             rpki.remove(net, &roa);
         }
     }
 
-    pub(crate) async fn rpki_reset(
+    pub(crate) fn rpki_reset(
         &self,
         addr: Arc<IpAddr>,
         roas: Vec<(packet::IpNet, Arc<table::Roa>)>,
@@ -446,27 +447,27 @@ impl TableManager {
         }
     }
 
-    pub(crate) async fn rpki_drop_all(&self, addr: Arc<IpAddr>) {
+    pub(crate) fn rpki_drop_all(&self, addr: Arc<IpAddr>) {
         self.rpki.write().unwrap().drop_source(addr);
     }
 
-    pub(crate) async fn table_state(&self, family: Family) -> table::TableState {
+    pub(crate) fn table_state(&self, family: Family) -> table::TableState {
         let mut state = table::TableState::default();
         for shard in &self.shards {
-            state += shard.lock().await.rtable.state(family);
+            state += shard.lock().unwrap().rtable.state(family);
         }
         state
     }
 
-    pub(crate) async fn collect_loc_rib_paths(&self, family: Family) -> Vec<table::NlriChange> {
+    pub(crate) fn collect_loc_rib_paths(&self, family: Family) -> Vec<table::NlriChange> {
         let mut out = Vec::new();
         for shard in &self.shards {
-            out.extend(shard.lock().await.rtable.collect_loc_rib_paths(&family));
+            out.extend(shard.lock().unwrap().rtable.collect_loc_rib_paths(&family));
         }
         out
     }
 
-    pub(crate) async fn collect_roa(&self, family: Family) -> Vec<(packet::IpNet, table::Roa)> {
+    pub(crate) fn collect_roa(&self, family: Family) -> Vec<(packet::IpNet, table::Roa)> {
         self.rpki
             .read()
             .unwrap()
@@ -475,18 +476,18 @@ impl TableManager {
             .collect()
     }
 
-    pub(crate) async fn rpki_state(&self, addr: &IpAddr) -> table::RpkiTableState {
+    pub(crate) fn rpki_state(&self, addr: &IpAddr) -> table::RpkiTableState {
         self.rpki.read().unwrap().state(addr)
     }
 
-    pub(crate) async fn collect_peer_stats(
+    pub(crate) fn collect_peer_stats(
         &self,
         addrs: &[IpAddr],
     ) -> FnvHashMap<IpAddr, FnvHashMap<Family, table::PrefixStats>> {
         let mut map: FnvHashMap<IpAddr, FnvHashMap<Family, table::PrefixStats>> =
             FnvHashMap::default();
         for shard in &self.shards {
-            let t = shard.lock().await;
+            let t = shard.lock().unwrap();
             for addr in addrs {
                 if let Some(iter) = t.rtable.peer_stats(addr) {
                     let entry = map.entry(*addr).or_default();
@@ -501,7 +502,7 @@ impl TableManager {
         map
     }
 
-    pub(crate) async fn collect_paths(
+    pub(crate) fn collect_paths(
         &self,
         query: table::TableQuery,
         family: Family,
@@ -511,7 +512,7 @@ impl TableManager {
         // Phase 1: collect from each shard (validation: None); shard lock released after each.
         let mut out = Vec::new();
         for shard in &self.shards {
-            let t = shard.lock().await;
+            let t = shard.lock().unwrap();
             out.extend(
                 t.rtable
                     .destinations(query, family, prefixes.clone(), enable_filtered),
@@ -529,7 +530,7 @@ impl TableManager {
 
     /// Subscribe with snapshot: calls `on_change` for each current route (per shard, under lock),
     /// then registers for live AdjRibIn/PeerUp/PeerDown events.
-    pub(crate) async fn subscribe_with<F>(&self, mut on_change: F) -> Subscription
+    pub(crate) fn subscribe_with<F>(&self, mut on_change: F) -> Subscription
     where
         F: FnMut(AdjRibInChange),
     {
@@ -540,12 +541,12 @@ impl TableManager {
         let (tx, rx) = mpsc::unbounded_channel();
         // Register for peer events (PeerUp/PeerDown) first to avoid missing events.
         {
-            let mut subs = self.subscribers.lock().await;
+            let mut subs = self.subscribers.lock().unwrap();
             subs.insert(id, tx.clone());
         }
         // Snapshot each shard atomically while registering for live AdjRibIn events.
         for shard in &self.shards {
-            let mut t = shard.lock().await;
+            let mut t = shard.lock().unwrap();
             for f in t.rtable.families().collect::<Vec<_>>() {
                 for reach in t.rtable.iter_reach(f) {
                     let addpath = t.has_addpath(&reach.source.remote_addr, &f);
@@ -566,43 +567,43 @@ impl TableManager {
     }
 
     /// Subscribe for live events only (no snapshot). Used by watch_event gRPC and MRT.
-    pub(crate) async fn subscribe_live(&self) -> Subscription {
+    pub(crate) fn subscribe_live(&self) -> Subscription {
         let id = SubscriptionId(
             self.next_sub_id
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
         );
         let (tx, rx) = mpsc::unbounded_channel();
         {
-            let mut subs = self.subscribers.lock().await;
+            let mut subs = self.subscribers.lock().unwrap();
             subs.insert(id, tx.clone());
         }
         for shard in &self.shards {
-            let mut shard = shard.lock().await;
+            let mut shard = shard.lock().unwrap();
             shard.subscribers.insert(id, tx.clone());
         }
         Subscription { rx, id }
     }
 
-    pub(crate) async fn unsubscribe(&self, id: SubscriptionId) {
+    pub(crate) fn unsubscribe(&self, id: SubscriptionId) {
         {
-            let mut subs = self.subscribers.lock().await;
+            let mut subs = self.subscribers.lock().unwrap();
             subs.remove(&id);
         }
         for shard in &self.shards {
-            let mut shard = shard.lock().await;
+            let mut shard = shard.lock().unwrap();
             shard.subscribers.remove(&id);
         }
     }
 
-    pub(crate) async fn peer_up(&self, data: PeerUpData) {
-        let subs = self.subscribers.lock().await;
+    pub(crate) fn peer_up(&self, data: PeerUpData) {
+        let subs = self.subscribers.lock().unwrap();
         for tx in subs.values() {
             let _ = tx.send(BgpEvent::PeerUp(data.clone()));
         }
     }
 
-    pub(crate) async fn peer_down(&self, data: PeerDownData) {
-        let subs = self.subscribers.lock().await;
+    pub(crate) fn peer_down(&self, data: PeerDownData) {
+        let subs = self.subscribers.lock().unwrap();
         for tx in subs.values() {
             let _ = tx.send(BgpEvent::PeerDown(data.clone()));
         }
@@ -613,7 +614,7 @@ impl TableManager {
     /// For each shard, while the lock is held, `on_shard` is called with the
     /// shard's routing table so the caller can populate its initial routes.
     /// The returned receiver delivers `ToPeerEvent` messages from all shards.
-    pub(crate) async fn register_peer<F>(
+    pub(crate) fn register_peer<F>(
         &self,
         addr: IpAddr,
         addpath: FnvHashSet<Family>,
@@ -624,7 +625,7 @@ impl TableManager {
     {
         let (tx, rx) = mpsc::unbounded_channel();
         for shard in &self.shards {
-            let mut t = shard.lock().await;
+            let mut t = shard.lock().unwrap();
             on_shard(&t.rtable);
             t.peer_event_tx.insert(addr, tx.clone());
             if !addpath.is_empty() {
@@ -634,7 +635,7 @@ impl TableManager {
         rx
     }
 
-    pub(crate) async fn unregister_peer(
+    pub(crate) fn unregister_peer(
         &self,
         addr: IpAddr,
         drop_families: &[Family],
@@ -642,7 +643,7 @@ impl TableManager {
     ) {
         let kernel_handle = self.kernel_handle.load_full();
         for shard in &self.shards {
-            let mut t = shard.lock().await;
+            let mut t = shard.lock().unwrap();
             t.peer_event_tx.remove(&addr);
             t.addpath.remove(&addr);
             for &family in drop_families {
@@ -659,7 +660,7 @@ impl TableManager {
     /// Updates the `nexthop_invalid` ArcSwap set so that newly inserted paths
     /// see the current reachability, then walks all shards to flip
     /// `FLAG_NEXTHOP_INVALID` on affected paths and distribute routing changes.
-    pub(crate) async fn update_nexthop_validity(&self, addr: IpAddr, reachable: bool) {
+    pub(crate) fn update_nexthop_validity(&self, addr: IpAddr, reachable: bool) {
         // Update the ArcSwap set.  Loads/swaps are serialized through the event loop.
         let current = self.nexthop_invalid.load_full();
         let mut new_set = (*current).clone();
@@ -672,7 +673,7 @@ impl TableManager {
 
         let kernel_handle = self.kernel_handle.load_full();
         for shard in &self.shards {
-            let mut t = shard.lock().await;
+            let mut t = shard.lock().unwrap();
             for change in t.rtable.update_nexthop_validity(addr, reachable) {
                 t.distribute_update(change, kernel_handle.as_deref());
             }
@@ -680,7 +681,7 @@ impl TableManager {
     }
 
     /// Inject a kernel-redistributed route into the BGP RIB.
-    pub(crate) async fn inject_kernel_route(&self, kr: kernel::KernelRoute) {
+    pub(crate) fn inject_kernel_route(&self, kr: kernel::KernelRoute) {
         let Some((family, net, nexthop, attr)) = kernel_route_to_path(&kr) else {
             return;
         };
@@ -692,12 +693,11 @@ impl TableManager {
             attr,
             None,
             std::time::SystemTime::now(),
-        )
-        .await;
+        );
     }
 
     /// Withdraw a kernel-redistributed route from the BGP RIB.
-    pub(crate) async fn withdraw_kernel_route(&self, dst: std::net::IpAddr, prefix_len: u8) {
+    pub(crate) fn withdraw_kernel_route(&self, dst: std::net::IpAddr, prefix_len: u8) {
         let nlri = ip_to_nlri(dst, prefix_len);
         let family = nlri_family(&nlri);
         self.remove_route(
@@ -706,15 +706,14 @@ impl TableManager {
             packet::PathNlri { nlri, path_id: 0 },
             None,
             std::time::SystemTime::now(),
-        )
-        .await;
+        );
     }
 
     /// Inject or withdraw a Connected route triggered by an interface address event.
     ///
     /// The route destination is the network prefix (interface address masked by
     /// prefix_len); the BGP nexthop is the interface address itself per RFC 4271 §5.1.3.
-    pub(crate) async fn handle_address_event(&self, event: kernel::KernelAddressEvent) {
+    pub(crate) fn handle_address_event(&self, event: kernel::KernelAddressEvent) {
         let (ka, is_add) = match event {
             kernel::KernelAddressEvent::Add(a) => (a, true),
             kernel::KernelAddressEvent::Delete(a) => (a, false),
@@ -728,9 +727,9 @@ impl TableManager {
                 metric: 0,
                 protocol: kernel::Protocol::Kernel,
             };
-            self.inject_kernel_route(kr).await;
+            self.inject_kernel_route(kr);
         } else {
-            self.withdraw_kernel_route(network, ka.prefix_len).await;
+            self.withdraw_kernel_route(network, ka.prefix_len);
         }
     }
 }
@@ -1172,15 +1171,13 @@ mod tests {
     async fn inject_kernel_route_adds_path() {
         let tables = make_tables();
         let kr = kr_v4("10.0.0.0", 24, "192.168.1.1", 0, kernel::Protocol::Static);
-        tables.inject_kernel_route(kr).await;
-        let paths = tables
-            .collect_paths(
-                rustybgp_table::TableQuery::Global,
-                Family::IPV4,
-                vec![],
-                false,
-            )
-            .await;
+        tables.inject_kernel_route(kr);
+        let paths = tables.collect_paths(
+            rustybgp_table::TableQuery::Global,
+            Family::IPV4,
+            vec![],
+            false,
+        );
         assert_eq!(paths.len(), 1);
         assert!(paths[0].paths[0].source.is_kernel());
     }
@@ -1189,18 +1186,14 @@ mod tests {
     async fn withdraw_kernel_route_removes_path() {
         let tables = make_tables();
         let kr = kr_v4("10.0.0.0", 24, "192.168.1.1", 0, kernel::Protocol::Static);
-        tables.inject_kernel_route(kr).await;
-        tables
-            .withdraw_kernel_route("10.0.0.0".parse().unwrap(), 24)
-            .await;
-        let paths = tables
-            .collect_paths(
-                rustybgp_table::TableQuery::Global,
-                Family::IPV4,
-                vec![],
-                false,
-            )
-            .await;
+        tables.inject_kernel_route(kr);
+        tables.withdraw_kernel_route("10.0.0.0".parse().unwrap(), 24);
+        let paths = tables.collect_paths(
+            rustybgp_table::TableQuery::Global,
+            Family::IPV4,
+            vec![],
+            false,
+        );
         assert_eq!(paths.len(), 0);
     }
 
@@ -1217,7 +1210,7 @@ mod tests {
         ))
     }
 
-    async fn insert_v4_route(
+    fn insert_v4_route(
         tables: &TableManager,
         source: Arc<table::Source>,
         prefix: &str,
@@ -1226,17 +1219,15 @@ mod tests {
         let nlri: packet::Nlri = prefix.parse().unwrap();
         let net = packet::PathNlri::new(nlri);
         let nh: std::net::Ipv4Addr = nexthop.parse().unwrap();
-        tables
-            .insert_route(
-                source,
-                Family::IPV4,
-                net,
-                Some(packet::bgp::Nexthop::V4(nh)),
-                Arc::new(vec![]),
-                None,
-                std::time::SystemTime::UNIX_EPOCH,
-            )
-            .await;
+        tables.insert_route(
+            source,
+            Family::IPV4,
+            net,
+            Some(packet::bgp::Nexthop::V4(nh)),
+            Arc::new(vec![]),
+            None,
+            std::time::SystemTime::UNIX_EPOCH,
+        );
     }
 
     fn loc_rib_len(tables: &TableManager, shard: usize, family: Family) -> usize {
@@ -1254,13 +1245,11 @@ mod tests {
     async fn nht_invalid_nexthop_excluded_from_best() {
         let tables = make_tables();
         let src = make_peer_source("10.0.0.2", "127.0.0.1", 65002);
-        insert_v4_route(&tables, src, "192.168.1.0/24", "10.0.0.2").await;
+        insert_v4_route(&tables, src, "192.168.1.0/24", "10.0.0.2");
 
         assert_eq!(loc_rib_len(&tables, 0, Family::IPV4), 1);
 
-        tables
-            .update_nexthop_validity("10.0.0.2".parse().unwrap(), false)
-            .await;
+        tables.update_nexthop_validity("10.0.0.2".parse().unwrap(), false);
 
         // Nexthop is now invalid: path must be excluded from loc-RIB.
         assert_eq!(loc_rib_len(&tables, 0, Family::IPV4), 0);
@@ -1270,17 +1259,13 @@ mod tests {
     async fn nht_valid_nexthop_restored() {
         let tables = make_tables();
         let src = make_peer_source("10.0.0.2", "127.0.0.1", 65002);
-        insert_v4_route(&tables, src, "192.168.1.0/24", "10.0.0.2").await;
+        insert_v4_route(&tables, src, "192.168.1.0/24", "10.0.0.2");
 
-        tables
-            .update_nexthop_validity("10.0.0.2".parse().unwrap(), false)
-            .await;
+        tables.update_nexthop_validity("10.0.0.2".parse().unwrap(), false);
         assert_eq!(loc_rib_len(&tables, 0, Family::IPV4), 0);
 
         // Nexthop becomes reachable again: path must be restored to loc-RIB.
-        tables
-            .update_nexthop_validity("10.0.0.2".parse().unwrap(), true)
-            .await;
+        tables.update_nexthop_validity("10.0.0.2".parse().unwrap(), true);
         assert_eq!(loc_rib_len(&tables, 0, Family::IPV4), 1);
     }
 
@@ -1289,12 +1274,10 @@ mod tests {
         let tables = make_tables();
 
         // Mark the nexthop unreachable BEFORE the path arrives.
-        tables
-            .update_nexthop_validity("10.0.0.2".parse().unwrap(), false)
-            .await;
+        tables.update_nexthop_validity("10.0.0.2".parse().unwrap(), false);
 
         let src = make_peer_source("10.0.0.2", "127.0.0.1", 65002);
-        insert_v4_route(&tables, src, "192.168.1.0/24", "10.0.0.2").await;
+        insert_v4_route(&tables, src, "192.168.1.0/24", "10.0.0.2");
 
         // The path must not appear in loc-RIB: the ArcSwap set was checked
         // at insertion time and nexthop_invalid_flag was set.


### PR DESCRIPTION
…nd subscribers

All TableManager shard locks were tokio::sync::Mutex but no code ever held a lock guard across an .await point, so the async lock bought nothing over a std::sync::Mutex.  Switching to std::sync eliminates the need to .await lock acquisitions and allows 30 of the 33 TableManager methods to drop their async qualifier.  The remaining three (subscribe_with, subscribe_live, unsubscribe, soft_reset_out, peer_up, peer_down) also convert cleanly since the subscribers Mutex had the same property.

The synchronous API simplifies call sites in event.rs, bmp.rs, mrt.rs, and rpki.rs, removing ~40 .await expressions from those files.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>