### PR TITLE
packet: add GoBGP wire-format test for SRv6 L2 Service TLV

### DIFF
--- a/packet/src/prefix_sid.rs
+++ b/packet/src/prefix_sid.rs
@@ -464,3 +464,57 @@ fn decode_rejects_sid_structure_too_short() {
     ];
     assert!(PrefixSid::decode(&bytes).is_err());
 }
+
+// GoBGP-generated wire bytes for Prefix SID attribute TLVs.
+// Regenerate with: go run packet/tests/fixtures/gen/prefix_sid/
+#[cfg(test)]
+#[rustfmt::skip]
+const GOBGP_SRV6_L2_SERVICE: &[u8] = &[
+    // TLV: type=6 (SRv6 L2 Service), length=34
+    0x06, 0x00, 0x22,
+    0x00, // reserved
+    // Sub-TLV: type=1 (SRv6 Information), length=30
+    0x01, 0x00, 0x1e,
+    0x00, // reserved
+    // SID: 2001:0:5:3::
+    0x20, 0x01, 0x00, 0x00, 0x00, 0x05, 0x00, 0x03,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, // flags
+    0x00, 0x17, // endpoint behavior 23 (End.DT2U)
+    0x00, // reserved
+    // Sub-Sub-TLV: type=1 (SRv6 SID Structure), length=6
+    0x01, 0x00, 0x06,
+    0x28, 0x18, 0x10, 0x00, 0x10, 0x40,
+];
+
+#[test]
+fn gobgp_srv6_l2_service_decode() {
+    let decoded = PrefixSid::decode(GOBGP_SRV6_L2_SERVICE).unwrap();
+    match &decoded.tlvs[0] {
+        PrefixSidTlv::Srv6L2Service(t) => match &t.sub_tlvs[0] {
+            Srv6ServiceSubTlv::Information(i) => {
+                assert_eq!(i.sid, "2001:0:5:3::".parse::<std::net::Ipv6Addr>().unwrap());
+                assert_eq!(i.endpoint_behavior, 23); // End.DT2U
+                match &i.sub_sub_tlvs[0] {
+                    Srv6ServiceDataSubSubTlv::Structure(s) => {
+                        assert_eq!(s.locator_block_length, 40);
+                        assert_eq!(s.locator_node_length, 24);
+                        assert_eq!(s.function_length, 16);
+                        assert_eq!(s.argument_length, 0);
+                        assert_eq!(s.transposition_length, 16);
+                        assert_eq!(s.transposition_offset, 64);
+                    }
+                    _ => panic!("expected Structure sub-sub-tlv"),
+                }
+            }
+            _ => panic!("expected Information sub-tlv"),
+        },
+        _ => panic!("expected Srv6L2Service"),
+    }
+}
+
+#[test]
+fn gobgp_srv6_l2_service_encode() {
+    let decoded = PrefixSid::decode(GOBGP_SRV6_L2_SERVICE).unwrap();
+    assert_eq!(decoded.to_vec(), GOBGP_SRV6_L2_SERVICE);
+}

--- a/packet/tests/fixtures/gen/prefix_sid/main.go
+++ b/packet/tests/fixtures/gen/prefix_sid/main.go
@@ -1,0 +1,71 @@
+// gen_prefix_sid generates Prefix SID attribute wire bytes using GoBGP's
+// packet library, and prints them as Rust byte-array literals for use as
+// test vectors.
+//
+// Usage:
+//
+//	go run .
+//
+// Regenerate after any change to Prefix SID encoding.
+package main
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+)
+
+func rustBytes(buf []byte) string {
+	parts := make([]string, len(buf))
+	for i, b := range buf {
+		parts[i] = fmt.Sprintf("0x%02x", b)
+	}
+	return "&[" + strings.Join(parts, ", ") + "]"
+}
+
+func prefixSidAttr(tlvs ...bgp.PrefixSIDTLVInterface) []byte {
+	attr := bgp.NewPathAttributePrefixSID(tlvs...)
+	buf, err := attr.Serialize()
+	if err != nil {
+		panic(err)
+	}
+	// Strip the path-attribute header (flags=1, type=1, length=1 or 2 bytes)
+	// so the test vector covers only the TLV payload, matching how RustyBGP
+	// stores PrefixSid as the raw attribute value bytes.
+	flags := buf[0]
+	if flags&0x10 != 0 {
+		return buf[4:] // extended-length: 4-byte header
+	}
+	return buf[3:] // normal: 3-byte header
+}
+
+func main() {
+	sid := netip.MustParseAddr("2001:0:5:3::")
+	structure := bgp.NewSRv6SIDStructureSubSubTLV(40, 24, 16, 0, 16, 64)
+
+	// --- SRv6 L3 Service (type 5): SID 2001:0:5:3::, End.DT4 (19), structure 40/24/16/0/16/64 ---
+	{
+		buf := prefixSidAttr(
+			bgp.NewSRv6ServiceTLV(
+				bgp.TLVTypeSRv6L3Service,
+				bgp.NewSRv6InformationSubTLV(sid, bgp.END_DT4, structure),
+			),
+		)
+		fmt.Printf("// SRv6 L3 Service TLV: SID 2001:0:5:3::, End.DT4 (19), structure 40/24/16/0/16/64\n")
+		fmt.Printf("pub const SRV6_L3_SERVICE: &[u8] = %s;\n\n", rustBytes(buf))
+	}
+
+	// --- SRv6 L2 Service (type 6): SID 2001:0:5:3::, End.DT2U (23), structure 40/24/16/0/16/64 ---
+	{
+		buf := prefixSidAttr(
+			bgp.NewSRv6ServiceTLV(
+				bgp.TLVTypeSRv6L2Service,
+				bgp.NewSRv6InformationSubTLV(sid, bgp.END_DT2U, structure),
+			),
+		)
+		fmt.Printf("// SRv6 L2 Service TLV: SID 2001:0:5:3::, End.DT2U (23), structure 40/24/16/0/16/64\n")
+		fmt.Printf("pub const SRV6_L2_SERVICE: &[u8] = %s;\n\n", rustBytes(buf))
+	}
+}


### PR DESCRIPTION
SRv6 L2 Service (type 6) lacked a GoBGP hex test; only L3 Service (type 5) was covered. Internal roundtrip tests cannot catch encode/decode bugs that are consistent between the two directions, so a GoBGP-generated test vector is needed to verify actual wire compatibility.

Add gen/prefix_sid/main.go that produces hex constants for both L3 and L2 Service TLVs from the GoBGP library. Add GOBGP_SRV6_L2_SERVICE constant and gobgp_srv6_l2_service_decode/encode tests to prefix_sid.rs.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>