### PR TITLE
ci: rename workflow to CI and job to clippy, test, fmt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: CI
 
 on: [pull_request]
 
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build:
-    name: build
+    name: clippy, test, fmt
     runs-on: ubuntu-22.04
     steps:
       - name: checking out


### PR DESCRIPTION
The workflow and job were both named "build", which is redundant and does not reflect what the job actually does (clippy lint, cargo test, fmt check, and kernel integration tests).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>