### PR TITLE
daemon: add BFD server task with RFC 5880/5881 state machine

### DIFF
--- a/daemon/src/bfd.rs
+++ b/daemon/src/bfd.rs
@@ -1,0 +1,582 @@
+// Copyright (C) 2026 The RustyBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//! BFD server (RFC 5880 / RFC 5881) — single-hop BFD for BGP peers.
+//!
+//! Architecture:
+//!   - One server task owns a UDP socket on port 3784, dispatches received
+//!     packets to per-peer tasks via unbounded channels.
+//!   - One peer task per BGP neighbor drives the RFC 5880 state machine,
+//!     sends periodic BFD Control packets, and fires the detection timer.
+//!   - When a peer session goes Down the peer task sends BfdEvent::SessionDown
+//!     to the daemon's event loop via the channel supplied at start time.
+//!
+//! GTSM (RFC 5881 §5):
+//!   - Outgoing packets are sent with TTL = 255 (per-peer send socket).
+//!   - On Linux the receive socket uses IP_MINTTL = 255 so the kernel drops
+//!     packets with TTL < 255 before they reach userspace.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use rustybgp_packet::bfd::{Diagnostic, Message, State};
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tokio::time::Instant;
+
+/// UDP port for single-hop BFD (RFC 5881).
+pub(crate) const BFD_PORT: u16 = 3784;
+
+/// Source port range mandated by RFC 5881 §4.
+const SRC_PORT_MIN: u16 = 49152;
+const SRC_PORT_MAX: u16 = 65535;
+
+const DEFAULT_TX_US: u32 = 1_000_000;
+const DEFAULT_RX_US: u32 = 1_000_000;
+const DEFAULT_DETECT_MULT: u8 = 3;
+
+/// Global counter used for discriminator generation.
+static DISC_CTR: AtomicU64 = AtomicU64::new(1);
+
+fn next_disc() -> u32 {
+    // Wrapping cast: upper bits discarded, 0 excluded by using max(1, …).
+    (DISC_CTR.fetch_add(1, Ordering::Relaxed) as u32).max(1)
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Config for one BFD peer session; mirrors api::BfdPeerConfig fields.
+#[derive(Clone)]
+pub(crate) struct BfdPeerConfig {
+    pub desired_min_tx_interval_us: u32,
+    pub required_min_rx_interval_us: u32,
+    pub detect_multiplier: u8,
+    /// Remote UDP port; 0 means use the default (3784).
+    pub port: u16,
+}
+
+impl Default for BfdPeerConfig {
+    fn default() -> Self {
+        Self {
+            desired_min_tx_interval_us: DEFAULT_TX_US,
+            required_min_rx_interval_us: DEFAULT_RX_US,
+            detect_multiplier: DEFAULT_DETECT_MULT,
+            port: 0,
+        }
+    }
+}
+
+impl BfdPeerConfig {
+    fn remote_port(&self) -> u16 {
+        if self.port > 0 { self.port } else { BFD_PORT }
+    }
+
+    fn tx_interval(&self) -> Duration {
+        Duration::from_micros(self.desired_min_tx_interval_us.max(1) as u64)
+    }
+
+    fn detect_interval(&self) -> Duration {
+        Duration::from_micros(
+            self.detect_multiplier as u64 * self.required_min_rx_interval_us.max(1) as u64,
+        )
+    }
+}
+
+/// Events the BFD server sends to the daemon's main event loop.
+pub(crate) enum BfdEvent {
+    SessionDown { peer_addr: IpAddr },
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+enum BfdRequest {
+    AddPeer { addr: IpAddr, config: BfdPeerConfig },
+    RemovePeer { addr: IpAddr },
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct PeerStateSnapshot {
+    /// api::BfdSessionState value (i32 so it's FFI-compatible with proto enum).
+    pub session_state: i32,
+    pub rx_packets: u64,
+    pub tx_packets: u64,
+}
+
+#[derive(Default)]
+struct ServerStats {
+    rx_packet: AtomicU64,
+    rx_error: AtomicU64,
+    invalid_packet: AtomicU64,
+    unknown_peer: AtomicU64,
+}
+
+struct PeerHandle {
+    /// Dropping this sender causes the peer task to exit.
+    _rx_tx: mpsc::UnboundedSender<Message>,
+}
+
+// ---------------------------------------------------------------------------
+// BfdHandle — public API
+// ---------------------------------------------------------------------------
+
+/// Handle to the BFD server task.  Cheap to clone; all clones share the same
+/// underlying task via the channel.
+pub(crate) struct BfdHandle {
+    tx: mpsc::UnboundedSender<BfdRequest>,
+    #[allow(dead_code)]
+    stats: Arc<ServerStats>,
+    /// Peer states updated by peer tasks; read by gRPC handlers.
+    #[allow(dead_code)]
+    peer_states: Arc<RwLock<HashMap<IpAddr, PeerStateSnapshot>>>,
+}
+
+impl BfdHandle {
+    /// Spawn the BFD server task and return a handle to it.
+    /// `event_tx` receives BfdEvent notifications when sessions change state.
+    pub(crate) fn start(event_tx: mpsc::UnboundedSender<BfdEvent>) -> Self {
+        let stats = Arc::new(ServerStats::default());
+        let peer_states = Arc::new(RwLock::new(HashMap::<IpAddr, PeerStateSnapshot>::new()));
+        let (req_tx, req_rx) = mpsc::unbounded_channel();
+        let h = BfdHandle {
+            tx: req_tx,
+            stats: stats.clone(),
+            peer_states: peer_states.clone(),
+        };
+        tokio::spawn(server_loop(req_rx, event_tx, stats, peer_states));
+        h
+    }
+
+    /// Register a BGP peer for BFD monitoring.  Idempotent: a second call for
+    /// the same address is silently ignored by the server task.
+    pub(crate) fn add_peer(&self, addr: IpAddr, config: BfdPeerConfig) {
+        let _ = self.tx.send(BfdRequest::AddPeer { addr, config });
+    }
+
+    /// Deregister a BGP peer.  The peer task is stopped; any in-flight session
+    /// is torn down without notifying BGP (the caller is responsible for that).
+    pub(crate) fn remove_peer(&self, addr: IpAddr) {
+        let _ = self.tx.send(BfdRequest::RemovePeer { addr });
+    }
+
+    /// Return the current BFD state snapshot for a peer (for gRPC queries).
+    #[allow(dead_code)]
+    pub(crate) fn get_peer_state(&self, addr: IpAddr) -> Option<PeerStateSnapshot> {
+        self.peer_states.read().ok()?.get(&addr).cloned()
+    }
+
+    /// Return server-wide packet counters.
+    #[allow(dead_code)]
+    pub(crate) fn get_server_stats(&self) -> (u64, u64, u64, u64) {
+        (
+            self.stats.rx_packet.load(Ordering::Relaxed),
+            self.stats.rx_error.load(Ordering::Relaxed),
+            self.stats.invalid_packet.load(Ordering::Relaxed),
+            self.stats.unknown_peer.load(Ordering::Relaxed),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server task
+// ---------------------------------------------------------------------------
+
+async fn server_loop(
+    mut req_rx: mpsc::UnboundedReceiver<BfdRequest>,
+    event_tx: mpsc::UnboundedSender<BfdEvent>,
+    stats: Arc<ServerStats>,
+    peer_states: Arc<RwLock<HashMap<IpAddr, PeerStateSnapshot>>>,
+) {
+    let socket = match create_listen_socket() {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            log::error!("BFD: failed to bind port {BFD_PORT}: {e}");
+            return;
+        }
+    };
+
+    let mut peers: HashMap<IpAddr, PeerHandle> = HashMap::new();
+    let mut buf = [0u8; 4096];
+
+    loop {
+        tokio::select! {
+            req = req_rx.recv() => {
+                match req {
+                    Some(BfdRequest::AddPeer { addr, config }) => {
+                        if peers.contains_key(&addr) {
+                            continue;
+                        }
+                        let disc = next_disc();
+                        let (rx_tx, rx_rx) = mpsc::unbounded_channel::<Message>();
+                        {
+                            let mut ps = peer_states.write().unwrap();
+                            ps.insert(addr, PeerStateSnapshot::default());
+                        }
+                        let peer_states2 = peer_states.clone();
+                        let event_tx2 = event_tx.clone();
+                        tokio::spawn(peer_loop(
+                            addr, config, disc,
+                            socket.clone(), rx_rx,
+                            event_tx2, peer_states2,
+                        ));
+                        peers.insert(addr, PeerHandle { _rx_tx: rx_tx });
+                        log::info!("BFD: peer {addr} added (disc={disc:#010x})");
+                    }
+                    Some(BfdRequest::RemovePeer { addr }) => {
+                        if peers.remove(&addr).is_some() {
+                            peer_states.write().unwrap().remove(&addr);
+                            log::info!("BFD: peer {addr} removed");
+                        }
+                    }
+                    None => break,
+                }
+            }
+            result = socket.recv_from(&mut buf) => {
+                match result {
+                    Ok((len, src)) => {
+                        stats.rx_packet.fetch_add(1, Ordering::Relaxed);
+                        let addr = src.ip();
+                        match Message::decode(&buf[..len]) {
+                            Ok(msg) => {
+                                if let Some(peer) = peers.get(&addr) {
+                                    // Channel is bounded only by memory; drop if full.
+                                    if peer._rx_tx.send(msg).is_err() {
+                                        log::debug!("BFD: rx drop for {addr}");
+                                    }
+                                } else {
+                                    stats.unknown_peer.fetch_add(1, Ordering::Relaxed);
+                                    log::debug!("BFD: unknown peer {addr}");
+                                }
+                            }
+                            Err(e) => {
+                                stats.invalid_packet.fetch_add(1, Ordering::Relaxed);
+                                log::debug!("BFD: invalid packet from {addr}: {e}");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        stats.rx_error.fetch_add(1, Ordering::Relaxed);
+                        log::warn!("BFD: recv error: {e}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-peer task
+// ---------------------------------------------------------------------------
+
+async fn peer_loop(
+    peer_addr: IpAddr,
+    config: BfdPeerConfig,
+    my_disc: u32,
+    server_socket: Arc<UdpSocket>,
+    mut rx_rx: mpsc::UnboundedReceiver<Message>,
+    event_tx: mpsc::UnboundedSender<BfdEvent>,
+    peer_states: Arc<RwLock<HashMap<IpAddr, PeerStateSnapshot>>>,
+) {
+    let send_socket = match create_send_socket(peer_addr, config.remote_port()) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("BFD: send socket for {peer_addr}: {e}");
+            return;
+        }
+    };
+
+    let tx_interval = config.tx_interval();
+    let detect_interval = config.detect_interval();
+    let ctx = SendCtx {
+        send_socket,
+        server_socket: &server_socket,
+        peer_addr,
+        remote_port: config.remote_port(),
+        config: &config,
+    };
+
+    let mut session_state = State::Down;
+    let mut your_disc: u32 = 0;
+    let mut rx_count: u64 = 0;
+    let mut tx_count: u64 = 0;
+    // Detection timer deadline; None while in Down (timer not running).
+    let mut expiry: Option<Instant> = None;
+
+    let mut tx_ticker = tokio::time::interval(tx_interval);
+
+    loop {
+        tokio::select! {
+            msg = rx_rx.recv() => {
+                let msg = match msg {
+                    Some(m) => m,
+                    // Server task dropped our sender → we are deregistered.
+                    None => break,
+                };
+
+                // RFC 5880 §6.8.6: discard if Your Discriminator is set and
+                // doesn't match our local discriminator.
+                if msg.your_discriminator != 0 && msg.your_discriminator != my_disc {
+                    log::debug!(
+                        "BFD: {peer_addr} discriminator mismatch \
+                         (expected {my_disc:#010x}, got {:#010x})",
+                        msg.your_discriminator
+                    );
+                    continue;
+                }
+
+                rx_count += 1;
+                your_disc = msg.my_discriminator;
+
+                let new_state = next_state(session_state, msg.state);
+
+                if new_state != session_state {
+                    log::info!(
+                        "BFD: {peer_addr} {session_state} -> {new_state} \
+                         (remote diag: {})",
+                        msg.diagnostic
+                    );
+                }
+
+                // Notify daemon when session transitions out of Up/Init.
+                if is_established(session_state) && !is_established(new_state) {
+                    let _ = event_tx.send(BfdEvent::SessionDown { peer_addr });
+                    expiry = None;
+                } else if is_established(new_state) {
+                    // Reset detection timer on every received packet while up.
+                    expiry = Some(Instant::now() + detect_interval);
+                }
+
+                session_state = new_state;
+                write_state(&peer_states, peer_addr, session_state, rx_count, tx_count);
+
+                // Respond to Poll with Final (RFC 5880 §6.5).
+                if msg.poll {
+                    ctx.send_packet(session_state, my_disc, your_disc, false, true).await;
+                    tx_count += 1;
+                }
+            }
+            _ = tx_ticker.tick() => {
+                ctx.send_packet(session_state, my_disc, your_disc, false, false).await;
+                tx_count += 1;
+                write_state(&peer_states, peer_addr, session_state, rx_count, tx_count);
+            }
+            _ = sleep_until_opt(expiry) => {
+                // Detection timeout (RFC 5880 §6.8.4).
+                if is_established(session_state) {
+                    log::warn!("BFD: {peer_addr} detection timeout");
+                    session_state = State::Down;
+                    your_disc = 0;
+                    expiry = None;
+                    let _ = event_tx.send(BfdEvent::SessionDown { peer_addr });
+                    write_state(&peer_states, peer_addr, session_state, rx_count, tx_count);
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RFC 5880 §6.8.6 state machine
+// ---------------------------------------------------------------------------
+
+fn next_state(current: State, remote: State) -> State {
+    match remote {
+        // Remote is admin-down: always Down regardless of current state.
+        State::AdminDown => State::Down,
+        State::Down => match current {
+            State::Down => State::Init,
+            State::Up => State::Down,
+            _ => current,
+        },
+        State::Init => match current {
+            State::Down | State::Init => State::Up,
+            _ => current,
+        },
+        State::Up => match current {
+            State::Init => State::Up,
+            _ => current,
+        },
+    }
+}
+
+fn is_established(s: State) -> bool {
+    matches!(s, State::Init | State::Up)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn write_state(
+    peer_states: &Arc<RwLock<HashMap<IpAddr, PeerStateSnapshot>>>,
+    addr: IpAddr,
+    state: State,
+    rx_packets: u64,
+    tx_packets: u64,
+) {
+    // api::BfdSessionState numeric values match the proto enum:
+    // 0=UNSPECIFIED, 1=UP, 2=DOWN, 3=ADMIN_DOWN, 4=INIT
+    let session_state = match state {
+        State::AdminDown => 3,
+        State::Down => 2,
+        State::Init => 4,
+        State::Up => 1,
+    };
+    if let Ok(mut ps) = peer_states.write()
+        && let Some(entry) = ps.get_mut(&addr)
+    {
+        entry.session_state = session_state;
+        entry.rx_packets = rx_packets;
+        entry.tx_packets = tx_packets;
+    }
+}
+
+async fn sleep_until_opt(deadline: Option<Instant>) {
+    match deadline {
+        Some(d) => tokio::time::sleep_until(d).await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Per-peer send context: owns the optional connected socket and holds
+/// references to the shared server socket + fixed peer parameters.
+struct SendCtx<'a> {
+    send_socket: Option<UdpSocket>,
+    server_socket: &'a UdpSocket,
+    peer_addr: IpAddr,
+    remote_port: u16,
+    config: &'a BfdPeerConfig,
+}
+
+impl SendCtx<'_> {
+    async fn send_packet(
+        &self,
+        state: State,
+        my_disc: u32,
+        your_disc: u32,
+        poll: bool,
+        final_: bool,
+    ) {
+        let msg = Message {
+            diagnostic: Diagnostic::NO_DIAGNOSTIC,
+            state,
+            poll,
+            final_,
+            control_plane_independent: false,
+            demand: false,
+            detect_multiplier: self.config.detect_multiplier,
+            my_discriminator: my_disc,
+            your_discriminator: your_disc,
+            desired_min_tx_interval: self.config.desired_min_tx_interval_us,
+            required_min_rx_interval: self.config.required_min_rx_interval_us,
+            required_min_echo_rx_interval: 0,
+        };
+        let buf = match msg.encode() {
+            Ok(b) => b,
+            Err(e) => {
+                log::error!("BFD: encode error: {e}");
+                return;
+            }
+        };
+
+        // Prefer the per-peer send socket (TTL=255, RFC-compliant source port).
+        // Fall back to server_socket with send_to if the per-peer socket failed.
+        if let Some(s) = &self.send_socket {
+            if let Err(e) = s.send(&buf).await {
+                log::debug!("BFD: send to {}: {e}", self.peer_addr);
+            }
+        } else {
+            let remote = SocketAddr::new(self.peer_addr, self.remote_port);
+            if let Err(e) = self.server_socket.send_to(&buf, remote).await {
+                log::debug!("BFD: send_to {}: {e}", self.peer_addr);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Socket creation
+// ---------------------------------------------------------------------------
+
+fn create_listen_socket() -> std::io::Result<UdpSocket> {
+    // Bind on all interfaces, port 3784.
+    let std_sock =
+        std::net::UdpSocket::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), BFD_PORT))?;
+
+    // GTSM (RFC 5881 §5): drop incoming packets with TTL < 255 in the kernel.
+    // IP_MINTTL (Linux ≥ 2.6.34) avoids the cost of checking TTL in userspace.
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::io::AsRawFd;
+        let val: libc::c_int = 255;
+        let ret = unsafe {
+            libc::setsockopt(
+                std_sock.as_raw_fd(),
+                libc::IPPROTO_IP,
+                libc::IP_MINTTL,
+                std::ptr::addr_of!(val).cast(),
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        };
+        if ret != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+
+    std_sock.set_nonblocking(true)?;
+    UdpSocket::from_std(std_sock)
+}
+
+/// Create a connected UDP socket for sending to one peer.
+/// Bound to a random source port in 49152–65535 (RFC 5881 §4).
+/// TTL is set to 255 (GTSM, RFC 5881 §5).
+fn create_send_socket(peer_addr: IpAddr, remote_port: u16) -> std::io::Result<Option<UdpSocket>> {
+    let remote = SocketAddr::new(peer_addr, remote_port);
+    let unspecified: IpAddr = match peer_addr {
+        IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+    };
+
+    // Try up to 64 ports in the required range before giving up.
+    let base = (next_disc() % (SRC_PORT_MAX - SRC_PORT_MIN + 1) as u32) as u16;
+    for i in 0u16..64 {
+        let port = SRC_PORT_MIN + (base + i) % (SRC_PORT_MAX - SRC_PORT_MIN + 1);
+        let bind_addr = SocketAddr::new(unspecified, port);
+        let std_sock = match std::net::UdpSocket::bind(bind_addr) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => continue,
+            Err(e) => return Err(e),
+        };
+        // connect() on a UDP socket just sets the default destination;
+        // it's a local syscall, not a network operation.
+        std_sock.connect(remote)?;
+        std_sock.set_nonblocking(true)?;
+        let sock = UdpSocket::from_std(std_sock)?;
+        // GTSM: set outgoing TTL to 255.
+        sock.set_ttl(255)?;
+        return Ok(Some(sock));
+    }
+
+    log::warn!(
+        "BFD: could not bind a source port in {SRC_PORT_MIN}-{SRC_PORT_MAX} \
+         for {peer_addr}; falling back to server socket"
+    );
+    Ok(None)
+}

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -270,6 +270,18 @@ impl TryFrom<&api::Peer> for PeerParams {
             send_max: FnvHashMap::default(),
             prefix_limits: FnvHashMap::default(),
             graceful_restart,
+            bfd_config: p.bfd.as_ref().and_then(|b| {
+                if b.enabled {
+                    Some(crate::bfd::BfdPeerConfig {
+                        desired_min_tx_interval_us: b.desired_minimum_tx_interval,
+                        required_min_rx_interval_us: b.required_minimum_receive,
+                        detect_multiplier: b.detection_multiplier as u8,
+                        port: b.port as u16,
+                    })
+                } else {
+                    None
+                }
+            }),
         })
     }
 }
@@ -776,6 +788,9 @@ impl GoBgpService for GrpcService {
                     for fd in &global.listen_sockets {
                         auth::set_md5sig(*fd, &peer_addr, "");
                     }
+                }
+                if let Some(bfd) = &global.bfd_handle {
+                    bfd.remove_peer(peer_addr);
                 }
                 return Ok(tonic::Response::new(api::DeletePeerResponse {}));
             } else {

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -699,6 +699,11 @@ pub(crate) struct Global {
     /// Sender end of the kernel event channel; cloned into KernelService::start.
     kernel_event_tx: mpsc::UnboundedSender<kernel::KernelEvent>,
 
+    /// BFD server handle.  None until at least one BFD-enabled peer exists.
+    pub(crate) bfd_handle: Option<crate::bfd::BfdHandle>,
+    /// Sender end of the BFD event channel; shared with bfd_handle.
+    bfd_event_tx: mpsc::UnboundedSender<crate::bfd::BfdEvent>,
+
     /// Sending on this channel causes the BGP listener loop to stop, enabling
     /// a subsequent start_bgp call to restart it.  None when BGP is not running.
     stop_tx: Option<tokio::sync::oneshot::Sender<()>>,
@@ -707,7 +712,10 @@ pub(crate) struct Global {
 impl Global {
     const BGP_PORT: u16 = 179;
 
-    fn new(kernel_event_tx: mpsc::UnboundedSender<kernel::KernelEvent>) -> Global {
+    fn new(
+        kernel_event_tx: mpsc::UnboundedSender<kernel::KernelEvent>,
+        bfd_event_tx: mpsc::UnboundedSender<crate::bfd::BfdEvent>,
+    ) -> Global {
         Global {
             asn: 0,
             router_id: Ipv4Addr::new(0, 0, 0, 0),
@@ -731,6 +739,9 @@ impl Global {
 
             kernel_service: None,
             kernel_event_tx,
+
+            bfd_handle: None,
+            bfd_event_tx,
 
             stop_tx: None,
         }
@@ -814,6 +825,8 @@ impl Global {
         {
             params.local_asn = conf.id;
         }
+        // Extract bfd_config before params.build() consumes params.
+        let bfd_config = params.bfd_config.take();
         let mut peer = params.build(u32::from(self.router_id), self.asn);
         if peer.admin_down {
             peer.state
@@ -823,7 +836,17 @@ impl Global {
         if let Some(tx) = tx {
             enable_active_connect(&mut peer, tx);
         }
-        self.peers.insert(peer.config.remote_addr, peer);
+        let addr = peer.config.remote_addr;
+        self.peers.insert(addr, peer);
+
+        // Register with BFD server if the peer has BFD enabled.
+        if let Some(bfd_cfg) = bfd_config {
+            let handle = self
+                .bfd_handle
+                .get_or_insert_with(|| crate::bfd::BfdHandle::start(self.bfd_event_tx.clone()));
+            handle.add_peer(addr, bfd_cfg);
+        }
+
         Ok(())
     }
 }
@@ -900,6 +923,7 @@ async fn accept_connection(
                 send_max: group.send_max.clone(),
                 prefix_limits: FnvHashMap::default(),
                 graceful_restart: group.graceful_restart.clone(),
+                bfd_config: None,
             };
             let _ = g.add_peer(params, None);
             g.peers.get_mut(&remote_addr).unwrap()
@@ -980,7 +1004,11 @@ impl Global {
     ) {
         let (kernel_event_tx, mut kernel_event_rx) =
             mpsc::unbounded_channel::<kernel::KernelEvent>();
-        let global: GlobalHandle = Arc::new(tokio::sync::RwLock::new(Global::new(kernel_event_tx)));
+        let (bfd_event_tx, mut bfd_event_rx) = mpsc::unbounded_channel::<crate::bfd::BfdEvent>();
+        let global: GlobalHandle = Arc::new(tokio::sync::RwLock::new(Global::new(
+            kernel_event_tx,
+            bfd_event_tx,
+        )));
         let tables: TableHandle = Arc::new(TableManager::new(num_cpus::get()));
         let global_config = bgp
             .as_ref()
@@ -1377,6 +1405,20 @@ impl Global {
                                 tables.handle_address_event(addr_event);
                             }
                             None => {}
+                        }
+                    }
+                    event = bfd_event_rx.recv().fuse() => {
+                        if let Some(crate::bfd::BfdEvent::SessionDown { peer_addr }) = event {
+                            let mut g = global.write().await;
+                            if let Some(peer) = g.peers.get_mut(&peer_addr) {
+                                // RFC 5882 §4.2: tear down BGP without NOTIFICATION.
+                                // CloseReason::Silent closes TCP silently and suppresses GR.
+                                peer.context.lock().unwrap().force_down(
+                                    CloseReason::Silent,
+                                    false,
+                                );
+                                log::info!("BFD: session down for {peer_addr}, BGP peer reset");
+                            }
                         }
                     }
                     stream = bgp_listen_futures.next() => {
@@ -3023,7 +3065,8 @@ mod tests {
 
     fn make_global() -> GlobalHandle {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut g = Global::new(tx);
+        let (bfd_tx, _bfd_rx) = mpsc::unbounded_channel();
+        let mut g = Global::new(tx, bfd_tx);
         g.asn = 65001;
         g.router_id = Ipv4Addr::new(1, 0, 0, 1);
         Arc::new(tokio::sync::RwLock::new(g))
@@ -3054,6 +3097,7 @@ mod tests {
             send_max: FnvHashMap::default(),
             prefix_limits: FnvHashMap::default(),
             graceful_restart: None,
+            bfd_config: None,
         }
     }
 
@@ -3195,7 +3239,8 @@ mod tests {
     #[test]
     fn confederation_api_parses_id_and_members() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut g = Global::new(tx);
+        let (bfd_tx, _bfd_rx) = mpsc::unbounded_channel();
+        let mut g = Global::new(tx, bfd_tx);
         g.asn = 65001;
         let conf = api::Confederation {
             enabled: true,
@@ -3218,7 +3263,8 @@ mod tests {
     #[test]
     fn confederation_api_disabled_flag_ignored() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut g = Global::new(tx);
+        let (bfd_tx, _bfd_rx) = mpsc::unbounded_channel();
+        let mut g = Global::new(tx, bfd_tx);
         g.asn = 65001;
         let conf = api::Confederation {
             enabled: false,
@@ -3242,7 +3288,8 @@ mod tests {
             member_as_list: Some(vec![65001, 65002]),
         };
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut g = Global::new(tx);
+        let (bfd_tx, _bfd_rx) = mpsc::unbounded_channel();
+        let mut g = Global::new(tx, bfd_tx);
         g.asn = 65001;
         if let Some((id, c)) = conf_config
             .enabled
@@ -3337,7 +3384,8 @@ mod tests {
     fn external_peer_gets_confederation_id_as_local_asn() {
         // RFC 5065 §4: OPEN my_as for non-member peers must be confederation id.
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut g = Global::new(tx);
+        let (bfd_tx, _bfd_rx) = mpsc::unbounded_channel();
+        let mut g = Global::new(tx, bfd_tx);
         g.asn = 65001;
         g.router_id = Ipv4Addr::new(1, 0, 0, 1);
         g.confederation = Some(ConfederationConfig {

--- a/daemon/src/event/peer.rs
+++ b/daemon/src/event/peer.rs
@@ -108,6 +108,7 @@ pub(crate) struct PeerParams {
     pub(crate) send_max: FnvHashMap<Family, usize>,
     pub(crate) prefix_limits: FnvHashMap<Family, u32>,
     pub(crate) graceful_restart: Option<GrPeerConfig>,
+    pub(crate) bfd_config: Option<crate::bfd::BfdPeerConfig>,
 }
 
 impl PeerParams {
@@ -450,6 +451,22 @@ impl TryFrom<&config::Neighbor> for PeerParams {
             send_max,
             prefix_limits,
             graceful_restart,
+            bfd_config: n
+                .bfd
+                .as_ref()
+                .and_then(|b| b.config.as_ref())
+                .and_then(|bc| {
+                    if bc.enabled.unwrap_or(false) {
+                        Some(crate::bfd::BfdPeerConfig {
+                            desired_min_tx_interval_us: bc.desired_minimum_tx_interval.unwrap_or(0),
+                            required_min_rx_interval_us: bc.required_minimum_receive.unwrap_or(0),
+                            detect_multiplier: bc.detection_multiplier.unwrap_or(0),
+                            port: 0,
+                        })
+                    } else {
+                        None
+                    }
+                }),
         })
     }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -18,6 +18,7 @@
 pub(crate) use rustybgp_api as api;
 pub(crate) use rustybgp_config as config;
 mod auth;
+mod bfd;
 mod bmp;
 mod convert;
 mod error;


### PR DESCRIPTION
BFD (RFC 5880) is used to detect BGP neighbor reachability failures faster than the BGP hold-timer allows.  This commit wires an internal BFD server into the daemon so that each BGP peer with a bfd_config gets a monitored BFD session.

When a BFD session goes Down, the daemon closes the BGP TCP session via CloseReason::Silent (no NOTIFICATION sent, GR disabled), implementing the teardown behaviour specified in RFC 5882.

Architecture:
- BfdHandle (mirroring kernel::Handle) exposes add_peer/remove_peer and is lazily initialised when the first BFD peer is configured.
- One server task owns the UDP socket on port 3784 and dispatches received packets to per-peer tasks.
- One peer task per BGP neighbor runs the RFC 5880 FSM, sends periodic Control packets, and fires the detection timer.
- BfdEvent::SessionDown is forwarded to the daemon event loop via an unbounded channel, matching the KernelEvent pattern.

GTSM (RFC 5881 §5): outgoing TTL is set to 255; on Linux the receive socket uses IP_MINTTL=255 so the kernel discards packets with TTL<255 before they reach userspace.

Source ports are drawn from the 49152-65535 range (RFC 5881 §4). Discriminators are generated from a global AtomicU64 counter.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>