### PR TITLE
tests/e2e: add BGP-LS end-to-end test (RFC 7752)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -246,3 +246,25 @@ jobs:
           RUSTYBGP_BUILD_CONTEXT: /tmp/rustybgp-prebuilt
           RUSTYBGP_DOCKERFILE: Dockerfile
         run: ./run-test.sh
+
+  e2e-link-state:
+    name: BGP-LS (RFC 7752)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: rustybgpd-musl
+          path: /tmp/rustybgp-prebuilt
+      - name: prepare prebuilt context
+        run: |
+          chmod +x /tmp/rustybgp-prebuilt/rustybgpd
+          cp tests/e2e/shared/Dockerfile.rustybgp-prebuilt /tmp/rustybgp-prebuilt/Dockerfile
+      - name: Run BGP-LS e2e test
+        working-directory: tests/e2e/link-state
+        env:
+          RUSTYBGP_BUILD_CONTEXT: /tmp/rustybgp-prebuilt
+          RUSTYBGP_DOCKERFILE: Dockerfile
+        run: ./run-test.sh

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -68,6 +68,7 @@ RUSTYBGP_DOCKERFILE=Dockerfile \
 | `graceful-restart-restarting` | Graceful Restart — restarting speaker | RFC 4724 |
 | `route-reflector` | Route Reflector | RFC 4456 |
 | `route-server` | BGP Route Server | RFC 7947 |
+| `link-state` | BGP-LS (Node, Link, PrefixV4 NLRIs + BGP-LS attribute) | RFC 7752 |
 | `rpki` | RPKI Route Origin Validation | RFC 6811, RFC 8210 |
 | `sr-policy` | SR Policy (IPv4, MPLS binding SID, segment list) | RFC 9830 |
 

--- a/tests/e2e/link-state/docker-compose.yml
+++ b/tests/e2e/link-state/docker-compose.yml
@@ -1,0 +1,73 @@
+networks:
+  left-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.7.0/24
+          gateway: 172.30.7.254
+
+  right-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.8.0/24
+          gateway: 172.30.8.254
+
+services:
+  # GoBGP A (AS 65002): injects BGP-LS NLRIs, peers with rustybgp on left-net
+  gobgp-a:
+    build:
+      context: ../shared
+      dockerfile: Dockerfile.gobgp
+    container_name: gobgp-a
+    privileged: true
+    volumes:
+      - ./gobgp-a/gobgpd.conf:/etc/gobgpd.conf:ro
+    command: ["-f", "/etc/gobgpd.conf"]
+    networks:
+      left-net:
+        ipv4_address: 172.30.7.2
+
+  # rustybgp (AS 65001): relays BGP-LS NLRIs between gobgp-a and gobgp-b
+  router-rusty:
+    build:
+      context: ${RUSTYBGP_BUILD_CONTEXT:-../../..}
+      dockerfile: ${RUSTYBGP_DOCKERFILE:-tests/e2e/shared/Dockerfile.rustybgp}
+      args:
+        RUST_TARGET: ${RUST_TARGET:-aarch64-unknown-linux-musl}
+    container_name: router-rusty
+    privileged: true
+    networks:
+      left-net:
+        ipv4_address: 172.30.7.1
+      right-net:
+        ipv4_address: 172.30.8.1
+    volumes:
+      - ./rustybgp.yaml:/etc/rustybgp.yaml:ro
+      - ./entrypoint-rusty.sh:/entrypoint.sh:ro
+
+  # GoBGP B (AS 65003): receives BGP-LS NLRIs from rustybgp on right-net
+  gobgp-b:
+    build:
+      context: ../shared
+      dockerfile: Dockerfile.gobgp
+    container_name: gobgp-b
+    privileged: true
+    volumes:
+      - ./gobgp-b/gobgpd.conf:/etc/gobgpd.conf:ro
+    command: ["-f", "/etc/gobgpd.conf"]
+    networks:
+      right-net:
+        ipv4_address: 172.30.8.2
+
+  # Go gRPC tools: ls-inject and ls-verify binaries for NLRI injection and verification
+  tools:
+    build:
+      context: ./tools
+      dockerfile: Dockerfile
+    container_name: ls-tools
+    networks:
+      left-net:
+        ipv4_address: 172.30.7.4
+      right-net:
+        ipv4_address: 172.30.8.4

--- a/tests/e2e/link-state/entrypoint-rusty.sh
+++ b/tests/e2e/link-state/entrypoint-rusty.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+sysctl -w net.ipv4.ip_forward=1
+
+exec rustybgpd -f /etc/rustybgp.yaml

--- a/tests/e2e/link-state/gobgp-a/gobgpd.conf
+++ b/tests/e2e/link-state/gobgp-a/gobgpd.conf
@@ -1,0 +1,11 @@
+[global.config]
+  as = 65002
+  router-id = "172.30.7.2"
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "172.30.7.1"
+    peer-as = 65001
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ls"

--- a/tests/e2e/link-state/gobgp-b/gobgpd.conf
+++ b/tests/e2e/link-state/gobgp-b/gobgpd.conf
@@ -1,0 +1,11 @@
+[global.config]
+  as = 65003
+  router-id = "172.30.8.2"
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "172.30.8.1"
+    peer-as = 65001
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ls"

--- a/tests/e2e/link-state/run-test.sh
+++ b/tests/e2e/link-state/run-test.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# BGP-LS (RFC 7752) End-to-End Test
+#
+# Topology:
+#   [gobgp-a (AS 65002)] - left-net - [router-rusty (AS 65001)] - right-net - [gobgp-b (AS 65003)]
+#                       172.30.7.0/24                               172.30.8.0/24
+#   [ls-tools]          172.30.7.4 / 172.30.8.4  (gRPC inject/verify)
+#
+# Test scenarios:
+#   1. BGP sessions establish with ls AFI-SAFI
+#   2. gobgp-a injects a Node NLRI with BGP-LS node attribute (node name)
+#   3. gobgp-a injects a Link NLRI
+#   4. gobgp-a injects a PrefixV4 NLRI
+#   5. All three NLRIs propagate through rustybgp to gobgp-b
+#   6. BGP-LS attribute (type 29) is forwarded with the Node NLRI
+#   7. All three NLRIs appear in rustybgp RIB
+#   8. Withdrawal of Node NLRI propagates to gobgp-b
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+source ../shared/helpers.sh
+
+PASS=0
+FAIL=0
+
+pass() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    docker compose down --volumes --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== BGP-LS (RFC 7752) End-to-End Test ==="
+echo ""
+
+echo "Building and starting containers..."
+docker compose up -d --build 2>&1
+
+echo "Waiting for BGP convergence..."
+MAX_WAIT=60
+A_OK=false
+B_OK=false
+
+for i in $(seq 1 $MAX_WAIT); do
+    if ! $A_OK; then
+        if [ "$(gobgp_bgp_state gobgp-a 172.30.7.1)" = "Established" ]; then
+            A_OK=true
+            echo "gobgp-a <-> rustybgp session established after ${i}s"
+        fi
+    fi
+    if ! $B_OK; then
+        if [ "$(gobgp_bgp_state gobgp-b 172.30.8.1)" = "Established" ]; then
+            B_OK=true
+            echo "gobgp-b <-> rustybgp session established after ${i}s"
+        fi
+    fi
+    if $A_OK && $B_OK; then
+        break
+    fi
+    if [ "$i" -eq "$MAX_WAIT" ]; then
+        echo "BGP sessions did not fully establish within ${MAX_WAIT}s"
+        echo ""
+        echo "--- gobgp-a neighbors ---"
+        docker exec gobgp-a gobgp neighbor 2>/dev/null || true
+        echo ""
+        echo "--- gobgp-b neighbors ---"
+        docker exec gobgp-b gobgp neighbor 2>/dev/null || true
+        echo ""
+        echo "--- rustybgpd logs ---"
+        docker logs router-rusty 2>&1 | tail -30
+    fi
+    sleep 1
+done
+
+echo ""
+echo "--- Test Results ---"
+
+# Tests 1-2: Session establishment
+if $A_OK; then
+    pass "gobgp-a <-> rustybgp session established (ls)"
+else
+    fail "gobgp-a <-> rustybgp session did not establish"
+fi
+if $B_OK; then
+    pass "gobgp-b <-> rustybgp session established (ls)"
+else
+    fail "gobgp-b <-> rustybgp session did not establish"
+fi
+
+echo ""
+echo "Injecting BGP-LS NLRIs from gobgp-a..."
+
+# Node NLRI: router 1.0.0.1 with node name for BGP-LS attribute check
+docker exec ls-tools ls-inject \
+    -host gobgp-a:50051 \
+    -type node \
+    -nexthop 172.30.7.2 \
+    -local-router-id 1.0.0.1 \
+    -node-name test-router-a
+
+# Link NLRI: 1.0.0.1 <-> 1.0.0.2 via 10.0.12.1/10.0.12.2
+docker exec ls-tools ls-inject \
+    -host gobgp-a:50051 \
+    -type link \
+    -nexthop 172.30.7.2 \
+    -local-router-id 1.0.0.1 \
+    -remote-router-id 1.0.0.2 \
+    -iface-addr 10.0.12.1 \
+    -neighbor-addr 10.0.12.2
+
+# PrefixV4 NLRI: 192.168.1.0/24 reachable via 1.0.0.1
+docker exec ls-tools ls-inject \
+    -host gobgp-a:50051 \
+    -type prefix \
+    -nexthop 172.30.7.2 \
+    -local-router-id 1.0.0.1 \
+    -prefix 192.168.1.0/24
+
+echo "Waiting for propagation..."
+sleep 5
+
+# Test 3: Node NLRI at gobgp-b
+if docker exec ls-tools ls-verify \
+    -host gobgp-b:50051 \
+    -type node \
+    -local-router-id 1.0.0.1; then
+    pass "gobgp-b has Node NLRI (local=1.0.0.1)"
+else
+    fail "gobgp-b missing Node NLRI"
+    echo "    Debug: rustybgpd logs:"
+    docker logs router-rusty 2>&1 | tail -20
+fi
+
+# Test 4: BGP-LS attribute (type 29) forwarded with Node NLRI
+if docker exec ls-tools ls-verify \
+    -host gobgp-b:50051 \
+    -type node \
+    -local-router-id 1.0.0.1 \
+    -node-name test-router-a; then
+    pass "gobgp-b has BGP-LS node attribute (name=test-router-a) forwarded end-to-end"
+else
+    fail "gobgp-b missing BGP-LS node attribute or name mismatch"
+fi
+
+# Test 5: Link NLRI at gobgp-b
+if docker exec ls-tools ls-verify \
+    -host gobgp-b:50051 \
+    -type link \
+    -local-router-id 1.0.0.1 \
+    -remote-router-id 1.0.0.2; then
+    pass "gobgp-b has Link NLRI (1.0.0.1 <-> 1.0.0.2)"
+else
+    fail "gobgp-b missing Link NLRI"
+fi
+
+# Test 6: PrefixV4 NLRI at gobgp-b
+if docker exec ls-tools ls-verify \
+    -host gobgp-b:50051 \
+    -type prefix \
+    -local-router-id 1.0.0.1 \
+    -prefix 192.168.1.0/24; then
+    pass "gobgp-b has PrefixV4 NLRI (192.168.1.0/24)"
+else
+    fail "gobgp-b missing PrefixV4 NLRI"
+fi
+
+# Test 7: All three NLRIs in rustybgp RIB
+RUSTY_OK=0
+docker exec ls-tools ls-verify \
+    -host 172.30.7.1:50051 \
+    -type node \
+    -local-router-id 1.0.0.1 2>/dev/null && RUSTY_OK=$((RUSTY_OK + 1)) || true
+docker exec ls-tools ls-verify \
+    -host 172.30.7.1:50051 \
+    -type link \
+    -local-router-id 1.0.0.1 \
+    -remote-router-id 1.0.0.2 2>/dev/null && RUSTY_OK=$((RUSTY_OK + 1)) || true
+docker exec ls-tools ls-verify \
+    -host 172.30.7.1:50051 \
+    -type prefix \
+    -local-router-id 1.0.0.1 \
+    -prefix 192.168.1.0/24 2>/dev/null && RUSTY_OK=$((RUSTY_OK + 1)) || true
+if [ "$RUSTY_OK" -eq 3 ]; then
+    pass "rustybgp RIB contains all three BGP-LS NLRIs"
+else
+    fail "rustybgp RIB missing BGP-LS NLRIs ($RUSTY_OK/3 found)"
+fi
+
+# Test 8: Withdrawal propagation
+echo ""
+echo "Withdrawing Node NLRI from gobgp-a..."
+docker exec ls-tools ls-inject \
+    -host gobgp-a:50051 \
+    -delete \
+    -type node \
+    -nexthop 172.30.7.2 \
+    -local-router-id 1.0.0.1 \
+    -node-name test-router-a
+
+sleep 3
+
+if docker exec ls-tools ls-verify \
+    -host gobgp-b:50051 \
+    -absent \
+    -type node \
+    -local-router-id 1.0.0.1; then
+    pass "withdrawn Node NLRI absent from gobgp-b"
+else
+    fail "withdrawn Node NLRI still present in gobgp-b"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/e2e/link-state/rustybgp.yaml
+++ b/tests/e2e/link-state/rustybgp.yaml
@@ -1,0 +1,17 @@
+global:
+  config:
+    as: 65001
+    router-id: "172.30.7.1"
+neighbors:
+  - config:
+      neighbor-address: "172.30.7.2"
+      peer-as: 65002
+    afi-safis:
+      - config:
+          afi-safi-name: ls
+  - config:
+      neighbor-address: "172.30.8.2"
+      peer-as: 65003
+    afi-safis:
+      - config:
+          afi-safi-name: ls

--- a/tests/e2e/link-state/tools/Dockerfile
+++ b/tests/e2e/link-state/tools/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.24-alpine AS builder
+RUN apk add --no-cache git ca-certificates
+WORKDIR /src
+COPY . .
+RUN go mod tidy && \
+    go build -o /usr/local/bin/ls-inject ./inject && \
+    go build -o /usr/local/bin/ls-verify ./verify
+
+FROM alpine:3.21
+COPY --from=builder /usr/local/bin/ls-inject /usr/local/bin/
+COPY --from=builder /usr/local/bin/ls-verify /usr/local/bin/
+CMD ["sleep", "infinity"]

--- a/tests/e2e/link-state/tools/go.mod
+++ b/tests/e2e/link-state/tools/go.mod
@@ -1,0 +1,5 @@
+module tools
+
+go 1.24.5
+
+require github.com/osrg/gobgp/v4 v4.6.0

--- a/tests/e2e/link-state/tools/inject/main.go
+++ b/tests/e2e/link-state/tools/inject/main.go
@@ -1,0 +1,182 @@
+// ls-inject: inject or withdraw a BGP-LS NLRI via GoBGP gRPC API.
+//
+// Supports three NLRI types (selected by -type):
+//
+//	node   - LsNodeNLRI   (local-router-id required)
+//	link   - LsLinkNLRI   (local-router-id, remote-router-id, iface-addr, neighbor-addr required)
+//	prefix - LsPrefixV4NLRI (local-router-id, prefix required)
+//
+// A BGP-LS attribute (type 29) is always attached. For node NLRIs the
+// attribute carries the node name set via -node-name so the verify tool
+// can confirm the attribute was forwarded end-to-end.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	api "github.com/osrg/gobgp/v4/api"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func main() {
+	host            := flag.String("host", "localhost:50051", "GoBGP gRPC endpoint")
+	del             := flag.Bool("delete", false, "delete path instead of adding")
+	nlriType        := flag.String("type", "node", "NLRI type: node, link, or prefix")
+	nexthop         := flag.String("nexthop", "", "BGP next-hop IPv4 address (required)")
+	asn             := flag.Uint("asn", 65002, "AS number for node descriptors")
+	localRouterID   := flag.String("local-router-id", "", "local node IGP router ID (IPv4, required)")
+	remoteRouterID  := flag.String("remote-router-id", "", "remote node IGP router ID (IPv4, required for link)")
+	ifaceAddr       := flag.String("iface-addr", "", "link interface IPv4 address (required for link)")
+	neighborAddr    := flag.String("neighbor-addr", "", "link neighbor IPv4 address (required for link)")
+	prefix          := flag.String("prefix", "", "IPv4 prefix in CIDR notation (required for prefix)")
+	nodeName        := flag.String("node-name", "", "node name in BGP-LS node attribute")
+	flag.Parse()
+
+	if *nexthop == "" {
+		fmt.Fprintln(os.Stderr, "error: -nexthop is required")
+		os.Exit(1)
+	}
+	if *localRouterID == "" {
+		fmt.Fprintln(os.Stderr, "error: -local-router-id is required")
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpc.Dial(*host, grpc.WithTransportCredentials(insecure.NewCredentials())) //nolint:staticcheck
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "grpc.Dial %s: %v\n", *host, err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	client := api.NewGoBgpServiceClient(conn)
+
+	localNode := &api.LsNodeDescriptor{
+		Asn:         uint32(*asn),
+		BgpLsId:     1,
+		IgpRouterId: *localRouterID,
+	}
+
+	var lsNlri *api.LsAddrPrefix
+	var lsAttr *api.LsAttribute
+
+	switch *nlriType {
+	case "node":
+		lsNlri = &api.LsAddrPrefix{
+			Type:       api.LsNLRIType_LS_NLRI_TYPE_NODE,
+			ProtocolId: api.LsProtocolID_LS_PROTOCOL_ID_OSPF_V2,
+			Identifier: 0,
+			Nlri: &api.LsAddrPrefix_LsNLRI{
+				Nlri: &api.LsAddrPrefix_LsNLRI_Node{
+					Node: &api.LsNodeNLRI{LocalNode: localNode},
+				},
+			},
+		}
+		lsAttr = &api.LsAttribute{
+			Node: &api.LsAttributeNode{Name: *nodeName},
+		}
+
+	case "link":
+		if *remoteRouterID == "" || *ifaceAddr == "" || *neighborAddr == "" {
+			fmt.Fprintln(os.Stderr, "error: link type requires -remote-router-id, -iface-addr, -neighbor-addr")
+			os.Exit(1)
+		}
+		remoteNode := &api.LsNodeDescriptor{
+			Asn:         uint32(*asn),
+			BgpLsId:     1,
+			IgpRouterId: *remoteRouterID,
+		}
+		lsNlri = &api.LsAddrPrefix{
+			Type:       api.LsNLRIType_LS_NLRI_TYPE_LINK,
+			ProtocolId: api.LsProtocolID_LS_PROTOCOL_ID_OSPF_V2,
+			Identifier: 0,
+			Nlri: &api.LsAddrPrefix_LsNLRI{
+				Nlri: &api.LsAddrPrefix_LsNLRI_Link{
+					Link: &api.LsLinkNLRI{
+						LocalNode:  localNode,
+						RemoteNode: remoteNode,
+						LinkDescriptor: &api.LsLinkDescriptor{
+							InterfaceAddrIpv4: *ifaceAddr,
+							NeighborAddrIpv4:  *neighborAddr,
+						},
+					},
+				},
+			},
+		}
+		lsAttr = &api.LsAttribute{
+			Link: &api.LsAttributeLink{
+				LocalRouterId:  *localRouterID,
+				RemoteRouterId: *remoteRouterID,
+			},
+		}
+
+	case "prefix":
+		if *prefix == "" {
+			fmt.Fprintln(os.Stderr, "error: prefix type requires -prefix")
+			os.Exit(1)
+		}
+		lsNlri = &api.LsAddrPrefix{
+			Type:       api.LsNLRIType_LS_NLRI_TYPE_PREFIX_V4,
+			ProtocolId: api.LsProtocolID_LS_PROTOCOL_ID_OSPF_V2,
+			Identifier: 0,
+			Nlri: &api.LsAddrPrefix_LsNLRI{
+				Nlri: &api.LsAddrPrefix_LsNLRI_PrefixV4{
+					PrefixV4: &api.LsPrefixV4NLRI{
+						LocalNode: localNode,
+						PrefixDescriptor: &api.LsPrefixDescriptor{
+							IpReachability: []string{*prefix},
+							OspfRouteType:  api.LsOspfRouteType_LS_OSPF_ROUTE_TYPE_INTRA_AREA,
+						},
+					},
+				},
+			},
+		}
+		lsAttr = &api.LsAttribute{
+			Prefix: &api.LsAttributePrefix{},
+		}
+
+	default:
+		fmt.Fprintf(os.Stderr, "error: unknown -type %q (want node, link, or prefix)\n", *nlriType)
+		os.Exit(1)
+	}
+
+	path := &api.Path{
+		Nlri: &api.NLRI{Nlri: &api.NLRI_LsAddrPrefix{LsAddrPrefix: lsNlri}},
+		Pattrs: []*api.Attribute{
+			{Attr: &api.Attribute_Origin{
+				Origin: &api.OriginAttribute{Origin: 0},
+			}},
+			{Attr: &api.Attribute_NextHop{
+				NextHop: &api.NextHopAttribute{NextHop: *nexthop},
+			}},
+			{Attr: &api.Attribute_Ls{Ls: lsAttr}},
+		},
+		Family: &api.Family{
+			Afi:  api.Family_AFI_LS,
+			Safi: api.Family_SAFI_LS,
+		},
+	}
+
+	if *del {
+		_, err = client.DeletePath(ctx, &api.DeletePathRequest{Path: path})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "DeletePath: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("deleted BGP-LS %s NLRI (local=%s)\n", *nlriType, *localRouterID)
+	} else {
+		_, err = client.AddPath(ctx, &api.AddPathRequest{Path: path})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "AddPath: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("injected BGP-LS %s NLRI (local=%s)\n", *nlriType, *localRouterID)
+	}
+}

--- a/tests/e2e/link-state/tools/verify/main.go
+++ b/tests/e2e/link-state/tools/verify/main.go
@@ -1,0 +1,161 @@
+// ls-verify: verify that a BGP-LS NLRI is (or is not) present in a GoBGP RIB.
+//
+// Supported -type values: node, link, prefix
+//
+// For node NLRIs, -node-name checks that the BGP-LS attribute (type 29)
+// was forwarded with the correct node name, verifying end-to-end attribute
+// propagation through rustybgp.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	api "github.com/osrg/gobgp/v4/api"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func main() {
+	host           := flag.String("host", "localhost:50051", "GoBGP gRPC endpoint")
+	nlriType       := flag.String("type", "node", "NLRI type: node, link, or prefix")
+	localRouterID  := flag.String("local-router-id", "", "local node IGP router ID to match (required)")
+	remoteRouterID := flag.String("remote-router-id", "", "remote node IGP router ID to match (required for link)")
+	prefix         := flag.String("prefix", "", "IPv4 prefix to match (required for prefix)")
+	nodeName       := flag.String("node-name", "", "expected node name in BGP-LS attribute (node type, empty = skip check)")
+	absent         := flag.Bool("absent", false, "assert NLRI is NOT present")
+	flag.Parse()
+
+	if *localRouterID == "" {
+		fmt.Fprintln(os.Stderr, "error: -local-router-id is required")
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpc.Dial(*host, grpc.WithTransportCredentials(insecure.NewCredentials())) //nolint:staticcheck
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "grpc.Dial %s: %v\n", *host, err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	client := api.NewGoBgpServiceClient(conn)
+
+	stream, err := client.ListPath(ctx, &api.ListPathRequest{
+		TableType: api.TableType_TABLE_TYPE_GLOBAL,
+		Family: &api.Family{
+			Afi:  api.Family_AFI_LS,
+			Safi: api.Family_SAFI_LS,
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ListPath: %v\n", err)
+		os.Exit(1)
+	}
+
+	found := false
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Recv: %v\n", err)
+			os.Exit(1)
+		}
+		for _, path := range resp.Destination.Paths {
+			if path.Nlri == nil {
+				continue
+			}
+			lsPrefix, ok := path.Nlri.Nlri.(*api.NLRI_LsAddrPrefix)
+			if !ok {
+				continue
+			}
+			if !matchNLRI(lsPrefix.LsAddrPrefix, *nlriType, *localRouterID, *remoteRouterID, *prefix) {
+				continue
+			}
+			if *nodeName != "" && !matchNodeName(path.Pattrs, *nodeName) {
+				continue
+			}
+			found = true
+		}
+		if found {
+			break
+		}
+	}
+
+	desc := fmt.Sprintf("type=%s local=%s", *nlriType, *localRouterID)
+	if *remoteRouterID != "" {
+		desc += " remote=" + *remoteRouterID
+	}
+	if *prefix != "" {
+		desc += " prefix=" + *prefix
+	}
+	if *nodeName != "" {
+		desc += " node-name=" + *nodeName
+	}
+
+	if *absent {
+		if found {
+			fmt.Fprintf(os.Stderr, "FAIL: BGP-LS NLRI %s unexpectedly present in %s\n", desc, *host)
+			os.Exit(1)
+		}
+		fmt.Printf("OK: BGP-LS NLRI %s absent in %s\n", desc, *host)
+	} else {
+		if !found {
+			fmt.Fprintf(os.Stderr, "FAIL: BGP-LS NLRI %s not found in %s\n", desc, *host)
+			os.Exit(1)
+		}
+		fmt.Printf("OK: BGP-LS NLRI %s found in %s\n", desc, *host)
+	}
+}
+
+func matchNLRI(lp *api.LsAddrPrefix, nlriType, localID, remoteID, pfx string) bool {
+	if lp == nil || lp.Nlri == nil {
+		return false
+	}
+	switch nlriType {
+	case "node":
+		n := lp.Nlri.GetNode()
+		return n != nil && n.LocalNode != nil && n.LocalNode.IgpRouterId == localID
+	case "link":
+		l := lp.Nlri.GetLink()
+		return l != nil &&
+			l.LocalNode != nil && l.LocalNode.IgpRouterId == localID &&
+			l.RemoteNode != nil && l.RemoteNode.IgpRouterId == remoteID
+	case "prefix":
+		p := lp.Nlri.GetPrefixV4()
+		if p == nil || p.LocalNode == nil || p.LocalNode.IgpRouterId != localID {
+			return false
+		}
+		if p.PrefixDescriptor == nil {
+			return false
+		}
+		for _, r := range p.PrefixDescriptor.IpReachability {
+			if r == pfx {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+func matchNodeName(pattrs []*api.Attribute, wantName string) bool {
+	for _, attr := range pattrs {
+		ls, ok := attr.Attr.(*api.Attribute_Ls)
+		if !ok {
+			continue
+		}
+		if ls.Ls.GetNode().GetName() == wantName {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
RustyBGP implements BGP-LS (AFI 16388, SAFI 71) in packet/src/ls.rs and daemon/src/convert.rs, but no e2e test existed to verify that NLRI propagation and BGP-LS attribute forwarding work end-to-end.

The topology mirrors the SR Policy test: gobgp-a (AS 65002) injects NLRIs, rustybgp (AS 65001) relays them, gobgp-b (AS 65003) receives. GoBGP's CLI does not support BGP-LS injection, so two Go gRPC tools are used instead:

- ls-inject: calls GoBGP AddPath/DeletePath with LsAddrPrefix NLRIs of type node, link, or prefix; attaches a BGP-LS attribute (type 29) carrying a node name for the attribute-forwarding assertion
- ls-verify: calls ListPath and matches NLRIs by type, local/remote router ID, and prefix; optionally checks the node name in the BGP-LS attribute to verify type-29 forwarding through rustybgp

Eight assertions are checked: both ls sessions establish, Node/Link/ PrefixV4 NLRIs propagate to gobgp-b, the BGP-LS node attribute (type 29) is forwarded end-to-end, all three NLRIs appear in rustybgp's own RIB, and withdrawal removes the Node NLRI from gobgp-b.

RFC 4271 only requires discarding unrecognized optional non-transitive attributes; for recognized ones (BGP-LS attribute, type 29) the forwarding decision follows RFC 7752, which says the attribute SHOULD accompany BGP-LS NLRIs. The test confirms rustybgp follows this rule.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>