### PR TITLE
packet: fix IPv4/IPv6 Multicast nexthop encoding in MP_REACH_NLRI

### DIFF
--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -2147,10 +2147,17 @@ impl PeerCodec {
             dst.put_bytes(0, 8); // 8-byte zero RD (RFC 4364 §4.3.2)
             dst.put_slice(&nh_bytes);
         } else if nh_bytes.len() < 16
-            && !matches!(family, &Family::IPV4_SRPOLICY | &Family::IPV6_SRPOLICY)
+            && !matches!(
+                family,
+                &Family::IPV4_SRPOLICY
+                    | &Family::IPV6_SRPOLICY
+                    | &Family::IPV4_MC
+                    | &Family::IPV6_MC
+            )
         {
-            // Pad IPv4 nexthop to 16 bytes for extended-nexthop families (RFC 8950).
-            // SR Policy uses the nexthop as-is (4 bytes for AFI=1, 16 for AFI=2).
+            // Pad IPv4 nexthop to 16 bytes for RFC 8950 extended-nexthop families.
+            // SR Policy and multicast use the nexthop as-is (RFC 4760 requires 4-byte
+            // IPv4 nexthop for AFI=1 multicast; SR Policy follows the same rule).
             dst.put_u8(16);
             dst.put_slice(&nh_bytes);
             dst.put_bytes(0, 16 - nh_bytes.len());


### PR DESCRIPTION
RFC 4760 requires the nexthop field in MP_REACH_NLRI to be 4 bytes for an IPv4 nexthop. The 16-byte padding path in mp_reach_encode was added for RFC 8950 extended-nexthop families (IPv4 unicast over IPv6 sessions) but incorrectly also applied to IPv4/IPv6 Multicast (AFI=1/2, SAFI=2), which always carry a plain IPv4/IPv6 nexthop without padding.

Exclude Family::IPV4_MC and Family::IPV6_MC from the padding branch so their nexthop is encoded at its natural length (4 or 16 bytes).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>