### PR TITLE
packet,daemon: add SR Policy (SAFI 73) and Tunnel Encap attribute sup…

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -19,8 +19,8 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
 use rustybgp_packet::{
-    Family, IpNet, Nlri, bgp::Attribute, bgp::Capability, bgp::Ipv4Net, bgp::Ipv6Net, bgp_ls,
-    flowspec, mup, prefix_sid, rd::RouteDistinguisher,
+    self as packet, Family, IpNet, Nlri, bgp::Attribute, bgp::Capability, bgp::Ipv4Net,
+    bgp::Ipv6Net, bgp_ls, flowspec, mup, prefix_sid, rd::RouteDistinguisher,
 };
 
 use regex::Regex;
@@ -263,6 +263,17 @@ pub(crate) fn nlri_to_api(f: &Nlri) -> api::Nlri {
         },
         Nlri::Ls(n) => api::Nlri {
             nlri: Some(api::nlri::Nlri::LsAddrPrefix(ls_nlri_to_api(n))),
+        },
+        Nlri::SrPolicy(n) => api::Nlri {
+            nlri: Some(api::nlri::Nlri::SrPolicy(api::SrPolicyNlri {
+                length: if n.endpoint.is_ipv4() { 96 } else { 192 },
+                distinguisher: n.distinguisher,
+                color: n.color,
+                endpoint: match n.endpoint {
+                    std::net::IpAddr::V4(a) => a.octets().to_vec(),
+                    std::net::IpAddr::V6(a) => a.octets().to_vec(),
+                },
+            })),
         },
     }
 }
@@ -1202,6 +1213,16 @@ pub(crate) fn attr_to_api(a: &Attribute) -> api::Attribute {
                 )),
             }
         }
+        Attribute::TUNNEL_ENCAP => {
+            let tlvs = packet::tunnel_encap::decode(a.binary().unwrap());
+            api::Attribute {
+                attr: Some(api::attribute::Attr::TunnelEncap(
+                    api::TunnelEncapAttribute {
+                        tlvs: tlvs.iter().map(tunnel_encap_tlv_to_api).collect(),
+                    },
+                )),
+            }
+        }
         Attribute::PREFIX_SID => match prefix_sid::PrefixSid::decode(a.binary().unwrap()) {
             Ok(sid) => api::Attribute {
                 attr: Some(api::attribute::Attr::PrefixSid(prefix_sid_to_api(&sid))),
@@ -1810,6 +1831,8 @@ pub(crate) fn family_from_config(f: &config::generate::AfiSafiType) -> Result<Fa
         config::generate::AfiSafiType::Ipv6Flowspec => Ok(Family::IPV6_FLOWSPEC),
         config::generate::AfiSafiType::L3VpnIpv4Flowspec => Ok(Family::IPV4_FLOWSPEC_VPN),
         config::generate::AfiSafiType::L3VpnIpv6Flowspec => Ok(Family::IPV6_FLOWSPEC_VPN),
+        config::generate::AfiSafiType::Ipv4Srpolicy => Ok(Family::IPV4_SRPOLICY),
+        config::generate::AfiSafiType::Ipv6Srpolicy => Ok(Family::IPV6_SRPOLICY),
         _ => Err(()),
     }
 }
@@ -2060,6 +2083,32 @@ pub(crate) fn net_from_api(n: api::Nlri, family: Family) -> Result<Nlri, Error> 
             }
         }
         Some(api::nlri::Nlri::LsAddrPrefix(n)) => ls_nlri_from_api(n),
+        Some(api::nlri::Nlri::SrPolicy(n)) => {
+            let endpoint = match n.endpoint.len() {
+                4 => {
+                    let arr: [u8; 4] = n.endpoint[..4].try_into().map_err(|_| {
+                        Error::InvalidArgument("invalid SR Policy endpoint".to_string())
+                    })?;
+                    std::net::IpAddr::V4(std::net::Ipv4Addr::from(arr))
+                }
+                16 => {
+                    let arr: [u8; 16] = n.endpoint[..16].try_into().map_err(|_| {
+                        Error::InvalidArgument("invalid SR Policy endpoint".to_string())
+                    })?;
+                    std::net::IpAddr::V6(std::net::Ipv6Addr::from(arr))
+                }
+                _ => {
+                    return Err(Error::InvalidArgument(
+                        "SR Policy endpoint must be 4 or 16 bytes".to_string(),
+                    ));
+                }
+            };
+            Ok(Nlri::SrPolicy(packet::sr_policy::SrPolicyNlri {
+                distinguisher: n.distinguisher,
+                color: n.color,
+                endpoint,
+            }))
+        }
         _ => Err(Error::InvalidArgument("invalid NLRI".to_string())),
     }
 }
@@ -2161,6 +2210,13 @@ pub(crate) fn attr_from_api(a: api::Attribute) -> Result<Attribute, Error> {
                 c.write_u32::<NetworkEndian>(v.local_data2).unwrap();
             }
             Attribute::new_with_bin(Attribute::LARGE_COMMUNITY, c.into_inner())
+                .ok_or(Error::InvalidArgument("unsupported attribute".to_string()))
+        }
+        api::attribute::Attr::TunnelEncap(te) => {
+            let tlvs: Vec<packet::tunnel_encap::TunnelEncapTlv> =
+                te.tlvs.iter().map(tunnel_encap_tlv_from_api).collect();
+            let bytes = packet::tunnel_encap::encode(&tlvs);
+            Attribute::new_with_bin(Attribute::TUNNEL_ENCAP, bytes)
                 .ok_or(Error::InvalidArgument("unsupported attribute".to_string()))
         }
         api::attribute::Attr::MpReach(m) => {
@@ -2514,6 +2570,376 @@ fn ls_tlvs_from_api(attr: &api::LsAttribute) -> Vec<u8> {
     }
 
     dst
+}
+
+fn tunnel_encap_tlv_to_api(tlv: &packet::tunnel_encap::TunnelEncapTlv) -> api::TunnelEncapTlv {
+    use packet::tunnel_encap::{SrPolicyBindingSid, SrSegment, TunnelEncapValue};
+
+    let sub_tlvs: Vec<api::tunnel_encap_tlv::Tlv> = match &tlv.value {
+        TunnelEncapValue::Unknown(_) => vec![],
+        TunnelEncapValue::SrPolicy(cp) => {
+            let mut tlvs = Vec::new();
+
+            if let Some(pref) = &cp.preference {
+                tlvs.push(api::tunnel_encap_tlv::Tlv {
+                    tlv: Some(api::tunnel_encap_tlv::tlv::Tlv::SrPreference(
+                        api::TunnelEncapSubTlvsrPreference {
+                            flags: pref.flags as u32,
+                            preference: pref.preference,
+                        },
+                    )),
+                });
+            }
+            if let Some(bsid) = &cp.binding_sid {
+                let api_bsid = match bsid {
+                    SrPolicyBindingSid::Mpls { flags, label } => {
+                        api::TunnelEncapSubTlvsrBindingSid {
+                            bsid: Some(
+                                api::tunnel_encap_sub_tlvsr_binding_sid::Bsid::SrBindingSid(
+                                    api::SrBindingSid {
+                                        s_flag: flags & 0x80 != 0,
+                                        i_flag: flags & 0x40 != 0,
+                                        sid: (label << 12).to_be_bytes().to_vec(),
+                                    },
+                                ),
+                            ),
+                        }
+                    }
+                    SrPolicyBindingSid::Srv6 { flags, sid } => api::TunnelEncapSubTlvsrBindingSid {
+                        bsid: Some(
+                            api::tunnel_encap_sub_tlvsr_binding_sid::Bsid::Srv6BindingSid(
+                                api::SRv6BindingSid {
+                                    s_flag: flags & 0x80 != 0,
+                                    i_flag: flags & 0x40 != 0,
+                                    b_flag: false,
+                                    sid: sid.octets().to_vec(),
+                                    endpoint_behavior_structure: None,
+                                },
+                            ),
+                        ),
+                    },
+                };
+                tlvs.push(api::tunnel_encap_tlv::Tlv {
+                    tlv: Some(api::tunnel_encap_tlv::tlv::Tlv::SrBindingSid(api_bsid)),
+                });
+            }
+            if let Some(bsid) = &cp.srv6_binding_sid {
+                let eb = &bsid.endpoint_behavior;
+                tlvs.push(api::tunnel_encap_tlv::Tlv {
+                    tlv: Some(api::tunnel_encap_tlv::tlv::Tlv::SrBindingSid(
+                        api::TunnelEncapSubTlvsrBindingSid {
+                            bsid: Some(
+                                api::tunnel_encap_sub_tlvsr_binding_sid::Bsid::Srv6BindingSid(
+                                    api::SRv6BindingSid {
+                                        s_flag: bsid.flags & 0x80 != 0,
+                                        i_flag: bsid.flags & 0x40 != 0,
+                                        b_flag: bsid.flags & 0x20 != 0,
+                                        sid: bsid.sid.octets().to_vec(),
+                                        endpoint_behavior_structure: Some(
+                                            api::SRv6EndPointBehavior {
+                                                behavior: eb.behavior as i32,
+                                                block_len: eb.block_len as u32,
+                                                node_len: eb.node_len as u32,
+                                                func_len: eb.func_len as u32,
+                                                arg_len: eb.arg_len as u32,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    )),
+                });
+            }
+            if let Some(enlp) = &cp.enlp {
+                tlvs.push(api::tunnel_encap_tlv::Tlv {
+                    tlv: Some(api::tunnel_encap_tlv::tlv::Tlv::SrEnlp(
+                        api::TunnelEncapSubTlvsrenlp {
+                            flags: enlp.flags as u32,
+                            enlp: enlp.enlp_type as i32,
+                        },
+                    )),
+                });
+            }
+            if let Some(pri) = cp.priority {
+                tlvs.push(api::tunnel_encap_tlv::Tlv {
+                    tlv: Some(api::tunnel_encap_tlv::tlv::Tlv::SrPriority(
+                        api::TunnelEncapSubTlvsrPriority {
+                            priority: pri as u32,
+                        },
+                    )),
+                });
+            }
+            for sl in &cp.segment_lists {
+                let mut segments = Vec::new();
+                for seg in &sl.segments {
+                    let api_seg = match seg {
+                        SrSegment::TypeA { flags, label } => {
+                            api::tunnel_encap_sub_tlvsr_segment_list::Segment {
+                                segment: Some(
+                                    api::tunnel_encap_sub_tlvsr_segment_list::segment::Segment::A(
+                                        api::SegmentTypeA {
+                                            flags: Some(api::SegmentFlags {
+                                                v_flag: flags & 0x80 != 0,
+                                                a_flag: flags & 0x40 != 0,
+                                                s_flag: flags & 0x20 != 0,
+                                                b_flag: flags & 0x10 != 0,
+                                            }),
+                                            label: *label,
+                                        },
+                                    ),
+                                ),
+                            }
+                        }
+                        SrSegment::TypeB {
+                            flags,
+                            sid,
+                            endpoint_behavior,
+                        } => api::tunnel_encap_sub_tlvsr_segment_list::Segment {
+                            segment: Some(
+                                api::tunnel_encap_sub_tlvsr_segment_list::segment::Segment::B(
+                                    api::SegmentTypeB {
+                                        flags: Some(api::SegmentFlags {
+                                            v_flag: flags & 0x80 != 0,
+                                            a_flag: flags & 0x40 != 0,
+                                            s_flag: flags & 0x20 != 0,
+                                            b_flag: flags & 0x10 != 0,
+                                        }),
+                                        sid: sid.octets().to_vec(),
+                                        endpoint_behavior_structure: endpoint_behavior
+                                            .as_ref()
+                                            .map(|eb| api::SRv6EndPointBehavior {
+                                                behavior: eb.behavior as i32,
+                                                block_len: eb.block_len as u32,
+                                                node_len: eb.node_len as u32,
+                                                func_len: eb.func_len as u32,
+                                                arg_len: eb.arg_len as u32,
+                                            }),
+                                    },
+                                ),
+                            ),
+                        },
+                    };
+                    segments.push(api_seg);
+                }
+                let weight = sl.weight.as_ref().map(|w| api::SrWeight {
+                    flags: w.flags as u32,
+                    weight: w.weight,
+                });
+                tlvs.push(api::tunnel_encap_tlv::Tlv {
+                    tlv: Some(api::tunnel_encap_tlv::tlv::Tlv::SrSegmentList(
+                        api::TunnelEncapSubTlvsrSegmentList { weight, segments },
+                    )),
+                });
+            }
+            if let Some(name) = &cp.candidate_path_name {
+                tlvs.push(api::tunnel_encap_tlv::Tlv {
+                    tlv: Some(api::tunnel_encap_tlv::tlv::Tlv::SrCandidatePathName(
+                        api::TunnelEncapSubTlvsrCandidatePathName {
+                            candidate_path_name: name.clone(),
+                        },
+                    )),
+                });
+            }
+            if let Some(name) = &cp.policy_name {
+                // Policy name uses the unknown sub-TLV since proto has no dedicated field.
+                // Encode as unknown type 130 (SUBTLV_POLICY_NAME).
+                let mut body = name.as_bytes().to_vec();
+                let mut raw = vec![130u8, body.len() as u8];
+                raw.append(&mut body);
+                tlvs.push(api::tunnel_encap_tlv::Tlv {
+                    tlv: Some(api::tunnel_encap_tlv::tlv::Tlv::Unknown(
+                        api::TunnelEncapSubTlvUnknown {
+                            r#type: 130,
+                            value: name.as_bytes().to_vec(),
+                        },
+                    )),
+                });
+            }
+            tlvs
+        }
+    };
+
+    api::TunnelEncapTlv {
+        r#type: tlv.tunnel_type as u32,
+        tlvs: sub_tlvs,
+    }
+}
+
+fn tunnel_encap_tlv_from_api(tlv: &api::TunnelEncapTlv) -> packet::tunnel_encap::TunnelEncapTlv {
+    use packet::tunnel_encap::{
+        SRv6EndpointBehavior, SrPolicyBindingSid, SrPolicyCandidatePath, SrPolicyEnlp,
+        SrPolicyPreference, SrPolicySegmentList, SrPolicySrv6BindingSid, SrSegment, SrWeight,
+        TUNNEL_TYPE_SR_POLICY, TunnelEncapValue,
+    };
+
+    let tunnel_type = tlv.r#type as u16;
+
+    if tunnel_type != TUNNEL_TYPE_SR_POLICY {
+        // Collect raw bytes for unknown tunnel types from the sub-TLVs unknown fields.
+        let raw: Vec<u8> = tlv
+            .tlvs
+            .iter()
+            .filter_map(|t| {
+                if let Some(api::tunnel_encap_tlv::tlv::Tlv::Unknown(u)) = &t.tlv {
+                    Some(u.value.clone())
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect();
+        return packet::tunnel_encap::TunnelEncapTlv {
+            tunnel_type,
+            value: TunnelEncapValue::Unknown(raw),
+        };
+    }
+
+    let mut cp = SrPolicyCandidatePath::default();
+
+    for sub in &tlv.tlvs {
+        match &sub.tlv {
+            Some(api::tunnel_encap_tlv::tlv::Tlv::SrPreference(p)) => {
+                cp.preference = Some(SrPolicyPreference {
+                    flags: p.flags as u8,
+                    preference: p.preference,
+                });
+            }
+            Some(api::tunnel_encap_tlv::tlv::Tlv::SrBindingSid(b)) => match &b.bsid {
+                Some(api::tunnel_encap_sub_tlvsr_binding_sid::Bsid::SrBindingSid(s)) => {
+                    let mut flags = 0u8;
+                    if s.s_flag {
+                        flags |= 0x80;
+                    }
+                    if s.i_flag {
+                        flags |= 0x40;
+                    }
+                    let label = if s.sid.len() >= 4 {
+                        u32::from_be_bytes(s.sid[..4].try_into().unwrap_or([0; 4])) >> 12
+                    } else {
+                        0
+                    };
+                    cp.binding_sid = Some(SrPolicyBindingSid::Mpls { flags, label });
+                }
+                Some(api::tunnel_encap_sub_tlvsr_binding_sid::Bsid::Srv6BindingSid(s)) => {
+                    let mut flags = 0u8;
+                    if s.s_flag {
+                        flags |= 0x80;
+                    }
+                    if s.i_flag {
+                        flags |= 0x40;
+                    }
+                    if s.b_flag {
+                        flags |= 0x20;
+                    }
+                    if s.sid.len() == 16 {
+                        let arr: [u8; 16] = s.sid[..16].try_into().unwrap_or([0; 16]);
+                        let sid = std::net::Ipv6Addr::from(arr);
+                        if let Some(eb) = &s.endpoint_behavior_structure {
+                            cp.srv6_binding_sid = Some(SrPolicySrv6BindingSid {
+                                flags,
+                                sid,
+                                endpoint_behavior: SRv6EndpointBehavior {
+                                    behavior: eb.behavior as u16,
+                                    block_len: eb.block_len as u8,
+                                    node_len: eb.node_len as u8,
+                                    func_len: eb.func_len as u8,
+                                    arg_len: eb.arg_len as u8,
+                                },
+                            });
+                        } else {
+                            cp.binding_sid = Some(SrPolicyBindingSid::Srv6 { flags, sid });
+                        }
+                    }
+                }
+                None => {}
+            },
+            Some(api::tunnel_encap_tlv::tlv::Tlv::SrEnlp(e)) => {
+                cp.enlp = Some(SrPolicyEnlp {
+                    flags: e.flags as u8,
+                    enlp_type: e.enlp as u8,
+                });
+            }
+            Some(api::tunnel_encap_tlv::tlv::Tlv::SrPriority(p)) => {
+                cp.priority = Some(p.priority as u8);
+            }
+            Some(api::tunnel_encap_tlv::tlv::Tlv::SrCandidatePathName(n)) => {
+                cp.candidate_path_name = Some(n.candidate_path_name.clone());
+            }
+            Some(api::tunnel_encap_tlv::tlv::Tlv::SrSegmentList(sl)) => {
+                let weight = sl.weight.as_ref().map(|w| SrWeight {
+                    flags: w.flags as u8,
+                    weight: w.weight,
+                });
+                let mut segments = Vec::new();
+                for seg in &sl.segments {
+                    match &seg.segment {
+                        Some(api::tunnel_encap_sub_tlvsr_segment_list::segment::Segment::A(a)) => {
+                            let flags = a.flags.as_ref().map(flags_from_api).unwrap_or(0);
+                            segments.push(SrSegment::TypeA {
+                                flags,
+                                label: a.label,
+                            });
+                        }
+                        Some(api::tunnel_encap_sub_tlvsr_segment_list::segment::Segment::B(b)) => {
+                            let flags = b.flags.as_ref().map(flags_from_api).unwrap_or(0);
+                            let sid = if b.sid.len() == 16 {
+                                let arr: [u8; 16] = b.sid[..16].try_into().unwrap_or([0; 16]);
+                                std::net::Ipv6Addr::from(arr)
+                            } else {
+                                std::net::Ipv6Addr::UNSPECIFIED
+                            };
+                            let endpoint_behavior =
+                                b.endpoint_behavior_structure.as_ref().map(|eb| {
+                                    SRv6EndpointBehavior {
+                                        behavior: eb.behavior as u16,
+                                        block_len: eb.block_len as u8,
+                                        node_len: eb.node_len as u8,
+                                        func_len: eb.func_len as u8,
+                                        arg_len: eb.arg_len as u8,
+                                    }
+                                });
+                            segments.push(SrSegment::TypeB {
+                                flags,
+                                sid,
+                                endpoint_behavior,
+                            });
+                        }
+                        None => {}
+                    }
+                }
+                cp.segment_lists
+                    .push(SrPolicySegmentList { weight, segments });
+            }
+            // Type 130 = policy name, stored as Unknown since proto has no dedicated field
+            Some(api::tunnel_encap_tlv::tlv::Tlv::Unknown(u)) if u.r#type == 130 => {
+                cp.policy_name = std::str::from_utf8(&u.value).ok().map(str::to_owned);
+            }
+            _ => {}
+        }
+    }
+
+    packet::tunnel_encap::TunnelEncapTlv {
+        tunnel_type,
+        value: TunnelEncapValue::SrPolicy(cp),
+    }
+}
+
+fn flags_from_api(f: &api::SegmentFlags) -> u8 {
+    let mut v = 0u8;
+    if f.v_flag {
+        v |= 0x80;
+    }
+    if f.a_flag {
+        v |= 0x40;
+    }
+    if f.s_flag {
+        v |= 0x20;
+    }
+    if f.b_flag {
+        v |= 0x10;
+    }
+    v
 }
 
 fn prefix_sid_to_api(sid: &prefix_sid::PrefixSid) -> api::PrefixSid {
@@ -5648,5 +6074,115 @@ bgp-actions.set-next-hop = "self"
             attr_from_api(attr).is_ok(),
             "Flowspec VPN MpReach with empty next_hops must succeed"
         );
+    }
+
+    #[test]
+    fn sr_policy_nlri_ipv4_round_trip() {
+        let nlri_api = api::Nlri {
+            nlri: Some(api::nlri::Nlri::SrPolicy(api::SrPolicyNlri {
+                length: 96,
+                distinguisher: 1,
+                color: 100,
+                endpoint: vec![10, 0, 0, 1],
+            })),
+        };
+        let nlri = net_from_api(nlri_api, Family::IPV4_SRPOLICY).unwrap();
+        assert!(matches!(nlri, packet::Nlri::SrPolicy(_)));
+        let back = nlri_to_api(&nlri);
+        if let Some(api::nlri::Nlri::SrPolicy(sp)) = back.nlri {
+            assert_eq!(sp.length, 96);
+            assert_eq!(sp.distinguisher, 1);
+            assert_eq!(sp.color, 100);
+            assert_eq!(sp.endpoint, vec![10, 0, 0, 1]);
+        } else {
+            panic!("expected SrPolicy NLRI");
+        }
+    }
+
+    #[test]
+    fn sr_policy_nlri_ipv6_round_trip() {
+        let nlri_api = api::Nlri {
+            nlri: Some(api::nlri::Nlri::SrPolicy(api::SrPolicyNlri {
+                length: 192,
+                distinguisher: 2,
+                color: 200,
+                endpoint: vec![0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+            })),
+        };
+        let nlri = net_from_api(nlri_api, Family::IPV6_SRPOLICY).unwrap();
+        let back = nlri_to_api(&nlri);
+        if let Some(api::nlri::Nlri::SrPolicy(sp)) = back.nlri {
+            assert_eq!(sp.length, 192);
+            assert_eq!(sp.distinguisher, 2);
+            assert_eq!(sp.color, 200);
+        } else {
+            panic!("expected SrPolicy NLRI");
+        }
+    }
+
+    #[test]
+    fn tunnel_encap_attr_round_trip() {
+        use api::tunnel_encap_sub_tlvsr_segment_list::Segment;
+        use api::tunnel_encap_sub_tlvsr_segment_list::segment::Segment as SegVariant;
+
+        let te_attr = api::Attribute {
+            attr: Some(api::attribute::Attr::TunnelEncap(
+                api::TunnelEncapAttribute {
+                    tlvs: vec![api::TunnelEncapTlv {
+                        r#type: 15,
+                        tlvs: vec![
+                            api::tunnel_encap_tlv::Tlv {
+                                tlv: Some(api::tunnel_encap_tlv::tlv::Tlv::SrPreference(
+                                    api::TunnelEncapSubTlvsrPreference {
+                                        flags: 0,
+                                        preference: 100,
+                                    },
+                                )),
+                            },
+                            api::tunnel_encap_tlv::Tlv {
+                                tlv: Some(api::tunnel_encap_tlv::tlv::Tlv::SrSegmentList(
+                                    api::TunnelEncapSubTlvsrSegmentList {
+                                        weight: Some(api::SrWeight {
+                                            flags: 0,
+                                            weight: 1,
+                                        }),
+                                        segments: vec![Segment {
+                                            segment: Some(SegVariant::A(api::SegmentTypeA {
+                                                flags: Some(api::SegmentFlags {
+                                                    v_flag: false,
+                                                    a_flag: false,
+                                                    s_flag: false,
+                                                    b_flag: false,
+                                                }),
+                                                label: 16001,
+                                            })),
+                                        }],
+                                    },
+                                )),
+                            },
+                        ],
+                    }],
+                },
+            )),
+        };
+
+        let attr = attr_from_api(te_attr).unwrap();
+        assert_eq!(attr.code(), packet::Attribute::TUNNEL_ENCAP);
+        let bytes = attr.binary().unwrap();
+        let tlvs = packet::tunnel_encap::decode(bytes);
+        assert_eq!(tlvs.len(), 1);
+        assert_eq!(tlvs[0].tunnel_type, 15);
+
+        if let packet::tunnel_encap::TunnelEncapValue::SrPolicy(cp) = &tlvs[0].value {
+            assert_eq!(cp.preference.as_ref().unwrap().preference, 100);
+            assert_eq!(cp.segment_lists.len(), 1);
+            assert_eq!(cp.segment_lists[0].segments.len(), 1);
+            assert!(matches!(
+                &cp.segment_lists[0].segments[0],
+                packet::tunnel_encap::SrSegment::TypeA { label, .. } if *label == 16001
+            ));
+        } else {
+            panic!("expected SrPolicy tunnel encap");
+        }
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -204,7 +204,8 @@ impl Handle {
             | packet::Nlri::FlowspecV6(_)
             | packet::Nlri::FlowspecVpnV4(_)
             | packet::Nlri::FlowspecVpnV6(_)
-            | packet::Nlri::Ls(_) => {
+            | packet::Nlri::Ls(_)
+            | packet::Nlri::SrPolicy(_) => {
                 return Ok(());
             }
         };

--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -351,6 +351,7 @@ impl Family {
     const SAFI_MUP: u8 = 85;
     const SAFI_MPLS_VPN: u8 = 128;
     const SAFI_MPLS_VPN6: u8 = 129;
+    const SAFI_SR_POLICY: u8 = 73;
     const SAFI_FLOWSPEC: u8 = 133;
     const SAFI_FLOWSPEC_VPN: u8 = 134;
 
@@ -370,6 +371,8 @@ impl Family {
     pub const IPV6_FLOWSPEC: Family = Family::new(Family::AFI_IP6, Family::SAFI_FLOWSPEC);
     pub const IPV4_FLOWSPEC_VPN: Family = Family::new(Family::AFI_IP, Family::SAFI_FLOWSPEC_VPN);
     pub const IPV6_FLOWSPEC_VPN: Family = Family::new(Family::AFI_IP6, Family::SAFI_FLOWSPEC_VPN);
+    pub const IPV4_SRPOLICY: Family = Family::new(Family::AFI_IP, Family::SAFI_SR_POLICY);
+    pub const IPV6_SRPOLICY: Family = Family::new(Family::AFI_IP6, Family::SAFI_SR_POLICY);
 
     pub const fn new(afi: u16, safi: u8) -> Self {
         Family((afi as u32) << 16 | safi as u32)
@@ -516,6 +519,7 @@ pub enum Nlri {
     FlowspecVpnV4(crate::flowspec::FlowspecVpnV4Nlri),
     FlowspecVpnV6(crate::flowspec::FlowspecVpnV6Nlri),
     Ls(crate::bgp_ls::BgpLsNlri),
+    SrPolicy(crate::sr_policy::SrPolicyNlri),
 }
 
 impl Nlri {
@@ -545,6 +549,10 @@ impl Nlri {
                 Ok(0)
             }
             Nlri::Ls(n) => {
+                n.encode(dst);
+                Ok(0)
+            }
+            Nlri::SrPolicy(n) => {
                 n.encode(dst);
                 Ok(0)
             }
@@ -599,6 +607,11 @@ impl Nlri {
             Family::LS => crate::bgp_ls::BgpLsNlri::decode(c)
                 .map(Nlri::Ls)
                 .ok_or(Notification::UpdateMalformedAttributeList),
+            Family::IPV4_SRPOLICY | Family::IPV6_SRPOLICY => {
+                crate::sr_policy::SrPolicyNlri::decode(c)
+                    .map(Nlri::SrPolicy)
+                    .map_err(|_| Notification::UpdateMalformedAttributeList)
+            }
             _ => Err(Notification::UpdateMalformedAttributeList),
         }
     }
@@ -633,6 +646,7 @@ impl fmt::Display for Nlri {
             Nlri::FlowspecVpnV4(n) => n.fmt(f),
             Nlri::FlowspecVpnV6(n) => n.fmt(f),
             Nlri::Ls(n) => n.fmt(f),
+            Nlri::SrPolicy(n) => n.fmt(f),
         }
     }
 }
@@ -1218,6 +1232,7 @@ impl Attribute {
     pub const LARGE_COMMUNITY: u8 = 32;
     pub const PREFIX_SID: u8 = 40;
     pub const LS: u8 = 29;
+    pub const TUNNEL_ENCAP: u8 = 23;
 
     pub const AS_PATH_TYPE_SET: u8 = 1;
     pub const AS_PATH_TYPE_SEQ: u8 = 2;
@@ -1325,6 +1340,7 @@ impl Attribute {
             Self::LARGE_COMMUNITY => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
             Self::PREFIX_SID => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
             Self::LS => Some(Self::FLAG_OPTIONAL),
+            Self::TUNNEL_ENCAP => Some(Self::FLAG_TRANSITIVE | Self::FLAG_OPTIONAL),
             _ => None,
         }
     }
@@ -2130,10 +2146,14 @@ impl PeerCodec {
             dst.put_u8(8 + nh_bytes.len() as u8);
             dst.put_bytes(0, 8); // 8-byte zero RD (RFC 4364 §4.3.2)
             dst.put_slice(&nh_bytes);
-        } else if nh_bytes.len() < 16 {
+        } else if nh_bytes.len() < 16
+            && !matches!(family, &Family::IPV4_SRPOLICY | &Family::IPV6_SRPOLICY)
+        {
+            // Pad IPv4 nexthop to 16 bytes for extended-nexthop families (RFC 8950).
+            // SR Policy uses the nexthop as-is (4 bytes for AFI=1, 16 for AFI=2).
             dst.put_u8(16);
             dst.put_slice(&nh_bytes);
-            dst.put_bytes(0, 16 - nh_bytes.len()); // pad to 16 bytes
+            dst.put_bytes(0, 16 - nh_bytes.len());
         } else {
             dst.put_u8(nh_bytes.len() as u8);
             dst.put_slice(&nh_bytes);

--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -33,4 +33,6 @@ pub mod mup;
 pub mod prefix_sid;
 pub mod rd;
 pub mod rpki;
+pub mod sr_policy;
+pub mod tunnel_encap;
 pub mod vpn;

--- a/packet/src/sr_policy.rs
+++ b/packet/src/sr_policy.rs
@@ -1,0 +1,140 @@
+// Copyright (C) 2026 The RustyBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SR Policy NLRI encoding/decoding (RFC 9830 §2.1).
+//!
+//! AFI/SAFI 1/73 (IPv4 endpoint) and 2/73 (IPv6 endpoint).
+
+use byteorder::{NetworkEndian, ReadBytesExt};
+use bytes::BufMut;
+use std::fmt;
+use std::io::{self, Read};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+// NLRI length in bits: Distinguisher(4) + Color(4) + Endpoint(4 or 16)
+const IPV4_LENGTH_BITS: u8 = 96;
+const IPV6_LENGTH_BITS: u8 = 192;
+
+/// SR Policy NLRI: <Distinguisher, Color, Endpoint> tuple (RFC 9830 §2.1).
+///
+/// Wire format: 1-byte length (bits) + 4-byte distinguisher + 4-byte color +
+/// 4-byte (IPv4) or 16-byte (IPv6) endpoint.
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub struct SrPolicyNlri {
+    pub distinguisher: u32,
+    pub color: u32,
+    pub endpoint: IpAddr,
+}
+
+impl SrPolicyNlri {
+    pub fn encode<B: BufMut>(&self, dst: &mut B) {
+        match self.endpoint {
+            IpAddr::V4(addr) => {
+                dst.put_u8(IPV4_LENGTH_BITS);
+                dst.put_u32(self.distinguisher);
+                dst.put_u32(self.color);
+                dst.put_slice(&addr.octets());
+            }
+            IpAddr::V6(addr) => {
+                dst.put_u8(IPV6_LENGTH_BITS);
+                dst.put_u32(self.distinguisher);
+                dst.put_u32(self.color);
+                dst.put_slice(&addr.octets());
+            }
+        }
+    }
+
+    pub fn decode<R: Read + ReadBytesExt>(c: &mut R) -> Result<Self, io::Error> {
+        let length_bits = c.read_u8()?;
+        let distinguisher = c.read_u32::<NetworkEndian>()?;
+        let color = c.read_u32::<NetworkEndian>()?;
+        let endpoint = match length_bits {
+            IPV4_LENGTH_BITS => {
+                let mut b = [0u8; 4];
+                c.read_exact(&mut b)?;
+                IpAddr::V4(Ipv4Addr::from(b))
+            }
+            IPV6_LENGTH_BITS => {
+                let mut b = [0u8; 16];
+                c.read_exact(&mut b)?;
+                IpAddr::V6(Ipv6Addr::from(b))
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid SR Policy NLRI length field",
+                ));
+            }
+        };
+        Ok(SrPolicyNlri {
+            distinguisher,
+            color,
+            endpoint,
+        })
+    }
+}
+
+impl fmt::Display for SrPolicyNlri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "sr-policy:{}:{}:{}",
+            self.distinguisher, self.color, self.endpoint
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn roundtrip_ipv4() {
+        let nlri = SrPolicyNlri {
+            distinguisher: 1,
+            color: 100,
+            endpoint: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        };
+        let mut buf = Vec::new();
+        nlri.encode(&mut buf);
+        // 1 (length) + 4 (distinguisher) + 4 (color) + 4 (endpoint) = 13
+        assert_eq!(buf.len(), 13);
+        let decoded = SrPolicyNlri::decode(&mut Cursor::new(&buf)).unwrap();
+        assert_eq!(decoded, nlri);
+    }
+
+    #[test]
+    fn roundtrip_ipv6() {
+        let nlri = SrPolicyNlri {
+            distinguisher: 2,
+            color: 200,
+            endpoint: IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+        };
+        let mut buf = Vec::new();
+        nlri.encode(&mut buf);
+        // 1 (length) + 4 (distinguisher) + 4 (color) + 16 (endpoint) = 25
+        assert_eq!(buf.len(), 25);
+        let decoded = SrPolicyNlri::decode(&mut Cursor::new(&buf)).unwrap();
+        assert_eq!(decoded, nlri);
+    }
+
+    #[test]
+    fn decode_invalid_length_rejected() {
+        // length_bits = 0 is invalid
+        let buf = [0u8, 0, 0, 0, 1, 0, 0, 0, 64, 10, 0, 0, 1];
+        assert!(SrPolicyNlri::decode(&mut Cursor::new(&buf)).is_err());
+    }
+}

--- a/packet/src/tunnel_encap.rs
+++ b/packet/src/tunnel_encap.rs
@@ -1,0 +1,729 @@
+// Copyright (C) 2026 The RustyBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! BGP Tunnel Encapsulation Attribute (RFC 9012) with SR Policy (RFC 9830).
+//!
+//! TLV format: 2-byte type + 2-byte length + N bytes value.
+//! Sub-TLV format: 1-byte type + 1-byte length + N bytes value (RFC 9012 §3.1).
+
+use byteorder::{NetworkEndian, ReadBytesExt};
+use std::io::Cursor;
+use std::net::Ipv6Addr;
+
+pub const TUNNEL_TYPE_SR_POLICY: u16 = 15;
+
+// SR Policy Candidate Path sub-TLV types (RFC 9830 §2.4)
+const SUBTLV_PREFERENCE: u8 = 12;
+const SUBTLV_BINDING_SID: u8 = 13;
+const SUBTLV_ENLP: u8 = 14;
+const SUBTLV_PRIORITY: u8 = 15;
+const SUBTLV_SRV6_BINDING_SID: u8 = 20;
+const SUBTLV_SEGMENT_LIST: u8 = 128;
+const SUBTLV_CANDIDATE_PATH_NAME: u8 = 129;
+const SUBTLV_POLICY_NAME: u8 = 130;
+
+// Sub-sub-TLV types within Segment List (RFC 9830 §2.4.7)
+const SEGSUB_WEIGHT: u8 = 9;
+const SEGSUB_TYPE_A: u8 = 1;
+const SEGSUB_TYPE_B: u8 = 13;
+
+/// One entry in the BGP Tunnel Encapsulation Attribute.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TunnelEncapTlv {
+    pub tunnel_type: u16,
+    pub value: TunnelEncapValue,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TunnelEncapValue {
+    /// Tunnel Type 15: SR Policy Candidate Path (RFC 9830).
+    SrPolicy(SrPolicyCandidatePath),
+    /// Any other tunnel type: raw value bytes.
+    Unknown(Vec<u8>),
+}
+
+/// SR Policy Candidate Path (RFC 9830 §2.4).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SrPolicyCandidatePath {
+    /// Sub-TLV 12: Preference.
+    pub preference: Option<SrPolicyPreference>,
+    /// Sub-TLV 13: SR-MPLS or SRv6 Binding SID (discriminated by length).
+    pub binding_sid: Option<SrPolicyBindingSid>,
+    /// Sub-TLV 20: SRv6 Binding SID with endpoint behavior structure.
+    pub srv6_binding_sid: Option<SrPolicySrv6BindingSid>,
+    /// Sub-TLV 14: Explicit NULL Label Policy.
+    pub enlp: Option<SrPolicyEnlp>,
+    /// Sub-TLV 15: Priority.
+    pub priority: Option<u8>,
+    /// Sub-TLV 128: Segment Lists (multiple are allowed).
+    pub segment_lists: Vec<SrPolicySegmentList>,
+    /// Sub-TLV 129: Candidate Path Name.
+    pub candidate_path_name: Option<String>,
+    /// Sub-TLV 130: Policy Name.
+    pub policy_name: Option<String>,
+}
+
+/// SR Policy Preference (sub-TLV 12, RFC 9830 §2.4.1).
+///
+/// Wire: flags(1) + preference(4) = 5 bytes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SrPolicyPreference {
+    pub flags: u8,
+    pub preference: u32,
+}
+
+/// SR Policy Binding SID (sub-TLV 13, RFC 9830 §2.4.3).
+///
+/// Wire (MPLS): flags(1) + reserved(1) + label_stack_entry(4) = 6 bytes.
+/// Wire (SRv6): flags(1) + reserved(1) + SID(16) = 18 bytes.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SrPolicyBindingSid {
+    /// SR-MPLS BSID: 20-bit label value (stored in bits [31:12] of a u32).
+    Mpls { flags: u8, label: u32 },
+    /// SRv6 BSID without endpoint behavior structure.
+    Srv6 { flags: u8, sid: Ipv6Addr },
+}
+
+/// SRv6 Binding SID with endpoint behavior (sub-TLV 20, RFC 9830 §2.4.4).
+///
+/// Wire: flags(1) + reserved(1) + SID(16) + behavior(2) + block_len(1) +
+///       node_len(1) + func_len(1) + arg_len(1) = 24 bytes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SrPolicySrv6BindingSid {
+    pub flags: u8,
+    pub sid: Ipv6Addr,
+    pub endpoint_behavior: SRv6EndpointBehavior,
+}
+
+/// SRv6 Endpoint Behavior Structure (RFC 9830 §2.4.4).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SRv6EndpointBehavior {
+    pub behavior: u16,
+    pub block_len: u8,
+    pub node_len: u8,
+    pub func_len: u8,
+    pub arg_len: u8,
+}
+
+/// Explicit NULL Label Policy (sub-TLV 14, RFC 9830 §2.4.5).
+///
+/// Wire: flags(1) + enlp_type(1) = 2 bytes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SrPolicyEnlp {
+    pub flags: u8,
+    pub enlp_type: u8,
+}
+
+/// Segment List (sub-TLV 128, RFC 9830 §2.4.7).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SrPolicySegmentList {
+    pub weight: Option<SrWeight>,
+    pub segments: Vec<SrSegment>,
+}
+
+/// Segment List weight (sub-sub-TLV 9).
+///
+/// Wire: flags(1) + weight(4) = 5 bytes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SrWeight {
+    pub flags: u8,
+    pub weight: u32,
+}
+
+/// One segment in a Segment List.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SrSegment {
+    /// Segment Type A: SR-MPLS label (sub-sub-TLV 1, RFC 9830 §2.5.1).
+    ///
+    /// Wire: flags(1) + reserved(1) + label_stack_entry(4) = 6 bytes.
+    /// `label` is the 20-bit label value (bits [31:12] of the stack entry).
+    TypeA { flags: u8, label: u32 },
+    /// Segment Type B: SRv6 SID (sub-sub-TLV 13, RFC 9830 §2.5.2).
+    ///
+    /// Wire: flags(1) + reserved(1) + SID(16) + optional behavior(6) = 18 or 24 bytes.
+    /// Endpoint behavior is present when the A-flag (0x40) in flags is set.
+    TypeB {
+        flags: u8,
+        sid: Ipv6Addr,
+        endpoint_behavior: Option<SRv6EndpointBehavior>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Decode
+// ---------------------------------------------------------------------------
+
+/// Decode all TLVs from the raw Tunnel Encapsulation Attribute value bytes.
+pub fn decode(data: &[u8]) -> Vec<TunnelEncapTlv> {
+    let mut tlvs = Vec::new();
+    let mut c = Cursor::new(data);
+    while (c.position() as usize) < data.len() {
+        let Ok(tunnel_type) = c.read_u16::<NetworkEndian>() else {
+            break;
+        };
+        let Ok(len) = c.read_u16::<NetworkEndian>() else {
+            break;
+        };
+        let pos = c.position() as usize;
+        let end = pos + len as usize;
+        if end > data.len() {
+            break;
+        }
+        let value_bytes = &data[pos..end];
+        c.set_position(end as u64);
+
+        let value = if tunnel_type == TUNNEL_TYPE_SR_POLICY {
+            TunnelEncapValue::SrPolicy(decode_sr_policy(value_bytes))
+        } else {
+            TunnelEncapValue::Unknown(value_bytes.to_vec())
+        };
+        tlvs.push(TunnelEncapTlv { tunnel_type, value });
+    }
+    tlvs
+}
+
+fn decode_sr_policy(data: &[u8]) -> SrPolicyCandidatePath {
+    let mut cp = SrPolicyCandidatePath::default();
+    let mut c = Cursor::new(data);
+    while (c.position() as usize) < data.len() {
+        let Ok(sub_type) = c.read_u8() else { break };
+        let Ok(sub_len) = c.read_u8() else { break };
+        let pos = c.position() as usize;
+        let end = pos + sub_len as usize;
+        if end > data.len() {
+            break;
+        }
+        let body = &data[pos..end];
+        c.set_position(end as u64);
+
+        match sub_type {
+            SUBTLV_PREFERENCE => {
+                if body.len() >= 5 {
+                    cp.preference = Some(SrPolicyPreference {
+                        flags: body[0],
+                        preference: u32::from_be_bytes(body[1..5].try_into().unwrap()),
+                    });
+                }
+            }
+            SUBTLV_BINDING_SID => match body.len() {
+                6 => {
+                    let flags = body[0];
+                    // body[1] is reserved
+                    let label = u32::from_be_bytes(body[2..6].try_into().unwrap()) >> 12;
+                    cp.binding_sid = Some(SrPolicyBindingSid::Mpls { flags, label });
+                }
+                18 => {
+                    let flags = body[0];
+                    // body[1] is reserved
+                    let sid = decode_ipv6(&body[2..18]);
+                    cp.binding_sid = Some(SrPolicyBindingSid::Srv6 { flags, sid });
+                }
+                _ => {}
+            },
+            SUBTLV_SRV6_BINDING_SID => {
+                if body.len() >= 24 {
+                    let flags = body[0];
+                    // body[1] is reserved
+                    let sid = decode_ipv6(&body[2..18]);
+                    let behavior = u16::from_be_bytes(body[18..20].try_into().unwrap());
+                    cp.srv6_binding_sid = Some(SrPolicySrv6BindingSid {
+                        flags,
+                        sid,
+                        endpoint_behavior: SRv6EndpointBehavior {
+                            behavior,
+                            block_len: body[20],
+                            node_len: body[21],
+                            func_len: body[22],
+                            arg_len: body[23],
+                        },
+                    });
+                }
+            }
+            SUBTLV_ENLP => {
+                if body.len() >= 2 {
+                    cp.enlp = Some(SrPolicyEnlp {
+                        flags: body[0],
+                        enlp_type: body[1],
+                    });
+                }
+            }
+            SUBTLV_PRIORITY => {
+                if !body.is_empty() {
+                    cp.priority = Some(body[0]);
+                }
+            }
+            SUBTLV_SEGMENT_LIST => {
+                if body.len() >= 2 {
+                    // body[0] = flags, body[1] = reserved
+                    let sl = decode_segment_list(&body[2..]);
+                    cp.segment_lists.push(sl);
+                }
+            }
+            SUBTLV_CANDIDATE_PATH_NAME => {
+                if let Ok(s) = std::str::from_utf8(body) {
+                    cp.candidate_path_name = Some(s.to_owned());
+                }
+            }
+            SUBTLV_POLICY_NAME => {
+                if let Ok(s) = std::str::from_utf8(body) {
+                    cp.policy_name = Some(s.to_owned());
+                }
+            }
+            _ => {}
+        }
+    }
+    cp
+}
+
+fn decode_segment_list(data: &[u8]) -> SrPolicySegmentList {
+    let mut sl = SrPolicySegmentList::default();
+    let mut c = Cursor::new(data);
+    while (c.position() as usize) < data.len() {
+        let Ok(seg_type) = c.read_u8() else { break };
+        let Ok(seg_len) = c.read_u8() else { break };
+        let pos = c.position() as usize;
+        let end = pos + seg_len as usize;
+        if end > data.len() {
+            break;
+        }
+        let body = &data[pos..end];
+        c.set_position(end as u64);
+
+        match seg_type {
+            SEGSUB_WEIGHT => {
+                if body.len() >= 5 {
+                    sl.weight = Some(SrWeight {
+                        flags: body[0],
+                        weight: u32::from_be_bytes(body[1..5].try_into().unwrap()),
+                    });
+                }
+            }
+            SEGSUB_TYPE_A => {
+                if body.len() >= 6 {
+                    let flags = body[0];
+                    // body[1] reserved
+                    let entry = u32::from_be_bytes(body[2..6].try_into().unwrap());
+                    let label = entry >> 12;
+                    sl.segments.push(SrSegment::TypeA { flags, label });
+                }
+            }
+            SEGSUB_TYPE_B if body.len() >= 18 => {
+                let flags = body[0];
+                // body[1] reserved
+                let sid = decode_ipv6(&body[2..18]);
+                // A-flag (0x40) indicates endpoint behavior is present
+                let endpoint_behavior = if flags & 0x40 != 0 && body.len() >= 24 {
+                    Some(SRv6EndpointBehavior {
+                        behavior: u16::from_be_bytes(body[18..20].try_into().unwrap()),
+                        block_len: body[20],
+                        node_len: body[21],
+                        func_len: body[22],
+                        arg_len: body[23],
+                    })
+                } else {
+                    None
+                };
+                sl.segments.push(SrSegment::TypeB {
+                    flags,
+                    sid,
+                    endpoint_behavior,
+                });
+            }
+            _ => {}
+        }
+    }
+    sl
+}
+
+fn decode_ipv6(b: &[u8]) -> Ipv6Addr {
+    let arr: [u8; 16] = b[..16].try_into().unwrap();
+    Ipv6Addr::from(arr)
+}
+
+// ---------------------------------------------------------------------------
+// Encode
+// ---------------------------------------------------------------------------
+
+/// Encode all TLVs into a byte buffer (the attribute value bytes).
+pub fn encode(tlvs: &[TunnelEncapTlv]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for tlv in tlvs {
+        let value = match &tlv.value {
+            TunnelEncapValue::SrPolicy(cp) => encode_sr_policy(cp),
+            TunnelEncapValue::Unknown(b) => b.clone(),
+        };
+        buf.extend_from_slice(&tlv.tunnel_type.to_be_bytes());
+        buf.extend_from_slice(&(value.len() as u16).to_be_bytes());
+        buf.extend_from_slice(&value);
+    }
+    buf
+}
+
+fn encode_sr_policy(cp: &SrPolicyCandidatePath) -> Vec<u8> {
+    let mut buf = Vec::new();
+
+    if let Some(pref) = &cp.preference {
+        let body = encode_preference(pref);
+        push_subtlv(&mut buf, SUBTLV_PREFERENCE, &body);
+    }
+    if let Some(bsid) = &cp.binding_sid {
+        let body = encode_binding_sid(bsid);
+        push_subtlv(&mut buf, SUBTLV_BINDING_SID, &body);
+    }
+    if let Some(bsid) = &cp.srv6_binding_sid {
+        let body = encode_srv6_binding_sid(bsid);
+        push_subtlv(&mut buf, SUBTLV_SRV6_BINDING_SID, &body);
+    }
+    if let Some(enlp) = &cp.enlp {
+        let body = [enlp.flags, enlp.enlp_type];
+        push_subtlv(&mut buf, SUBTLV_ENLP, &body);
+    }
+    if let Some(pri) = cp.priority {
+        push_subtlv(&mut buf, SUBTLV_PRIORITY, &[pri]);
+    }
+    for sl in &cp.segment_lists {
+        let body = encode_segment_list(sl);
+        push_subtlv(&mut buf, SUBTLV_SEGMENT_LIST, &body);
+    }
+    if let Some(name) = &cp.candidate_path_name {
+        push_subtlv(&mut buf, SUBTLV_CANDIDATE_PATH_NAME, name.as_bytes());
+    }
+    if let Some(name) = &cp.policy_name {
+        push_subtlv(&mut buf, SUBTLV_POLICY_NAME, name.as_bytes());
+    }
+
+    buf
+}
+
+fn encode_preference(pref: &SrPolicyPreference) -> Vec<u8> {
+    let mut b = Vec::with_capacity(5);
+    b.push(pref.flags);
+    b.extend_from_slice(&pref.preference.to_be_bytes());
+    b
+}
+
+fn encode_binding_sid(bsid: &SrPolicyBindingSid) -> Vec<u8> {
+    match bsid {
+        SrPolicyBindingSid::Mpls { flags, label } => {
+            let mut b = Vec::with_capacity(6);
+            b.push(*flags);
+            b.push(0); // reserved
+            b.extend_from_slice(&(label << 12).to_be_bytes());
+            b
+        }
+        SrPolicyBindingSid::Srv6 { flags, sid } => {
+            let mut b = Vec::with_capacity(18);
+            b.push(*flags);
+            b.push(0); // reserved
+            b.extend_from_slice(&sid.octets());
+            b
+        }
+    }
+}
+
+fn encode_srv6_binding_sid(bsid: &SrPolicySrv6BindingSid) -> Vec<u8> {
+    let mut b = Vec::with_capacity(24);
+    b.push(bsid.flags);
+    b.push(0); // reserved
+    b.extend_from_slice(&bsid.sid.octets());
+    b.extend_from_slice(&bsid.endpoint_behavior.behavior.to_be_bytes());
+    b.push(bsid.endpoint_behavior.block_len);
+    b.push(bsid.endpoint_behavior.node_len);
+    b.push(bsid.endpoint_behavior.func_len);
+    b.push(bsid.endpoint_behavior.arg_len);
+    b
+}
+
+fn encode_segment_list(sl: &SrPolicySegmentList) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.push(0); // flags
+    buf.push(0); // reserved
+
+    if let Some(w) = &sl.weight {
+        let mut body = Vec::with_capacity(5);
+        body.push(w.flags);
+        body.extend_from_slice(&w.weight.to_be_bytes());
+        push_subtlv(&mut buf, SEGSUB_WEIGHT, &body);
+    }
+    for seg in &sl.segments {
+        match seg {
+            SrSegment::TypeA { flags, label } => {
+                let mut body = Vec::with_capacity(6);
+                body.push(*flags);
+                body.push(0); // reserved
+                body.extend_from_slice(&(label << 12).to_be_bytes());
+                push_subtlv(&mut buf, SEGSUB_TYPE_A, &body);
+            }
+            SrSegment::TypeB {
+                flags,
+                sid,
+                endpoint_behavior,
+            } => {
+                let mut body = Vec::with_capacity(24);
+                body.push(*flags);
+                body.push(0); // reserved
+                body.extend_from_slice(&sid.octets());
+                if let Some(eb) = endpoint_behavior {
+                    body.extend_from_slice(&eb.behavior.to_be_bytes());
+                    body.push(eb.block_len);
+                    body.push(eb.node_len);
+                    body.push(eb.func_len);
+                    body.push(eb.arg_len);
+                }
+                push_subtlv(&mut buf, SEGSUB_TYPE_B, &body);
+            }
+        }
+    }
+    buf
+}
+
+fn push_subtlv(buf: &mut Vec<u8>, sub_type: u8, body: &[u8]) {
+    buf.push(sub_type);
+    buf.push(body.len() as u8);
+    buf.extend_from_slice(body);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv6Addr;
+
+    fn sr_policy_tlv(cp: SrPolicyCandidatePath) -> TunnelEncapTlv {
+        TunnelEncapTlv {
+            tunnel_type: TUNNEL_TYPE_SR_POLICY,
+            value: TunnelEncapValue::SrPolicy(cp),
+        }
+    }
+
+    #[test]
+    fn roundtrip_preference() {
+        let cp = SrPolicyCandidatePath {
+            preference: Some(SrPolicyPreference {
+                flags: 0,
+                preference: 100,
+            }),
+            ..Default::default()
+        };
+        let tlvs = vec![sr_policy_tlv(cp)];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+
+    #[test]
+    fn roundtrip_binding_sid_mpls() {
+        let cp = SrPolicyCandidatePath {
+            binding_sid: Some(SrPolicyBindingSid::Mpls {
+                flags: 0,
+                label: 1000,
+            }),
+            ..Default::default()
+        };
+        let tlvs = vec![sr_policy_tlv(cp)];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+
+    #[test]
+    fn roundtrip_binding_sid_srv6() {
+        let cp = SrPolicyCandidatePath {
+            binding_sid: Some(SrPolicyBindingSid::Srv6 {
+                flags: 0,
+                sid: Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1),
+            }),
+            ..Default::default()
+        };
+        let tlvs = vec![sr_policy_tlv(cp)];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+
+    #[test]
+    fn roundtrip_srv6_binding_sid_with_behavior() {
+        let cp = SrPolicyCandidatePath {
+            srv6_binding_sid: Some(SrPolicySrv6BindingSid {
+                flags: 0,
+                sid: Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 2),
+                endpoint_behavior: SRv6EndpointBehavior {
+                    behavior: 0x0013, // End.DT4
+                    block_len: 32,
+                    node_len: 16,
+                    func_len: 16,
+                    arg_len: 0,
+                },
+            }),
+            ..Default::default()
+        };
+        let tlvs = vec![sr_policy_tlv(cp)];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+
+    #[test]
+    fn roundtrip_enlp_and_priority() {
+        let cp = SrPolicyCandidatePath {
+            enlp: Some(SrPolicyEnlp {
+                flags: 0,
+                enlp_type: 2,
+            }),
+            priority: Some(10),
+            ..Default::default()
+        };
+        let tlvs = vec![sr_policy_tlv(cp)];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+
+    #[test]
+    fn roundtrip_segment_list_type_a() {
+        let cp = SrPolicyCandidatePath {
+            segment_lists: vec![SrPolicySegmentList {
+                weight: Some(SrWeight {
+                    flags: 0,
+                    weight: 1,
+                }),
+                segments: vec![
+                    SrSegment::TypeA {
+                        flags: 0,
+                        label: 16000,
+                    },
+                    SrSegment::TypeA {
+                        flags: 0,
+                        label: 16001,
+                    },
+                ],
+            }],
+            ..Default::default()
+        };
+        let tlvs = vec![sr_policy_tlv(cp)];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+
+    #[test]
+    fn roundtrip_segment_list_type_b_no_behavior() {
+        let cp = SrPolicyCandidatePath {
+            segment_lists: vec![SrPolicySegmentList {
+                weight: None,
+                segments: vec![SrSegment::TypeB {
+                    flags: 0,
+                    sid: Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 3),
+                    endpoint_behavior: None,
+                }],
+            }],
+            ..Default::default()
+        };
+        let tlvs = vec![sr_policy_tlv(cp)];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+
+    #[test]
+    fn roundtrip_segment_list_type_b_with_behavior() {
+        let cp = SrPolicyCandidatePath {
+            segment_lists: vec![SrPolicySegmentList {
+                weight: None,
+                segments: vec![SrSegment::TypeB {
+                    // A-flag (0x40) = endpoint_behavior present
+                    flags: 0x40,
+                    sid: Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 4),
+                    endpoint_behavior: Some(SRv6EndpointBehavior {
+                        behavior: 0x0001, // End
+                        block_len: 32,
+                        node_len: 16,
+                        func_len: 16,
+                        arg_len: 0,
+                    }),
+                }],
+            }],
+            ..Default::default()
+        };
+        let tlvs = vec![sr_policy_tlv(cp)];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+
+    #[test]
+    fn roundtrip_candidate_path_name() {
+        let cp = SrPolicyCandidatePath {
+            candidate_path_name: Some("test-path".to_string()),
+            policy_name: Some("my-policy".to_string()),
+            ..Default::default()
+        };
+        let tlvs = vec![sr_policy_tlv(cp)];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+
+    #[test]
+    fn roundtrip_unknown_tunnel_type() {
+        let tlvs = vec![TunnelEncapTlv {
+            tunnel_type: 99,
+            value: TunnelEncapValue::Unknown(vec![0x01, 0x02, 0x03]),
+        }];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+
+    #[test]
+    fn roundtrip_full_candidate_path() {
+        let cp = SrPolicyCandidatePath {
+            preference: Some(SrPolicyPreference {
+                flags: 0,
+                preference: 200,
+            }),
+            binding_sid: Some(SrPolicyBindingSid::Mpls {
+                flags: 0,
+                label: 2000,
+            }),
+            priority: Some(5),
+            segment_lists: vec![SrPolicySegmentList {
+                weight: Some(SrWeight {
+                    flags: 0,
+                    weight: 1,
+                }),
+                segments: vec![
+                    SrSegment::TypeA {
+                        flags: 0,
+                        label: 16100,
+                    },
+                    SrSegment::TypeA {
+                        flags: 0,
+                        label: 16200,
+                    },
+                ],
+            }],
+            candidate_path_name: Some("cp1".to_string()),
+            ..Default::default()
+        };
+        let tlvs = vec![sr_policy_tlv(cp)];
+        let encoded = encode(&tlvs);
+        let decoded = decode(&encoded);
+        assert_eq!(decoded, tlvs);
+    }
+}

--- a/table/src/policy.rs
+++ b/table/src/policy.rs
@@ -380,7 +380,8 @@ impl Condition {
                     | packet::Nlri::FlowspecV6(_)
                     | packet::Nlri::FlowspecVpnV4(_)
                     | packet::Nlri::FlowspecVpnV6(_)
-                    | packet::Nlri::Ls(_) => {}
+                    | packet::Nlri::Ls(_)
+                    | packet::Nlri::SrPolicy(_) => {}
                 };
             }
             Condition::AsPath(_name, opt, set) => {
@@ -559,6 +560,13 @@ fn nlri_family(net: &packet::Nlri) -> bgp::Family {
         packet::Nlri::FlowspecVpnV4(_) => bgp::Family::IPV4_FLOWSPEC_VPN,
         packet::Nlri::FlowspecVpnV6(_) => bgp::Family::IPV6_FLOWSPEC_VPN,
         packet::Nlri::Ls(_) => bgp::Family::LS,
+        packet::Nlri::SrPolicy(n) => {
+            if n.endpoint.is_ipv4() {
+                bgp::Family::IPV4_SRPOLICY
+            } else {
+                bgp::Family::IPV6_SRPOLICY
+            }
+        }
     }
 }
 


### PR DESCRIPTION
…port

BGP SR Policy (AFI/SAFI 1/73 and 2/73, RFC 9830) is a standard mechanism for distributing SR-TE candidate paths via BGP.  GoBGP supports it, and without this family RustyBGP cannot interoperate with SR-capable peers or be used as a route reflector in SR deployments.

New files:
- packet/src/sr_policy.rs: SrPolicyNlri encode/decode with IPv4 (96-bit) and IPv6 (192-bit) endpoint support, and round-trip tests.
- packet/src/tunnel_encap.rs: full decode/encode for the BGP Tunnel Encapsulation attribute (type 23, RFC 9012).  Tunnel Type 15 (SR Policy, RFC 9830 sec 2.4) is decoded into a structured SrPolicyCandidatePath; all other tunnel types pass through as Unknown(Vec<u8>).  Supports sub-TLVs: Preference (12), Binding SID (13), ENLP (14), Priority (15), SRv6 Binding SID (20), Segment List (128), Candidate Path Name (129). Segment types A (MPLS, sub-sub-TLV 1) and B (SRv6 SID, sub-sub-TLV 13) are fully decoded; types C-K are out of scope (not supported by GoBGP).

Changes to existing files:
- packet/src/bgp.rs: SAFI_SR_POLICY=73, Family::IPV4_SRPOLICY / IPV6_SRPOLICY constants, TUNNEL_ENCAP=23 attribute constant and its canonical flags, Nlri::SrPolicy variant with encode/decode/Display, and a fix to mp_reach_encode to skip the 16-byte nexthop padding for SR Policy families (padding is IPv4-mapped-IPv6 and does not apply here).
- daemon/src/convert.rs: family_from_config for both SR Policy families, nlri_to_api / net_from_api for Nlri::SrPolicy, attr_to_api / attr_from_api for Attribute::TUNNEL_ENCAP using the new tunnel_encap crate, plus three unit tests covering IPv4/IPv6 NLRI round-trips and a TunnelEncap attribute encode/decode round-trip.
- kernel/src/lib.rs: SR Policy routes are overlay-only; skip FIB install.
- table/src/lib.rs: skip ROA/RPKI validation for SR Policy NLRI.
- table/src/policy.rs: Condition::Prefix and nlri_family for SR Policy.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>