### PR TITLE
tests/e2e: add SR Policy end-to-end test (RFC 9830)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -224,3 +224,25 @@ jobs:
           RUSTYBGP_BUILD_CONTEXT: /tmp/rustybgp-prebuilt
           RUSTYBGP_DOCKERFILE: Dockerfile
         run: ./run-test.sh
+
+  e2e-sr-policy:
+    name: SR Policy (RFC 9830)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: rustybgpd-musl
+          path: /tmp/rustybgp-prebuilt
+      - name: prepare prebuilt context
+        run: |
+          chmod +x /tmp/rustybgp-prebuilt/rustybgpd
+          cp tests/e2e/shared/Dockerfile.rustybgp-prebuilt /tmp/rustybgp-prebuilt/Dockerfile
+      - name: Run SR Policy e2e test
+        working-directory: tests/e2e/sr-policy
+        env:
+          RUSTYBGP_BUILD_CONTEXT: /tmp/rustybgp-prebuilt
+          RUSTYBGP_DOCKERFILE: Dockerfile
+        run: ./run-test.sh

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -69,6 +69,7 @@ RUSTYBGP_DOCKERFILE=Dockerfile \
 | `route-reflector` | Route Reflector | RFC 4456 |
 | `route-server` | BGP Route Server | RFC 7947 |
 | `rpki` | RPKI Route Origin Validation | RFC 6811, RFC 8210 |
+| `sr-policy` | SR Policy (IPv4, MPLS binding SID, segment list) | RFC 9830 |
 
 ## Shared infrastructure
 

--- a/tests/e2e/sr-policy/docker-compose.yml
+++ b/tests/e2e/sr-policy/docker-compose.yml
@@ -1,0 +1,73 @@
+networks:
+  left-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.5.0/24
+          gateway: 172.30.5.254
+
+  right-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.6.0/24
+          gateway: 172.30.6.254
+
+services:
+  # GoBGP A (AS 65002): injects SR Policy routes, peers with rustybgp on left-net
+  gobgp-a:
+    build:
+      context: ../shared
+      dockerfile: Dockerfile.gobgp
+    container_name: gobgp-a
+    privileged: true
+    volumes:
+      - ./gobgp-a/gobgpd.conf:/etc/gobgpd.conf:ro
+    command: ["-f", "/etc/gobgpd.conf"]
+    networks:
+      left-net:
+        ipv4_address: 172.30.5.2
+
+  # rustybgp (AS 65001): relays SR Policy routes between gobgp-a and gobgp-b
+  router-rusty:
+    build:
+      context: ${RUSTYBGP_BUILD_CONTEXT:-../../..}
+      dockerfile: ${RUSTYBGP_DOCKERFILE:-tests/e2e/shared/Dockerfile.rustybgp}
+      args:
+        RUST_TARGET: ${RUST_TARGET:-aarch64-unknown-linux-musl}
+    container_name: router-rusty
+    privileged: true
+    networks:
+      left-net:
+        ipv4_address: 172.30.5.1
+      right-net:
+        ipv4_address: 172.30.6.1
+    volumes:
+      - ./rustybgp.yaml:/etc/rustybgp.yaml:ro
+      - ./entrypoint-rusty.sh:/entrypoint.sh:ro
+
+  # GoBGP B (AS 65003): receives SR Policy routes from rustybgp on right-net
+  gobgp-b:
+    build:
+      context: ../shared
+      dockerfile: Dockerfile.gobgp
+    container_name: gobgp-b
+    privileged: true
+    volumes:
+      - ./gobgp-b/gobgpd.conf:/etc/gobgpd.conf:ro
+    command: ["-f", "/etc/gobgpd.conf"]
+    networks:
+      right-net:
+        ipv4_address: 172.30.6.2
+
+  # Go gRPC tools: sr-inject and sr-verify binaries for route injection and verification
+  tools:
+    build:
+      context: ./tools
+      dockerfile: Dockerfile
+    container_name: sr-tools
+    networks:
+      left-net:
+        ipv4_address: 172.30.5.4
+      right-net:
+        ipv4_address: 172.30.6.4

--- a/tests/e2e/sr-policy/entrypoint-rusty.sh
+++ b/tests/e2e/sr-policy/entrypoint-rusty.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+sysctl -w net.ipv4.ip_forward=1
+
+exec rustybgpd -f /etc/rustybgp.yaml

--- a/tests/e2e/sr-policy/gobgp-a/gobgpd.conf
+++ b/tests/e2e/sr-policy/gobgp-a/gobgpd.conf
@@ -1,0 +1,11 @@
+[global.config]
+  as = 65002
+  router-id = "172.30.5.2"
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "172.30.5.1"
+    peer-as = 65001
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-srpolicy"

--- a/tests/e2e/sr-policy/gobgp-b/gobgpd.conf
+++ b/tests/e2e/sr-policy/gobgp-b/gobgpd.conf
@@ -1,0 +1,11 @@
+[global.config]
+  as = 65003
+  router-id = "172.30.6.2"
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "172.30.6.1"
+    peer-as = 65001
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-srpolicy"

--- a/tests/e2e/sr-policy/run-test.sh
+++ b/tests/e2e/sr-policy/run-test.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# SR Policy (RFC 9830) End-to-End Test
+#
+# Topology:
+#   [gobgp-a (AS 65002)] - left-net - [router-rusty (AS 65001)] - right-net - [gobgp-b (AS 65003)]
+#                       172.30.5.0/24                               172.30.6.0/24
+#   [sr-tools]          172.30.5.4 / 172.30.6.4  (gRPC inject/verify)
+#
+# Test scenarios:
+#   1. BGP sessions establish with ipv4-srpolicy AFI-SAFI
+#   2. gobgp-a injects an SR Policy route (preference only)
+#   3. gobgp-a injects an SR Policy route with MPLS binding SID and segment list
+#   4. Both routes appear in gobgp-b (propagated through rustybgp)
+#   5. Both routes appear in rustybgp RIB
+#   6. Withdrawal of route 1 propagates to gobgp-b
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+source ../shared/helpers.sh
+
+PASS=0
+FAIL=0
+
+pass() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    docker compose down --volumes --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== SR Policy (RFC 9830) End-to-End Test ==="
+echo ""
+
+echo "Building and starting containers..."
+docker compose up -d --build 2>&1
+
+echo "Waiting for BGP convergence..."
+MAX_WAIT=60
+A_OK=false
+B_OK=false
+
+for i in $(seq 1 $MAX_WAIT); do
+    if ! $A_OK; then
+        if [ "$(gobgp_bgp_state gobgp-a 172.30.5.1)" = "Established" ]; then
+            A_OK=true
+            echo "gobgp-a <-> rustybgp session established after ${i}s"
+        fi
+    fi
+    if ! $B_OK; then
+        if [ "$(gobgp_bgp_state gobgp-b 172.30.6.1)" = "Established" ]; then
+            B_OK=true
+            echo "gobgp-b <-> rustybgp session established after ${i}s"
+        fi
+    fi
+    if $A_OK && $B_OK; then
+        break
+    fi
+    if [ "$i" -eq "$MAX_WAIT" ]; then
+        echo "BGP sessions did not fully establish within ${MAX_WAIT}s"
+        echo ""
+        echo "--- gobgp-a neighbors ---"
+        docker exec gobgp-a gobgp neighbor 2>/dev/null || true
+        echo ""
+        echo "--- gobgp-b neighbors ---"
+        docker exec gobgp-b gobgp neighbor 2>/dev/null || true
+        echo ""
+        echo "--- rustybgpd logs ---"
+        docker logs router-rusty 2>&1 | tail -30
+    fi
+    sleep 1
+done
+
+echo ""
+echo "--- Test Results ---"
+
+# Tests 1-2: Session establishment
+if $A_OK; then
+    pass "gobgp-a <-> rustybgp session established (ipv4-srpolicy)"
+else
+    fail "gobgp-a <-> rustybgp session established"
+fi
+if $B_OK; then
+    pass "gobgp-b <-> rustybgp session established (ipv4-srpolicy)"
+else
+    fail "gobgp-b <-> rustybgp session established"
+fi
+
+echo ""
+echo "Injecting SR Policy routes from gobgp-a..."
+
+# Route 1: preference only (d=1, c=100, ep=10.0.0.1)
+docker exec sr-tools sr-inject \
+    -host gobgp-a:50051 \
+    -distinguisher 1 -color 100 -endpoint 10.0.0.1 \
+    -nexthop 172.30.5.2 -preference 100
+
+# Route 2: with MPLS binding SID and TypeA segment list (d=2, c=200, ep=10.0.0.2)
+docker exec sr-tools sr-inject \
+    -host gobgp-a:50051 \
+    -distinguisher 2 -color 200 -endpoint 10.0.0.2 \
+    -nexthop 172.30.5.2 -preference 200 -bsid 16001 -segment 16001
+
+echo "Waiting for propagation..."
+sleep 5
+
+# Test 3: gobgp-b has route 1 (with preference check)
+if docker exec sr-tools sr-verify \
+    -host gobgp-b:50051 \
+    -distinguisher 1 -color 100 -endpoint 10.0.0.1 -preference 100; then
+    pass "gobgp-b has SR Policy route d=1 c=100 (preference=100)"
+else
+    fail "gobgp-b missing SR Policy route d=1 c=100"
+    echo "    Debug: gobgp-a global rib:"
+    docker exec gobgp-a gobgp global rib 2>/dev/null || true
+    echo "    Debug: rustybgpd logs:"
+    docker logs router-rusty 2>&1 | tail -20
+fi
+
+# Test 4: gobgp-b has route 2 (with MPLS BSID check)
+if docker exec sr-tools sr-verify \
+    -host gobgp-b:50051 \
+    -distinguisher 2 -color 200 -endpoint 10.0.0.2 \
+    -preference 200 -bsid 16001; then
+    pass "gobgp-b has SR Policy route d=2 c=200 (MPLS BSID=16001)"
+else
+    fail "gobgp-b missing SR Policy route d=2 c=200"
+fi
+
+# Test 5: rustybgp RIB contains both routes
+RUSTY_OK=0
+if docker exec sr-tools sr-verify \
+    -host 172.30.5.1:50051 \
+    -distinguisher 1 -color 100 -endpoint 10.0.0.1 2>/dev/null; then
+    RUSTY_OK=$((RUSTY_OK + 1))
+fi
+if docker exec sr-tools sr-verify \
+    -host 172.30.5.1:50051 \
+    -distinguisher 2 -color 200 -endpoint 10.0.0.2 2>/dev/null; then
+    RUSTY_OK=$((RUSTY_OK + 1))
+fi
+if [ "$RUSTY_OK" -eq 2 ]; then
+    pass "rustybgp RIB contains both SR Policy routes"
+else
+    fail "rustybgp RIB missing SR Policy routes ($RUSTY_OK/2 found)"
+fi
+
+# Test 6: Withdrawal propagation
+echo ""
+echo "Withdrawing SR Policy route d=1 c=100 from gobgp-a..."
+docker exec sr-tools sr-inject \
+    -host gobgp-a:50051 \
+    -delete \
+    -distinguisher 1 -color 100 -endpoint 10.0.0.1 \
+    -nexthop 172.30.5.2 -preference 100
+
+sleep 3
+
+if docker exec sr-tools sr-verify \
+    -host gobgp-b:50051 \
+    -absent \
+    -distinguisher 1 -color 100 -endpoint 10.0.0.1; then
+    pass "withdrawn SR Policy route d=1 c=100 absent from gobgp-b"
+else
+    fail "withdrawn SR Policy route d=1 c=100 still present in gobgp-b"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/e2e/sr-policy/rustybgp.yaml
+++ b/tests/e2e/sr-policy/rustybgp.yaml
@@ -1,0 +1,19 @@
+global:
+  config:
+    as: 65001
+    router-id: "172.30.5.1"
+
+neighbors:
+  - config:
+      neighbor-address: "172.30.5.2"
+      peer-as: 65002
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-srpolicy
+
+  - config:
+      neighbor-address: "172.30.6.2"
+      peer-as: 65003
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-srpolicy

--- a/tests/e2e/sr-policy/tools/Dockerfile
+++ b/tests/e2e/sr-policy/tools/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.24-alpine AS builder
+RUN apk add --no-cache git ca-certificates
+WORKDIR /src
+COPY . .
+RUN go mod tidy && \
+    go build -o /usr/local/bin/sr-inject ./inject && \
+    go build -o /usr/local/bin/sr-verify ./verify && \
+    go build -o /usr/local/bin/sr-debug ./debug
+
+FROM alpine:3.21
+COPY --from=builder /usr/local/bin/sr-inject /usr/local/bin/
+COPY --from=builder /usr/local/bin/sr-verify /usr/local/bin/
+COPY --from=builder /usr/local/bin/sr-debug /usr/local/bin/
+CMD ["sleep", "infinity"]

--- a/tests/e2e/sr-policy/tools/debug/main.go
+++ b/tests/e2e/sr-policy/tools/debug/main.go
@@ -1,0 +1,60 @@
+// debug: dump ListPath response for SR Policy RIB
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	api "github.com/osrg/gobgp/v4/api"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func main() {
+	host := "localhost:50051"
+	if len(os.Args) > 1 {
+		host = os.Args[1]
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpc.Dial(host, grpc.WithTransportCredentials(insecure.NewCredentials())) //nolint:staticcheck
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "grpc.Dial: %v\n", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	client := api.NewGoBgpServiceClient(conn)
+
+	stream, err := client.ListPath(ctx, &api.ListPathRequest{
+		TableType: api.TableType_TABLE_TYPE_GLOBAL,
+		Family: &api.Family{
+			Afi:  api.Family_AFI_IP,
+			Safi: api.Family_SAFI_SR_POLICY,
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ListPath: %v\n", err)
+		os.Exit(1)
+	}
+
+	m := protojson.MarshalOptions{Multiline: true, Indent: "  "}
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Recv: %v\n", err)
+			os.Exit(1)
+		}
+		j, _ := m.Marshal(resp)
+		fmt.Println(string(j))
+	}
+}

--- a/tests/e2e/sr-policy/tools/go.mod
+++ b/tests/e2e/sr-policy/tools/go.mod
@@ -1,0 +1,5 @@
+module tools
+
+go 1.24.5
+
+require github.com/osrg/gobgp/v4 v4.6.0

--- a/tests/e2e/sr-policy/tools/inject/main.go
+++ b/tests/e2e/sr-policy/tools/inject/main.go
@@ -1,0 +1,150 @@
+// sr-inject: inject or withdraw an IPv4 SR Policy route via GoBGP gRPC API.
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	api "github.com/osrg/gobgp/v4/api"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func main() {
+	host         := flag.String("host", "localhost:50051", "GoBGP gRPC endpoint")
+	del          := flag.Bool("delete", false, "delete path instead of adding")
+	distinguisher := flag.Uint("distinguisher", 0, "SR Policy distinguisher")
+	color        := flag.Uint("color", 0, "SR Policy color")
+	endpoint     := flag.String("endpoint", "", "IPv4 endpoint address (required)")
+	nexthop      := flag.String("nexthop", "", "BGP next-hop IPv4 address (required)")
+	preference   := flag.Uint("preference", 100, "candidate path preference")
+	bsid         := flag.Uint("bsid", 0, "MPLS binding SID label value (0 = omit)")
+	segment      := flag.Uint("segment", 0, "TypeA segment MPLS label value (0 = omit)")
+	flag.Parse()
+
+	if *endpoint == "" || *nexthop == "" {
+		fmt.Fprintln(os.Stderr, "error: -endpoint and -nexthop are required")
+		os.Exit(1)
+	}
+
+	epIP := net.ParseIP(*endpoint).To4()
+	if epIP == nil {
+		fmt.Fprintln(os.Stderr, "error: -endpoint must be an IPv4 address")
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpc.Dial(*host, grpc.WithTransportCredentials(insecure.NewCredentials())) //nolint:staticcheck
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "grpc.Dial %s: %v\n", *host, err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	client := api.NewGoBgpServiceClient(conn)
+
+	nlri := &api.NLRI{
+		Nlri: &api.NLRI_SrPolicy{
+			SrPolicy: &api.SRPolicyNLRI{
+				Length:        96, // IPv4: distinguisher(32) + color(32) + endpoint(32) bits
+				Distinguisher: uint32(*distinguisher),
+				Color:         uint32(*color),
+				Endpoint:      epIP,
+			},
+		},
+	}
+
+	// Preference sub-TLV is always included.
+	subTlvs := []*api.TunnelEncapTLV_TLV{
+		{
+			Tlv: &api.TunnelEncapTLV_TLV_SrPreference{
+				SrPreference: &api.TunnelEncapSubTLVSRPreference{
+					Preference: uint32(*preference),
+				},
+			},
+		},
+	}
+
+	if *bsid > 0 {
+		// NewBSID(v) shifts the raw label left 12 internally; pass the raw label.
+		sidBytes := make([]byte, 4)
+		binary.BigEndian.PutUint32(sidBytes, uint32(*bsid))
+		subTlvs = append(subTlvs, &api.TunnelEncapTLV_TLV{
+			Tlv: &api.TunnelEncapTLV_TLV_SrBindingSid{
+				SrBindingSid: &api.TunnelEncapSubTLVSRBindingSID{
+					Bsid: &api.TunnelEncapSubTLVSRBindingSID_SrBindingSid{
+						SrBindingSid: &api.SRBindingSID{Sid: sidBytes},
+					},
+				},
+			},
+		})
+	}
+
+	if *segment > 0 {
+		// SegmentTypeA.Label is the full 4-byte MPLS stack entry (label<<12); GoBGP
+		// serializes it verbatim to wire, so pre-shift so the receiver can decode label
+		// via entry>>12.
+		subTlvs = append(subTlvs, &api.TunnelEncapTLV_TLV{
+			Tlv: &api.TunnelEncapTLV_TLV_SrSegmentList{
+				SrSegmentList: &api.TunnelEncapSubTLVSRSegmentList{
+					Weight: &api.SRWeight{Weight: 1},
+					Segments: []*api.TunnelEncapSubTLVSRSegmentList_Segment{
+						{
+							Segment: &api.TunnelEncapSubTLVSRSegmentList_Segment_A{
+								A: &api.SegmentTypeA{Label: uint32(*segment) << 12},
+							},
+						},
+					},
+				},
+			},
+		})
+	}
+
+	path := &api.Path{
+		Nlri: nlri,
+		Pattrs: []*api.Attribute{
+			{Attr: &api.Attribute_Origin{
+				Origin: &api.OriginAttribute{Origin: 0},
+			}},
+			{Attr: &api.Attribute_NextHop{
+				NextHop: &api.NextHopAttribute{NextHop: *nexthop},
+			}},
+			{Attr: &api.Attribute_TunnelEncap{
+				TunnelEncap: &api.TunnelEncapAttribute{
+					Tlvs: []*api.TunnelEncapTLV{
+						{Type: 15, Tlvs: subTlvs},
+					},
+				},
+			}},
+		},
+		Family: &api.Family{
+			Afi:  api.Family_AFI_IP,
+			Safi: api.Family_SAFI_SR_POLICY,
+		},
+	}
+
+	if *del {
+		_, err = client.DeletePath(ctx, &api.DeletePathRequest{Path: path})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "DeletePath: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("deleted SR Policy route: d=%d c=%d ep=%s\n",
+			*distinguisher, *color, *endpoint)
+	} else {
+		_, err = client.AddPath(ctx, &api.AddPathRequest{Path: path})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "AddPath: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("injected SR Policy route: d=%d c=%d ep=%s pref=%d\n",
+			*distinguisher, *color, *endpoint, *preference)
+	}
+}

--- a/tests/e2e/sr-policy/tools/verify/main.go
+++ b/tests/e2e/sr-policy/tools/verify/main.go
@@ -1,0 +1,149 @@
+// sr-verify: verify that an IPv4 SR Policy route is (or is not) present in a GoBGP RIB.
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	api "github.com/osrg/gobgp/v4/api"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func main() {
+	host          := flag.String("host", "localhost:50051", "GoBGP gRPC endpoint")
+	distinguisher := flag.Uint("distinguisher", 0, "SR Policy distinguisher")
+	color         := flag.Uint("color", 0, "SR Policy color")
+	endpoint      := flag.String("endpoint", "", "IPv4 endpoint address (required)")
+	preference    := flag.Uint("preference", 0, "expected preference value (0 = skip check)")
+	bsid          := flag.Uint("bsid", 0, "expected MPLS binding SID label (0 = skip check)")
+	absent        := flag.Bool("absent", false, "assert route is NOT present")
+	flag.Parse()
+
+	if *endpoint == "" {
+		fmt.Fprintln(os.Stderr, "error: -endpoint is required")
+		os.Exit(1)
+	}
+
+	epIP := net.ParseIP(*endpoint).To4()
+	if epIP == nil {
+		fmt.Fprintln(os.Stderr, "error: -endpoint must be an IPv4 address")
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpc.Dial(*host, grpc.WithTransportCredentials(insecure.NewCredentials())) //nolint:staticcheck
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "grpc.Dial %s: %v\n", *host, err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	client := api.NewGoBgpServiceClient(conn)
+
+	stream, err := client.ListPath(ctx, &api.ListPathRequest{
+		TableType: api.TableType_TABLE_TYPE_GLOBAL,
+		Family: &api.Family{
+			Afi:  api.Family_AFI_IP,
+			Safi: api.Family_SAFI_SR_POLICY,
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ListPath: %v\n", err)
+		os.Exit(1)
+	}
+
+	found := false
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Recv: %v\n", err)
+			os.Exit(1)
+		}
+		for _, path := range resp.Destination.Paths {
+			if path.Nlri == nil {
+				continue
+			}
+			srp, ok := path.Nlri.Nlri.(*api.NLRI_SrPolicy)
+			if !ok {
+				continue
+			}
+			nlri := srp.SrPolicy
+			if nlri.Distinguisher != uint32(*distinguisher) ||
+				nlri.Color != uint32(*color) ||
+				!net.IP(nlri.Endpoint).Equal(epIP) {
+				continue
+			}
+			if *preference > 0 || *bsid > 0 {
+				if !matchAttrs(path.Pattrs, uint32(*preference), uint32(*bsid)) {
+					continue
+				}
+			}
+			found = true
+		}
+		if found {
+			break
+		}
+	}
+
+	desc := fmt.Sprintf("d=%d c=%d ep=%s", *distinguisher, *color, *endpoint)
+
+	if *absent {
+		if found {
+			fmt.Fprintf(os.Stderr, "FAIL: route %s unexpectedly present in %s\n", desc, *host)
+			os.Exit(1)
+		}
+		fmt.Printf("OK: route %s absent in %s\n", desc, *host)
+	} else {
+		if !found {
+			fmt.Fprintf(os.Stderr, "FAIL: route %s not found in %s\n", desc, *host)
+			os.Exit(1)
+		}
+		fmt.Printf("OK: route %s found in %s\n", desc, *host)
+	}
+}
+
+func matchAttrs(pattrs []*api.Attribute, wantPref, wantBsid uint32) bool {
+	for _, attr := range pattrs {
+		te, ok := attr.Attr.(*api.Attribute_TunnelEncap)
+		if !ok {
+			continue
+		}
+		for _, tlv := range te.TunnelEncap.GetTlvs() {
+			if tlv.Type != 15 {
+				continue
+			}
+			var gotPref, gotBsidLabel uint32
+			for _, sub := range tlv.Tlvs {
+				switch v := sub.Tlv.(type) {
+				case *api.TunnelEncapTLV_TLV_SrPreference:
+					gotPref = v.SrPreference.Preference
+				case *api.TunnelEncapTLV_TLV_SrBindingSid:
+					if sr, ok := v.SrBindingSid.Bsid.(*api.TunnelEncapSubTLVSRBindingSID_SrBindingSid); ok {
+						sid := sr.SrBindingSid.Sid
+						if len(sid) >= 4 {
+							gotBsidLabel = binary.BigEndian.Uint32(sid[:4]) >> 12
+						}
+					}
+				}
+			}
+			prefOK := wantPref == 0 || gotPref == wantPref
+			bsidOK := wantBsid == 0 || gotBsidLabel == wantBsid
+			if prefOK && bsidOK {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
RustyBGP already implements SR Policy for IPv4 (AFI 1, SAFI 73), but no e2e test existed to verify the full propagation path end-to-end.

The test topology uses GoBGP v4.6.0 as both the route injector (gobgp-a, AS 65002) and the receiving peer (gobgp-b, AS 65003), with RustyBGP (AS 65001) in the middle. GoBGP's CLI does not support SR Policy, so two small Go tools are used instead:

- sr-inject: calls GoBGP gRPC AddPath/DeletePath to inject SR Policy routes with TunnelEncap (preference sub-TLV, MPLS binding SID, Type-A segment list)
- sr-verify: calls GoBGP gRPC ListPath and asserts NLRI match plus optional attribute checks (preference value, BSID label)
- sr-debug: dumps the full ListPath response as JSON for diagnostics

Six assertions are checked: both BGP sessions carry ipv4-srpolicy, two distinct SR Policy routes propagate gobgp-a -> rustybgp -> gobgp-b with correct BSID and preference attributes preserved, both routes appear in rustybgp's own RIB, and withdrawal removes the route from gobgp-b within the convergence window.

GoBGP's gRPC API has two encoding quirks that the inject tool must accommodate: NewBSID(v) treats the Sid bytes as a raw label value and shifts left 12 internally, so the tool must not pre-shift; and SegmentTypeA.Label is the full 4-byte MPLS stack entry (label<<12) rather than the raw 20-bit label, so the tool must pre-shift before passing it to GoBGP.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>