### PR TITLE
packet: fix VPNv6 SAFI value from 129 to 128 (RFC 4659 / GoBGP)

### DIFF
--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -350,7 +350,6 @@ impl Family {
     const SAFI_LS: u8 = 71;
     const SAFI_MUP: u8 = 85;
     const SAFI_MPLS_VPN: u8 = 128;
-    const SAFI_MPLS_VPN6: u8 = 129;
     const SAFI_SR_POLICY: u8 = 73;
     const SAFI_FLOWSPEC: u8 = 133;
     const SAFI_FLOWSPEC_VPN: u8 = 134;
@@ -366,7 +365,7 @@ impl Family {
     pub const IPV4_MUP: Family = Family::new(Family::AFI_IP, Family::SAFI_MUP);
     pub const IPV6_MUP: Family = Family::new(Family::AFI_IP6, Family::SAFI_MUP);
     pub const IPV4_VPN: Family = Family::new(Family::AFI_IP, Family::SAFI_MPLS_VPN);
-    pub const IPV6_VPN: Family = Family::new(Family::AFI_IP6, Family::SAFI_MPLS_VPN6);
+    pub const IPV6_VPN: Family = Family::new(Family::AFI_IP6, Family::SAFI_MPLS_VPN);
     pub const IPV4_FLOWSPEC: Family = Family::new(Family::AFI_IP, Family::SAFI_FLOWSPEC);
     pub const IPV6_FLOWSPEC: Family = Family::new(Family::AFI_IP6, Family::SAFI_FLOWSPEC);
     pub const IPV4_FLOWSPEC_VPN: Family = Family::new(Family::AFI_IP, Family::SAFI_FLOWSPEC_VPN);


### PR DESCRIPTION
RFC 4659 specifies that VPNv6 (L3VPN IPv6 Unicast) uses AFI=2 with SAFI=128, the same SAFI as VPNv4 (RFC 4364), distinguished only by AFI. GoBGP follows this: RF_IPv6_VPN = AFI_IP6 | SAFI_MPLS_VPN (128).

SAFI=129 is reserved for "Multicast for BGP/MPLS IP VPNs" (RFC 6514), not for VPNv6 Unicast. Using 129 for VPNv6 would cause capability negotiation to fail when interoperating with GoBGP or any RFC-compliant implementation.

Remove the separate SAFI_MPLS_VPN6 constant and reuse SAFI_MPLS_VPN (128) for IPV6_VPN, matching GoBGP's RF_IPv6_VPN definition.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>