### PR TITLE
packet: remove redundant AFI whitelist from MP_REACH/MP_UNREACH parsing

### DIFF
--- a/packet/src/bgp.rs
+++ b/packet/src/bgp.rs
@@ -2775,10 +2775,6 @@ impl PeerCodec {
                     }
                     let mut c = Cursor::new(buf);
                     let afi = c.read_u16::<NetworkEndian>().unwrap();
-                    match afi {
-                        Family::AFI_IP | Family::AFI_IP6 | Family::AFI_LS => {}
-                        _ => return Err(err),
-                    }
                     let safi = c.read_u8().unwrap();
                     let family = Family((afi as u32) << 16 | safi as u32);
                     let addpath_rx = self.families.get(&family).ok_or_else(malformed)?.addpath_rx;
@@ -2836,10 +2832,6 @@ impl PeerCodec {
                     }
                     let mut c = Cursor::new(buf);
                     let afi = c.read_u16::<NetworkEndian>().unwrap();
-                    match afi {
-                        Family::AFI_IP | Family::AFI_IP6 | Family::AFI_LS => {}
-                        _ => return Err(err),
-                    }
                     let safi = c.read_u8().unwrap();
                     let family = Family((afi as u32) << 16 | safi as u32);
                     let addpath_rx = self.families.get(&family).ok_or_else(malformed)?.addpath_rx;


### PR DESCRIPTION
The parse_message function had an early AFI whitelist check (IP, IPv6, BGP-LS) in both the MP_REACH_NLRI and MP_UNREACH_NLRI decode paths. This check is redundant: the family lookup that follows immediately (`self.families.get(&family).ok_or_else(malformed)?`) already rejects any AFI/SAFI that was not negotiated in the OPEN.

The whitelist was not updated when L2VPN/EVPN (AFI=25) support was added, causing parse_message to return UpdateOptionalAttributeError for every EVPN UPDATE received, making EVPN routes undeliverable despite the AFI-SAFI being successfully negotiated.

Removing the early check instead of extending it avoids the same omission for any future AFI.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>