### PR TITLE
ci: update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checking out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup
         run: |
           sudo apt-get update


### PR DESCRIPTION
v3 is deprecated and generates a Node.js 16 deprecation warning in GitHub Actions; v4 uses Node.js 20.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>