### PR TITLE
table,daemon: implement Condition::Rpki for RPKI-based export policy

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -2730,6 +2730,7 @@ impl GoBgpService for GrpcService {
                     };
                     let export_policy = self.tables.export_policy.load_full();
                     let changes = self.tables.collect_loc_rib_paths(family);
+                    let rpki = self.tables.rpki.read().unwrap();
                     let mut sink = AdjOutSink::default();
                     let mut export_map = ExportMap::new();
                     for change in changes {
@@ -2742,6 +2743,7 @@ impl GoBgpService for GrpcService {
                             &export_ctx,
                             export_policy.as_deref(),
                             cluster_id,
+                            Some(&rpki),
                         );
                     }
                     let destinations = sink.destinations;
@@ -5411,6 +5413,7 @@ impl PeerSession {
         }
 
         let export_policy = self.tables.export_policy.load_full();
+        let rpki = self.tables.rpki.read().unwrap();
         let peer_event_rx = self
             .tables
             .register_peer(self.remote_addr, addpath, |rtable| {
@@ -5430,6 +5433,7 @@ impl PeerSession {
                             &self.export_ctx,
                             export_policy.as_deref(),
                             self.cluster_id,
+                            Some(&rpki),
                         );
                     }
                 }
@@ -5470,6 +5474,7 @@ impl PeerSession {
         let effective_max =
             conn_effective_max(&self.conn_arbiter.lock().unwrap(), Some(self.role), family);
         let changes = self.tables.collect_loc_rib_paths(family);
+        let rpki = self.tables.rpki.read().unwrap();
         self.export_map.clear_family(family);
         for change in changes {
             let Some(pending) = self.pending.get_mut(&change.family) else {
@@ -5484,6 +5489,7 @@ impl PeerSession {
                 &self.export_ctx,
                 export_policy.as_deref(),
                 self.cluster_id,
+                Some(&rpki),
             );
         }
         self.pending.get_mut(&family).unwrap().schedule_eor();
@@ -5839,6 +5845,7 @@ impl PeerSession {
             return;
         };
         let export_policy = self.tables.export_policy.load_full();
+        let rpki = self.tables.rpki.read().unwrap();
         process_nlri_change(
             &update,
             effective_max,
@@ -5848,6 +5855,7 @@ impl PeerSession {
             &self.export_ctx,
             export_policy.as_deref(),
             self.cluster_id,
+            Some(&rpki),
         );
     }
 
@@ -6526,6 +6534,7 @@ fn process_nlri_change<S: NlriSink>(
     export_ctx: &PeerExportContext,
     export_policy: Option<&table::PolicyAssignment>,
     cluster_id: Option<Ipv4Addr>,
+    rpki: Option<&table::RpkiTable>,
 ) {
     if effective_max == 1 {
         // Non-Add-Path fast path: O(1) skip when best unchanged.
@@ -6553,8 +6562,9 @@ fn process_nlri_change<S: NlriSink>(
             let mut nexthop = best.nexthop;
             let mut attr = Arc::clone(&best.attr);
             if export_policy.is_some_and(|policy| {
-                table::Table::apply_policy(
+                table::apply_export(
                     policy,
+                    rpki,
                     &best.source,
                     &update.net,
                     &mut attr,
@@ -6611,8 +6621,9 @@ fn process_nlri_change<S: NlriSink>(
                 let mut nexthop = path.nexthop;
                 let mut attr = Arc::clone(&path.attr);
                 if export_policy.is_some_and(|policy| {
-                    table::Table::apply_policy(
+                    table::apply_export(
                         policy,
+                        rpki,
                         &path.source,
                         &update.net,
                         &mut attr,
@@ -8982,6 +8993,7 @@ mod tests {
                 &ebgp_ctx(),
                 None,
                 None,
+                None,
             );
 
             assert!(pending.is_empty());
@@ -9003,6 +9015,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
             );
@@ -9033,6 +9046,7 @@ mod tests {
                 &ebgp_ctx(),
                 None,
                 None,
+                None,
             );
 
             assert!(!em.was_sent(Family::IPV4, &net));
@@ -9056,6 +9070,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
             );
@@ -9082,6 +9097,7 @@ mod tests {
                 &ebgp_ctx(),
                 None,
                 None,
+                None,
             );
 
             assert!(pending.is_empty());
@@ -9106,6 +9122,7 @@ mod tests {
                 &ebgp_ctx(),
                 None,
                 None,
+                None,
             );
             assert!(em.was_sent(Family::IPV4, &net));
             pending.drain_messages(Family::IPV4); // flush
@@ -9118,6 +9135,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
             );
@@ -9145,6 +9163,7 @@ mod tests {
                 &ebgp_ctx(),
                 None,
                 None,
+                None,
             );
 
             assert!(pending.is_empty());
@@ -9166,6 +9185,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
             );
@@ -9200,6 +9220,7 @@ mod tests {
                 &ebgp_ctx(),
                 None,
                 None,
+                None,
             );
 
             assert!(em.contains_path(Family::IPV4, &net, 1));
@@ -9229,6 +9250,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
             );
@@ -9262,6 +9284,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
             );
@@ -9302,6 +9325,7 @@ mod tests {
                 &ebgp_ctx(),
                 None,
                 None,
+                None,
             );
 
             assert!(!em.contains_path(Family::IPV4, &net, 1)); // withdrawn
@@ -9333,6 +9357,7 @@ mod tests {
                 &ebgp_ctx(),
                 None,
                 None,
+                None,
             );
 
             assert!(!em.was_sent(Family::IPV4, &net));
@@ -9360,6 +9385,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
             );
@@ -9391,6 +9417,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
             );
@@ -9446,6 +9473,7 @@ mod tests {
                 &ibgp_ctx(),
                 None,
                 None,
+                None,
             );
 
             // Split horizon: iBGP-learned route must not be forwarded to iBGP peer
@@ -9471,6 +9499,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ibgp_ctx(),
+                None,
                 None,
                 None,
             );
@@ -9499,6 +9528,7 @@ mod tests {
                 &ibgp_ctx(),
                 None,
                 None,
+                None,
             );
 
             // eBGP-learned route CAN be forwarded to iBGP peer
@@ -9525,6 +9555,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ibgp_ctx(),
+                None,
                 None,
                 None,
             );
@@ -10009,6 +10040,7 @@ mod tests {
                 &ibgp_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
             );
 
             assert!(pending.is_empty());
@@ -10033,6 +10065,7 @@ mod tests {
                 &ibgp_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
             );
 
             assert!(em.was_sent(Family::IPV4, &net));
@@ -10060,6 +10093,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
             );
 
             assert!(em.was_sent(Family::IPV4, &net));
@@ -10117,6 +10151,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
             );
 
             let attrs = drain_first_reach_attrs(&mut pending);
@@ -10156,6 +10191,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
             );
 
             let attrs = drain_first_reach_attrs(&mut pending);
@@ -10196,6 +10232,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
             );
 
             let attrs = drain_first_reach_attrs(&mut pending);
@@ -10230,6 +10267,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
             );
 
             let attrs = drain_first_reach_attrs(&mut pending);
@@ -10262,6 +10300,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
             );
 
             let attrs = drain_first_reach_attrs(&mut pending);
@@ -10297,6 +10336,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
             );
 
             assert!(em.was_sent(Family::IPV4, &net));
@@ -10348,6 +10388,7 @@ mod tests {
                 &ebgp_ctx(),
                 None,
                 None,
+                None,
             );
 
             assert!(!em.was_sent(Family::IPV4, &net));
@@ -10375,6 +10416,7 @@ mod tests {
                 &rs_client_ctx(),
                 None,
                 None,
+                None,
             );
 
             assert!(!em.was_sent(Family::IPV4, &net));
@@ -10400,6 +10442,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &rs_client_ctx(),
+                None,
                 None,
                 None,
             );

--- a/daemon/src/policy.rs
+++ b/daemon/src/policy.rs
@@ -18,17 +18,13 @@
 //! Pure logic — no async, no I/O.
 
 use rustybgp_packet::bgp::Nexthop;
-use rustybgp_table::{Disposition, PolicyAssignment};
+use rustybgp_table::PolicyAssignment;
 use std::sync::Arc;
 
-/// Apply import policy to a route and return whether it should be filtered
-/// (rejected). Also applies any nexthop rewriting action.
-/// Apply import policy and return `(filtered, post_policy_attr)`.
+/// Apply import policy (without RPKI) and return `(filtered, post_policy_attr)`.
 ///
-/// `post_policy_attr` is the Arc after policy attribute modifications.  When
-/// the policy does not modify attributes it is the same Arc as `attrs` (only
-/// the reference count increases), so callers can store the original Arc
-/// separately for Adj-RIB-In without extra allocation.
+/// Used only for soft-reset-in where the RPKI guard cannot be held across shards.
+/// Primary import path uses [`TableManager::apply_import`] which includes RPKI.
 pub(crate) fn apply_import(
     import_policy: Option<&PolicyAssignment>,
     source: &Arc<rustybgp_table::Source>,
@@ -36,22 +32,10 @@ pub(crate) fn apply_import(
     attrs: &Arc<Vec<rustybgp_packet::Attribute>>,
     nexthop: &mut Option<Nexthop>,
 ) -> (bool, Arc<Vec<rustybgp_packet::Attribute>>) {
-    match import_policy {
-        None => (false, Arc::clone(attrs)),
-        Some(a) => {
-            let mut attr = Arc::clone(attrs);
-            let filtered = rustybgp_table::Table::apply_policy(
-                a,
-                source,
-                nlri,
-                &mut attr,
-                nexthop,
-                source.local_addr,
-                source.remote_addr,
-            ) == Disposition::Reject;
-            (filtered, attr)
-        }
-    }
+    let Some(policy) = import_policy else {
+        return (false, Arc::clone(attrs));
+    };
+    rustybgp_table::apply_import(policy, None, source, nlri, attrs, nexthop)
 }
 
 #[cfg(test)]
@@ -59,7 +43,7 @@ mod tests {
     use super::*;
     use rustybgp_packet::bgp::Nexthop;
     use rustybgp_packet::{self as packet};
-    use rustybgp_table as table;
+    use rustybgp_table::{self as table, Disposition};
     use std::net::{IpAddr, Ipv4Addr};
     use std::str::FromStr;
     use std::sync::Arc;

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -81,7 +81,7 @@ type SharedVrfs = Arc<ArcSwap<FnvHashMap<String, table::Vrf>>>;
 
 pub(crate) struct TableManager {
     pub(crate) shards: Vec<Mutex<TableShard>>,
-    rpki: std::sync::RwLock<table::RpkiTable>,
+    pub(crate) rpki: std::sync::RwLock<table::RpkiTable>,
     pub(crate) kernel_handle: ArcSwapOption<kernel::KernelHandle>,
     pub(crate) import_policy: ArcSwapOption<table::PolicyAssignment>,
     pub(crate) export_policy: ArcSwapOption<table::PolicyAssignment>,
@@ -273,13 +273,8 @@ impl TableManager {
             .lookup_nexthop(source.remote_addr, family, &net.nlri, net.path_id);
         let mut nh = nexthop;
         let original_attr = Arc::clone(&attr);
-        let (filtered, post_policy_attr) = crate::policy::apply_import(
-            import_policy.as_deref(),
-            &source,
-            &net.nlri,
-            &attr,
-            &mut nh,
-        );
+        let (filtered, post_policy_attr) =
+            self.apply_import(import_policy.as_deref(), &source, &net.nlri, &attr, &mut nh);
         let nexthop_invalid_flag = nh.is_some_and(|n| nht_set.contains(&n.addr()));
         let pl = prefix_limit.as_ref().map(|(max, counter)| (*max, counter));
         match t.rtable.insert(
@@ -480,6 +475,21 @@ impl TableManager {
         self.rpki.read().unwrap().state(addr)
     }
 
+    pub(crate) fn apply_import(
+        &self,
+        policy: Option<&table::PolicyAssignment>,
+        source: &Arc<table::Source>,
+        net: &packet::Nlri,
+        attrs: &Arc<Vec<packet::Attribute>>,
+        nexthop: &mut Option<packet::bgp::Nexthop>,
+    ) -> (bool, Arc<Vec<packet::Attribute>>) {
+        let Some(policy) = policy else {
+            return (false, Arc::clone(attrs));
+        };
+        let rpki = self.rpki.read().unwrap();
+        table::apply_import(policy, Some(&rpki), source, net, attrs, nexthop)
+    }
+
     pub(crate) fn collect_peer_stats(
         &self,
         addrs: &[IpAddr],
@@ -522,7 +532,7 @@ impl TableManager {
         let rpki = self.rpki.read().unwrap();
         for dest in &mut out {
             for path in &mut dest.paths {
-                path.validation = rpki.validate(family, &path.source, &dest.net, &path.attr);
+                path.validation = rpki.validate(&path.source, &dest.net, &path.attr);
             }
         }
         out

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -1512,6 +1512,7 @@ impl Table {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn apply_policy(
         assignment: &PolicyAssignment,
         source: &Arc<Source>,
@@ -1520,8 +1521,9 @@ impl Table {
         nexthop: &mut Option<bgp::Nexthop>,
         local_addr: IpAddr,
         peer_addr: IpAddr,
+        rpki: Option<&RpkiTable>,
     ) -> Disposition {
-        assignment.apply(source, net, attr, nexthop, local_addr, peer_addr)
+        assignment.apply(source, net, attr, nexthop, local_addr, peer_addr, rpki)
     }
 }
 
@@ -1553,7 +1555,7 @@ pub struct RpkiTableState {
     pub num_prefixes_v6: u32,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RpkiTable {
     roas: FnvHashMap<Family, PatriciaMap<Vec<Arc<Roa>>>>,
 }
@@ -1593,81 +1595,64 @@ impl RpkiTable {
 
     pub fn validate(
         &self,
-        family: Family,
         source: &Arc<Source>,
         net: &packet::Nlri,
         attr: &Arc<Vec<packet::Attribute>>,
     ) -> Option<RpkiValidation> {
-        match self.roas.get(&family) {
-            None => None,
-            Some(m) => {
-                if m.is_empty() {
-                    return None;
-                }
-                let mut result = RpkiValidation {
-                    state: RpkiValidationState::NotFound,
-                    reason: RpkiValidationReason::None,
-                    matched: Vec::new(),
-                    unmatched_asn: Vec::new(),
-                    unmatched_length: Vec::new(),
-                };
-                let asn =
-                    if let Some(a) = attr.iter().find(|a| a.code() == packet::Attribute::AS_PATH) {
-                        match a.as_path_origin() {
-                            Some(asn) => asn,
-                            None => source.local_asn,
-                        }
+        let (family, addr_bytes, mask) = match net {
+            packet::Nlri::V4(n) => (Family::IPV4, n.addr.octets().to_vec(), n.mask),
+            packet::Nlri::V6(n) => (Family::IPV6, n.addr.octets().to_vec(), n.mask),
+            _ => return None,
+        };
+        let m = self.roas.get(&family)?;
+        if m.is_empty() {
+            return None;
+        }
+        let mut result = RpkiValidation {
+            state: RpkiValidationState::NotFound,
+            reason: RpkiValidationReason::None,
+            matched: Vec::new(),
+            unmatched_asn: Vec::new(),
+            unmatched_length: Vec::new(),
+        };
+        let asn = if let Some(a) = attr.iter().find(|a| a.code() == packet::Attribute::AS_PATH) {
+            match a.as_path_origin() {
+                Some(asn) => asn,
+                None => source.local_asn,
+            }
+        } else {
+            source.local_asn
+        };
+        let mut addr = addr_bytes;
+        addr.drain((mask.div_ceil(8)) as usize..);
+        for (ipnet, entry) in m.iter_prefix(&addr) {
+            let ipnet = RpkiTable::key_to_addr(ipnet);
+            for roa in entry {
+                if mask <= roa.max_length {
+                    if roa.as_number != 0 && roa.as_number == asn {
+                        result.matched.push((ipnet.clone(), roa.as_ref().clone()));
                     } else {
-                        source.local_asn
-                    };
-                let (mut addr, mask) = match net {
-                    packet::Nlri::V4(net) => (net.addr.octets().to_vec(), net.mask),
-                    packet::Nlri::V6(net) => (net.addr.octets().to_vec(), net.mask),
-                    packet::Nlri::Mup(_)
-                    | packet::Nlri::VpnV4(_)
-                    | packet::Nlri::VpnV6(_)
-                    | packet::Nlri::LabeledV4(_)
-                    | packet::Nlri::LabeledV6(_)
-                    | packet::Nlri::FlowspecV4(_)
-                    | packet::Nlri::FlowspecV6(_)
-                    | packet::Nlri::FlowspecVpnV4(_)
-                    | packet::Nlri::FlowspecVpnV6(_)
-                    | packet::Nlri::Ls(_) => {
-                        return None;
+                        result
+                            .unmatched_asn
+                            .push((ipnet.clone(), roa.as_ref().clone()));
                     }
-                };
-                addr.drain((mask.div_ceil(8)) as usize..);
-                for (ipnet, entry) in m.iter_prefix(&addr) {
-                    let ipnet = RpkiTable::key_to_addr(ipnet);
-                    for roa in entry {
-                        if mask <= roa.max_length {
-                            if roa.as_number != 0 && roa.as_number == asn {
-                                result.matched.push((ipnet.clone(), roa.as_ref().clone()));
-                            } else {
-                                result
-                                    .unmatched_asn
-                                    .push((ipnet.clone(), roa.as_ref().clone()));
-                            }
-                        } else {
-                            result
-                                .unmatched_length
-                                .push((ipnet.clone(), roa.as_ref().clone()));
-                        }
-                    }
+                } else {
+                    result
+                        .unmatched_length
+                        .push((ipnet.clone(), roa.as_ref().clone()));
                 }
-                if !result.matched.is_empty() {
-                    result.state = RpkiValidationState::Valid;
-                } else if !result.unmatched_asn.is_empty() {
-                    result.state = RpkiValidationState::Invalid;
-                    result.reason = RpkiValidationReason::Asn;
-                } else if !result.unmatched_length.is_empty() {
-                    result.state = RpkiValidationState::Invalid;
-                    result.reason = RpkiValidationReason::Length;
-                }
-
-                Some(result)
             }
         }
+        if !result.matched.is_empty() {
+            result.state = RpkiValidationState::Valid;
+        } else if !result.unmatched_asn.is_empty() {
+            result.state = RpkiValidationState::Invalid;
+            result.reason = RpkiValidationReason::Asn;
+        } else if !result.unmatched_length.is_empty() {
+            result.state = RpkiValidationState::Invalid;
+            result.reason = RpkiValidationReason::Length;
+        }
+        Some(result)
     }
 
     pub fn insert(&mut self, net: packet::IpNet, roa: Arc<Roa>) {
@@ -3072,6 +3057,7 @@ mod tests {
             &mut nh(),
             IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
             s.remote_addr,
+            None,
         );
         assert_eq!(result, Disposition::Reject);
     }
@@ -3123,6 +3109,7 @@ mod tests {
             &mut nh(),
             IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
             s.remote_addr,
+            None,
         );
         assert_eq!(result, Disposition::Accept);
     }
@@ -3179,6 +3166,7 @@ mod tests {
             &mut nexthop,
             IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
             s.remote_addr,
+            None,
         );
         assert_eq!(result, Disposition::Accept);
         assert_eq!(
@@ -3238,6 +3226,7 @@ mod tests {
             &mut nexthop,
             local_addr,
             s.remote_addr,
+            None,
         );
         assert_eq!(result, Disposition::Accept);
         assert_eq!(
@@ -3300,6 +3289,7 @@ mod tests {
             &mut nexthop,
             IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
             s.remote_addr,
+            None,
         );
         assert_eq!(nexthop, original);
     }

--- a/table/src/policy.rs
+++ b/table/src/policy.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, LazyLock};
 
 use rustybgp_packet::{self as packet, Attribute, bgp};
 
-use crate::{RpkiValidationState, Source, TableError};
+use crate::{RpkiTable, RpkiValidationState, Source, TableError};
 
 #[derive(Clone)]
 pub struct Prefix {
@@ -352,6 +352,7 @@ impl Condition {
         attr: &Arc<Vec<packet::Attribute>>,
         nexthop: Option<&bgp::Nexthop>,
         peer_addr: IpAddr,
+        rpki: Option<&RpkiTable>,
     ) -> bool {
         match self {
             Condition::Prefix(_name, opt, set) => {
@@ -422,8 +423,10 @@ impl Condition {
                 }
                 return false;
             }
-            Condition::Rpki(_) => {
-                return false;
+            Condition::Rpki(expected) => {
+                return rpki
+                    .and_then(|r| r.validate(source, net, attr))
+                    .is_some_and(|v| v.state == *expected);
             }
             Condition::LocalPrefEq(v) => {
                 return attr
@@ -760,6 +763,7 @@ pub struct Statement {
 }
 
 impl Statement {
+    #[allow(clippy::too_many_arguments)]
     fn apply(
         &self,
         source: &Arc<Source>,
@@ -768,11 +772,12 @@ impl Statement {
         nexthop: &mut Option<bgp::Nexthop>,
         local_addr: IpAddr,
         peer_addr: IpAddr,
+        rpki: Option<&RpkiTable>,
     ) -> Disposition {
         let matched = self
             .conditions
             .iter()
-            .all(|c| c.evalute(source, net, attr, nexthop.as_ref(), peer_addr));
+            .all(|c| c.evalute(source, net, attr, nexthop.as_ref(), peer_addr, rpki));
         if !matched {
             return Disposition::Pass;
         }
@@ -1031,6 +1036,7 @@ pub struct Policy {
 }
 
 impl Policy {
+    #[allow(clippy::too_many_arguments)]
     fn apply(
         &self,
         source: &Arc<Source>,
@@ -1039,9 +1045,10 @@ impl Policy {
         nexthop: &mut Option<bgp::Nexthop>,
         local_addr: IpAddr,
         peer_addr: IpAddr,
+        rpki: Option<&RpkiTable>,
     ) -> Disposition {
         for statement in &self.statements {
-            let d = statement.apply(source, net, attr, nexthop, local_addr, peer_addr);
+            let d = statement.apply(source, net, attr, nexthop, local_addr, peer_addr, rpki);
             if d != Disposition::Pass {
                 return d;
             }
@@ -1057,6 +1064,7 @@ pub struct PolicyAssignment {
 }
 
 impl PolicyAssignment {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn apply(
         &self,
         source: &Arc<Source>,
@@ -1065,15 +1073,61 @@ impl PolicyAssignment {
         nexthop: &mut Option<bgp::Nexthop>,
         local_addr: IpAddr,
         peer_addr: IpAddr,
+        rpki: Option<&RpkiTable>,
     ) -> Disposition {
         for policy in &self.policies {
-            let d = policy.apply(source, net, attr, nexthop, local_addr, peer_addr);
+            let d = policy.apply(source, net, attr, nexthop, local_addr, peer_addr, rpki);
             if d != Disposition::Pass {
                 return d;
             }
         }
         self.disposition
     }
+}
+
+/// Apply import policy to a received route.
+///
+/// Returns `(filtered, post_policy_attr)`.  When not filtered, `post_policy_attr` reflects
+/// any attribute modifications made by the policy; if the policy made no changes it is the
+/// same `Arc` as `attrs` (only the reference count increases).
+/// Pass `rpki: None` to skip RPKI validation (e.g. in tests or when no RTR session is active).
+pub fn apply_import(
+    policy: &PolicyAssignment,
+    rpki: Option<&RpkiTable>,
+    source: &Arc<Source>,
+    net: &packet::Nlri,
+    attrs: &Arc<Vec<packet::Attribute>>,
+    nexthop: &mut Option<bgp::Nexthop>,
+) -> (bool, Arc<Vec<packet::Attribute>>) {
+    let mut attr = Arc::clone(attrs);
+    let filtered = policy.apply(
+        source,
+        net,
+        &mut attr,
+        nexthop,
+        source.local_addr,
+        source.remote_addr,
+        rpki,
+    ) == Disposition::Reject;
+    (filtered, attr)
+}
+
+/// Apply export policy to a route being advertised to a peer.
+///
+/// Returns the `Disposition` from the policy chain.
+/// Pass `rpki: None` to skip RPKI validation (e.g. in tests or when no RTR session is active).
+#[allow(clippy::too_many_arguments)]
+pub fn apply_export(
+    policy: &PolicyAssignment,
+    rpki: Option<&RpkiTable>,
+    source: &Arc<Source>,
+    net: &packet::Nlri,
+    attr: &mut Arc<Vec<packet::Attribute>>,
+    nexthop: &mut Option<bgp::Nexthop>,
+    local_addr: IpAddr,
+    peer_addr: IpAddr,
+) -> Disposition {
+    policy.apply(source, net, attr, nexthop, local_addr, peer_addr, rpki)
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -1911,6 +1965,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
 
         let result = get_communities(&attr);
@@ -1940,6 +1995,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
 
         let result = get_communities(&attr);
@@ -1965,6 +2021,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
 
         let result = get_communities(&attr);
@@ -1991,6 +2048,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
 
         assert!(
@@ -2020,6 +2078,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
 
         let result = get_communities(&attr);
@@ -2076,6 +2135,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
 
         assert_eq!(get_local_pref(&attr), Some(200));
@@ -2104,6 +2164,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
 
         assert_eq!(get_local_pref(&attr), Some(150));
@@ -2162,6 +2223,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_med(&attr), Some(300));
     }
@@ -2181,6 +2243,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_med(&attr), Some(100));
     }
@@ -2200,6 +2263,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_med(&attr), Some(250));
     }
@@ -2219,6 +2283,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_med(&attr), Some(150));
     }
@@ -2238,6 +2303,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_med(&attr), Some(0));
     }
@@ -2306,6 +2372,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_as_path(&attr), vec![65100, 65001, 65002]);
     }
@@ -2325,6 +2392,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_as_path(&attr), vec![65100, 65100, 65100, 65001]);
     }
@@ -2344,6 +2412,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_as_path(&attr), vec![65001, 65001, 65002]);
     }
@@ -2363,6 +2432,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_as_path(&attr), vec![65100, 65100]);
     }
@@ -2431,6 +2501,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         let result = get_ext_communities(&attr);
         assert!(result.contains(&SOO_65002_100), "original preserved");
@@ -2455,6 +2526,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         let result = get_ext_communities(&attr);
         assert!(!result.contains(&RT_65001_100), "removed");
@@ -2479,6 +2551,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         let result = get_ext_communities(&attr);
         assert_eq!(result, vec![RT_65001_100]);
@@ -2543,6 +2616,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         let result = get_large_communities(&attr);
         assert!(result.contains(&(65000, 1, 200)), "original preserved");
@@ -2567,6 +2641,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         let result = get_large_communities(&attr);
         assert!(!result.contains(&(65000, 1, 100)), "removed");
@@ -2591,6 +2666,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_large_communities(&attr), vec![(65001, 2, 50)]);
     }
@@ -2645,6 +2721,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_origin(&attr), Some(0));
     }
@@ -2666,6 +2743,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(get_origin(&attr), Some(2));
         assert_eq!(
@@ -2716,6 +2794,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -2737,6 +2816,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -2758,6 +2838,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -2779,6 +2860,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -2801,6 +2883,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -2823,6 +2906,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -2843,6 +2927,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -2863,6 +2948,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -2884,6 +2970,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -2904,6 +2991,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -2924,6 +3012,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -2944,6 +3033,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -2964,6 +3054,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -2984,6 +3075,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3012,6 +3104,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3090,6 +3183,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3113,6 +3207,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3185,6 +3280,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3208,6 +3304,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3250,6 +3347,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3270,6 +3368,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3292,6 +3391,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }


### PR DESCRIPTION
Add Condition::Rpki(RpkiValidationState) evaluation to the policy chain so that export policies can match routes by their RPKI validation state (Valid, Invalid, NotFound).

RpkiTable::validate() takes the route's Nlri directly and derives the address family internally from the V4/V6 variant, removing the need to pass Family alongside the table reference. All rpki parameters in the policy chain use Option<&RpkiTable>; None skips RPKI evaluation (used in tests and for non-RPKI import paths).

The rpki field in TableManager is pub(crate) so callers can acquire the read guard directly without a wrapper method.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>