### PR TITLE
fsm: use LocalNotification for all locally-sent NOTIFICATION reasons

### DIFF
--- a/daemon/src/event.rs
+++ b/daemon/src/event.rs
@@ -4680,7 +4680,7 @@ struct DisconnectInfo {
 /// RFC 4724: GR applies to unexpected TCP/IO drops.
 /// RFC 8538: when the N-bit is negotiated, GR also applies to
 /// NOTIFICATION (sent or received, unless Hard Reset) and Hold Timer expiry.
-/// AdminShutdown and FsmError never trigger GR.
+/// Only CEASE notifications are GR-eligible; OPEN/FSM/UPDATE errors are not.
 fn gr_on_disconnect(
     shutdown: &Option<crate::fsm::SessionDownReason>,
     gr: NegotiatedGr,
@@ -4691,7 +4691,21 @@ fn gr_on_disconnect(
             err,
         ))) => gr.notification_enabled && !err.is_hard_reset(),
         Some(crate::fsm::SessionDownReason::LocalNotification(bgp::Message::Notification(err))) => {
-            gr.notification_enabled && !err.is_hard_reset()
+            gr.notification_enabled
+                && matches!(
+                    err,
+                    rustybgp_packet::Notification::CeaseMaxPrefixReached
+                        | rustybgp_packet::Notification::CeaseAdminShutdown
+                        | rustybgp_packet::Notification::CeasePeerDeconfigured
+                        | rustybgp_packet::Notification::CeaseAdministrativeReset
+                        | rustybgp_packet::Notification::CeaseConnectionRejected
+                        | rustybgp_packet::Notification::CeaseOtherConfigurationChange
+                        | rustybgp_packet::Notification::CeaseConnectionCollision
+                        | rustybgp_packet::Notification::CeaseOutOfResources
+                        | rustybgp_packet::Notification::CeaseHardReset
+                        | rustybgp_packet::Notification::Other { code: 6, .. }
+                )
+                && !err.is_hard_reset()
         }
         Some(crate::fsm::SessionDownReason::HoldTimerExpired) => gr.notification_enabled,
         _ => false,

--- a/daemon/src/fsm.rs
+++ b/daemon/src/fsm.rs
@@ -241,13 +241,13 @@ impl Connection {
 
     fn on_open(&mut self, open: bgp::Open) -> Vec<Output> {
         if self.state != State::OpenSent {
+            let notif =
+                bgp::Message::Notification(rustybgp_packet::Notification::FsmUnexpectedState {
+                    state: u8::from(self.state),
+                });
             return vec![
-                Output::SendMessage(bgp::Message::Notification(
-                    rustybgp_packet::Notification::FsmUnexpectedState {
-                        state: u8::from(self.state),
-                    },
-                )),
-                Output::SessionDown(SessionDownReason::FsmError),
+                Output::SendMessage(notif.clone()),
+                Output::SessionDown(SessionDownReason::LocalNotification(notif)),
             ];
         }
 
@@ -255,10 +255,11 @@ impl Connection {
 
         // Validate ASN if pre-configured
         if self.expected_remote_asn != 0 && self.expected_remote_asn != open.as_number {
-            out.push(Output::SendMessage(bgp::Message::Notification(
-                rustybgp_packet::Notification::OpenBadPeerAs,
+            let notif = bgp::Message::Notification(rustybgp_packet::Notification::OpenBadPeerAs);
+            out.push(Output::SendMessage(notif.clone()));
+            out.push(Output::SessionDown(SessionDownReason::LocalNotification(
+                notif,
             )));
-            out.push(Output::SessionDown(SessionDownReason::AdminShutdown));
             return out;
         }
 
@@ -272,10 +273,13 @@ impl Connection {
             // RFC 5492 §4: data contains the capability TLV we require.
             let mut cap_data = vec![Capability::FOUR_OCTET_AS_NUMBER, 4];
             cap_data.extend_from_slice(&self.local_asn.to_be_bytes());
-            out.push(Output::SendMessage(bgp::Message::Notification(
+            let notif = bgp::Message::Notification(
                 rustybgp_packet::Notification::OpenUnsupportedCapability { data: cap_data },
+            );
+            out.push(Output::SendMessage(notif.clone()));
+            out.push(Output::SessionDown(SessionDownReason::LocalNotification(
+                notif,
             )));
-            out.push(Output::SessionDown(SessionDownReason::AdminShutdown));
             return out;
         }
 
@@ -349,26 +353,28 @@ impl Connection {
             State::Established => {
                 vec![Output::SetHoldTimer(self.negotiated_holdtime)]
             }
-            _ => vec![
-                Output::SendMessage(bgp::Message::Notification(
-                    rustybgp_packet::Notification::FsmUnexpectedState {
+            _ => {
+                let notif =
+                    bgp::Message::Notification(rustybgp_packet::Notification::FsmUnexpectedState {
                         state: u8::from(self.state),
-                    },
-                )),
-                Output::SessionDown(SessionDownReason::FsmError),
-            ],
+                    });
+                vec![
+                    Output::SendMessage(notif.clone()),
+                    Output::SessionDown(SessionDownReason::LocalNotification(notif)),
+                ]
+            }
         }
     }
 
     fn on_update(&mut self) -> Vec<Output> {
         if self.state != State::Established {
+            let notif =
+                bgp::Message::Notification(rustybgp_packet::Notification::FsmUnexpectedState {
+                    state: u8::from(self.state),
+                });
             return vec![
-                Output::SendMessage(bgp::Message::Notification(
-                    rustybgp_packet::Notification::FsmUnexpectedState {
-                        state: u8::from(self.state),
-                    },
-                )),
-                Output::SessionDown(SessionDownReason::FsmError),
+                Output::SendMessage(notif.clone()),
+                Output::SessionDown(SessionDownReason::LocalNotification(notif)),
             ];
         }
         vec![Output::SetHoldTimer(self.negotiated_holdtime)]
@@ -382,13 +388,13 @@ impl Connection {
 
     fn on_route_refresh(&mut self, family: Family) -> Vec<Output> {
         if self.state != State::Established {
+            let notif =
+                bgp::Message::Notification(rustybgp_packet::Notification::FsmUnexpectedState {
+                    state: u8::from(self.state),
+                });
             return vec![
-                Output::SendMessage(bgp::Message::Notification(
-                    rustybgp_packet::Notification::FsmUnexpectedState {
-                        state: u8::from(self.state),
-                    },
-                )),
-                Output::SessionDown(SessionDownReason::FsmError),
+                Output::SendMessage(notif.clone()),
+                Output::SessionDown(SessionDownReason::LocalNotification(notif)),
             ];
         }
         vec![Output::RouteRefresh(family)]
@@ -915,7 +921,7 @@ mod tests {
         )));
         assert!(has_output(&out, |o| matches!(
             o,
-            Output::SessionDown(SessionDownReason::FsmError)
+            Output::SessionDown(SessionDownReason::LocalNotification(_))
         )));
     }
 
@@ -1110,7 +1116,7 @@ mod tests {
         )));
         assert!(has_output(&out, |o| matches!(
             o,
-            Output::SessionDown(SessionDownReason::FsmError)
+            Output::SessionDown(SessionDownReason::LocalNotification(_))
         )));
     }
 
@@ -1150,7 +1156,7 @@ mod tests {
         )));
         assert!(has_output(&out, |o| matches!(
             o,
-            Output::SessionDown(SessionDownReason::FsmError)
+            Output::SessionDown(SessionDownReason::LocalNotification(_))
         )));
     }
 


### PR DESCRIPTION
AdminShutdown and FsmError were used as SessionDownReason even when a NOTIFICATION was being sent, causing BMP to record PeerDownReason as LocalFsm(0) and lose the notification content. OpenBadPeerAs and OpenUnsupportedCapability are configuration policy rejections, not admin shutdowns; FsmUnexpectedState carries diagnostic state that belongs in the notification payload.

Change on_open, on_keepalive, on_update, and on_route_refresh to emit LocalNotification(msg) instead of AdminShutdown or FsmError, cloning the notification message so both SendMessage and SessionDown carry it.

Update gr_on_disconnect to match only CEASE variants (including Other { code: 6 }) in the LocalNotification arm, preserving the existing rule that OPEN and FSM errors are not GR-eligible (RFC 4724).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>