### PR TITLE
daemon: extract gRPC server startup into start_grpc_server()

### DIFF
--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -655,6 +655,42 @@ impl GoBgpService for GrpcService {
                 ));
             }
         };
+
+        if let Some(listen_port) = global.listen_port {
+            let listen_addresses = if g.listen_addresses.is_empty() {
+                vec![
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), listen_port),
+                    SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), listen_port),
+                ]
+            } else {
+                g.listen_addresses
+                    .iter()
+                    .map(|addr| {
+                        let addr = IpAddr::from_str(addr).map_err(|_| {
+                            tonic::Status::new(
+                                tonic::Code::InvalidArgument,
+                                format!("invalid listen address: {}", addr),
+                            )
+                        })?;
+
+                        Ok::<std::net::SocketAddr, tonic::Status>(SocketAddr::new(
+                            addr,
+                            listen_port,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+            };
+
+            global.listen_sockets.append(
+                &mut listen_addresses
+                    .into_iter()
+                    .map(create_listen_socket)
+                    .filter_map(|x| x.ok())
+                    .map(|x| x.as_raw_fd())
+                    .collect(),
+            );
+        }
+
         global.router_id = Ipv4Addr::from_str(&g.router_id).map_err(|_| {
             tonic::Status::new(
                 tonic::Code::InvalidArgument,

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -1110,6 +1110,7 @@ impl Global {
         is_restarting: bool,
         active_tx: mpsc::UnboundedSender<TcpStream>,
         mut active_rx: mpsc::UnboundedReceiver<TcpStream>,
+        api_sockaddr: SocketAddr,
     ) {
         let (kernel_event_tx, mut kernel_event_rx) =
             mpsc::unbounded_channel::<kernel::KernelEvent>();
@@ -1354,7 +1355,7 @@ impl Global {
             tables.clone(),
             notify.clone(),
             active_tx.clone(),
-            "0.0.0.0:50051".parse().unwrap(),
+            api_sockaddr,
         );
 
         loop {
@@ -1486,9 +1487,22 @@ use crate::table_manager::{PeerDownData, PeerUpData, SubscriptionId, TableManage
 // Re-export for mrt.rs and bmp.rs which import from crate::event.
 pub(crate) use crate::table_manager::{AdjRibInChange, BgpEvent, TableHandle};
 
-pub(crate) async fn main(bgp: Option<config::BgpConfig>, any_peer: bool, is_restarting: bool) {
+pub(crate) async fn main(
+    bgp: Option<config::BgpConfig>,
+    any_peer: bool,
+    is_restarting: bool,
+    api_sockaddr: SocketAddr,
+) {
     let (active_tx, active_rx) = mpsc::unbounded_channel();
-    Global::serve(bgp, any_peer, is_restarting, active_tx, active_rx).await;
+    Global::serve(
+        bgp,
+        any_peer,
+        is_restarting,
+        active_tx,
+        active_rx,
+        api_sockaddr,
+    )
+    .await;
 }
 
 /// For an IPv6 socket, find the link-local address of the same interface.

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -1089,6 +1089,26 @@ async fn accept_connection(
     PeerSession::new(stream, remote_addr, role, Some(close_rx), res)
 }
 
+fn start_grpc_server(
+    global: GlobalHandle,
+    tables: TableHandle,
+    notify: Arc<tokio::sync::Notify>,
+    active_tx: mpsc::UnboundedSender<TcpStream>,
+    addr: SocketAddr,
+) {
+    tokio::spawn(async move {
+        if let Err(err) = tonic::transport::Server::builder()
+            .add_service(GoBgpServiceServer::new(GrpcService::new(
+                notify, active_tx, global, tables,
+            )))
+            .serve(addr)
+            .await
+        {
+            panic!("failed to listen on grpc {}", err);
+        }
+    });
+}
+
 impl Global {
     async fn serve(
         bgp: Option<config::BgpConfig>,
@@ -1334,22 +1354,15 @@ impl Global {
                 },
             );
         }
-        let addr = "0.0.0.0:50051".parse().unwrap();
-        let notify2 = notify.clone();
-        let active_tx2 = active_tx.clone();
-        let global2 = global.clone();
-        let tables2 = tables.clone();
-        tokio::spawn(async move {
-            if let Err(e) = tonic::transport::Server::builder()
-                .add_service(GoBgpServiceServer::new(GrpcService::new(
-                    notify2, active_tx2, global2, tables2,
-                )))
-                .serve(addr)
-                .await
-            {
-                panic!("failed to listen on grpc {}", e);
-            }
-        });
+
+        start_grpc_server(
+            global.clone(),
+            tables.clone(),
+            notify.clone(),
+            active_tx.clone(),
+            "0.0.0.0:50051".parse().unwrap(),
+        );
+
         loop {
             notify.notified().await;
             let listen_sockets = if let Some(listen_port) = global.read().await.listen_port {

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -611,12 +611,7 @@ pub(super) fn enable_active_connect(peer: &mut Peer, ch: mpsc::UnboundedSender<T
     ctx.active_connect_join_handle = Some(join_handle);
 }
 
-pub(super) fn create_listen_socket(
-    addr: String,
-    port: u16,
-) -> std::io::Result<std::net::TcpListener> {
-    let addr: std::net::SocketAddr = format!("{}:{}", addr, port).parse().unwrap();
-
+fn create_listen_socket(addr: SocketAddr) -> std::io::Result<std::net::TcpListener> {
     let sock = socket2::Socket::new(
         match addr {
             SocketAddr::V4(_) => socket2::Domain::IPV4,
@@ -701,7 +696,6 @@ impl Global {
             router_id: Ipv4Addr::new(0, 0, 0, 0),
             listen_port: None,
             listen_sockets: Vec::new(),
-
             peers: FnvHashMap::default(),
             peer_group: FnvHashMap::default(),
 
@@ -745,7 +739,7 @@ impl Global {
                     0 => Some(Global::BGP_PORT),
                     1..=65535 => Some(port as u16),
                     _ => return Err(Error::InvalidArgument("invalid listen port".to_string())),
-                };
+                }
             }
         }
 
@@ -1366,13 +1360,27 @@ impl Global {
         loop {
             notify.notified().await;
             let listen_sockets = if let Some(listen_port) = global.read().await.listen_port {
-                vec![
-                    create_listen_socket("0.0.0.0".to_string(), listen_port),
-                    create_listen_socket("[::]".to_string(), listen_port),
-                ]
-                .into_iter()
-                .filter_map(|x| x.ok())
-                .collect()
+                let addrs = if let Some(b) = bgp
+                    .as_ref()
+                    .and_then(|x| x.global.as_ref())
+                    .and_then(|g| g.config.as_ref())
+                    .and_then(|c| c.local_address_list.as_ref())
+                {
+                    b.iter()
+                        .map(|x| SocketAddr::new(*x, listen_port))
+                        .collect::<Vec<_>>()
+                } else {
+                    vec![
+                        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), listen_port),
+                        SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), listen_port),
+                    ]
+                };
+
+                addrs
+                    .into_iter()
+                    .map(create_listen_socket)
+                    .filter_map(|x| x.ok())
+                    .collect()
             } else {
                 Vec::new()
             };

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -938,172 +938,7 @@ impl Global {
         }
         Ok(())
     }
-}
 
-async fn accept_connection(
-    global: &GlobalHandle,
-    tables: &TableHandle,
-    stream: TcpStream,
-    role: crate::fsm::Role,
-) -> Option<PeerSession> {
-    let remote_sockaddr = stream.peer_addr().ok()?;
-    let remote_addr = remote_sockaddr.ip();
-    let mut g = global.write().await;
-    let is_restarting = g.selection_deferral.is_some();
-    let confederation = g.confederation.as_ref().map(|c| (c.id, c.members.clone()));
-    let peer = match g.peers.get_mut(&remote_addr) {
-        Some(peer) => {
-            if peer.admin_down {
-                log::warn!(
-                    "admin down; ignore a new passive connection from {}",
-                    remote_addr
-                );
-                return None;
-            }
-            let already_connected = {
-                let arb = peer.context.lock().unwrap();
-                let arb = arb.conn_arbiter.lock().unwrap();
-                match role {
-                    crate::fsm::Role::Active => arb.active_close_tx.is_some(),
-                    crate::fsm::Role::Passive => arb.passive_close_tx.is_some(),
-                }
-            };
-            if already_connected {
-                log::warn!("already has {:?} connection {}", role, remote_addr);
-                return None;
-            }
-            peer.state
-                .fsm
-                .store(SessionState::Active as u8, Ordering::Relaxed);
-            peer
-        }
-        None => {
-            let group = g.peer_group.values().find(|pg| {
-                pg.dynamic_peers
-                    .iter()
-                    .any(|d| d.prefix.contains(&remote_addr))
-            });
-            let Some(group) = group else {
-                log::warn!(
-                    "can't find configuration a new passive connection {}",
-                    remote_addr
-                );
-                return None;
-            };
-            let params = PeerParams {
-                remote_addr,
-                remote_port: Global::BGP_PORT,
-                expected_remote_asn: group.as_number,
-                local_asn: group.local_asn,
-                passive: group.passive,
-                rs_client: group.route_server_client,
-                route_reflector: group.route_reflector.clone(),
-                delete_on_disconnected: true,
-                admin_down: false,
-                state: SessionState::Active,
-                holdtime: group.holdtime.unwrap_or(PeerParams::DEFAULT_HOLD_TIME),
-                connect_retry_time: group
-                    .connect_retry_time
-                    .unwrap_or(PeerParams::DEFAULT_CONNECT_RETRY_TIME),
-                multihop_ttl: group.multihop_ttl,
-                ttl_security: group.ttl_security,
-                password: group.auth_password.clone(),
-                families: group.families.clone(),
-                send_max: group.send_max.clone(),
-                prefix_limits: FnvHashMap::default(),
-                graceful_restart: group.graceful_restart.clone(),
-                bfd_config: None,
-            };
-            let _ = g.add_peer(params, None);
-            g.peers.get_mut(&remote_addr).unwrap()
-        }
-    };
-    if let Some(ttl_min) = peer.config.ttl_security {
-        // GTSM (RFC 5082): send with TTL=255, drop incoming below ttl_min.
-        let _ = stream.set_ttl(255);
-        auth::set_min_ttl(stream.as_raw_fd(), &remote_addr, ttl_min);
-    } else if let Some(ttl) = peer.config.multihop_ttl {
-        if peer.config.expected_remote_asn != peer.config.local_asn {
-            let _ = stream.set_ttl(ttl.into());
-        }
-    } else {
-        let _ = stream.set_ttl(1);
-    }
-    let context = Arc::clone(&peer.context);
-    let (close_tx, close_rx) = tokio::sync::oneshot::channel::<CloseReason>();
-    {
-        let ctx = context.lock().unwrap();
-        let mut arb = ctx.conn_arbiter.lock().unwrap();
-        match role {
-            crate::fsm::Role::Active => arb.active_close_tx = Some(close_tx),
-            crate::fsm::Role::Passive => arb.passive_close_tx = Some(close_tx),
-        }
-    }
-    let peer_role = if peer.config.route_server_client {
-        PeerRole::RsClient
-    } else if peer.config.local_asn != 0 && peer.config.expected_remote_asn == peer.config.local_asn
-    {
-        if peer.config.route_reflector.route_reflector_client {
-            PeerRole::IbgpRrClient
-        } else {
-            PeerRole::Ibgp
-        }
-    } else if confederation
-        .as_ref()
-        .is_some_and(|(_, members)| members.contains(&peer.config.expected_remote_asn))
-    {
-        PeerRole::ConfedEbgp
-    } else {
-        PeerRole::Ebgp
-    };
-    let cluster_id = match peer_role {
-        PeerRole::Ibgp | PeerRole::IbgpRrClient => Some(
-            peer.config
-                .route_reflector
-                .route_reflector_cluster_id
-                .unwrap_or(peer.config.local_router_id),
-        ),
-        _ => None,
-    };
-    let res = PeerResources {
-        local_asn: peer.config.local_asn,
-        local_cap: peer.config.local_cap.to_owned(),
-        is_restarting,
-        role: peer_role,
-        prefix_limits: peer.config.prefix_limits.clone(),
-        state: peer.state.clone(),
-        counter_tx: peer.counter_tx.clone(),
-        counter_rx: peer.counter_rx.clone(),
-        tables: tables.clone(),
-        context,
-        local_router_id: peer.config.local_router_id,
-        cluster_id,
-        confederation_id: confederation.as_ref().map_or(0, |(id, _)| *id),
-    };
-    PeerSession::new(stream, remote_addr, role, Some(close_rx), res)
-}
-
-fn start_grpc_server(
-    global: GlobalHandle,
-    tables: TableHandle,
-    notify: Arc<tokio::sync::Notify>,
-    active_tx: mpsc::UnboundedSender<TcpStream>,
-    addr: SocketAddr,
-) {
-    tokio::spawn(async move {
-        if let Err(err) = tonic::transport::Server::builder()
-            .add_service(GoBgpServiceServer::new(GrpcService::new(
-                notify, active_tx, global, tables,
-            )))
-            .serve(addr)
-            .await
-        {
-            panic!("failed to listen on grpc {}", err);
-        }
-    });
-}
-
-impl Global {
     async fn serve(
         bgp: Option<config::BgpConfig>,
         any_peer: bool,
@@ -1481,6 +1316,169 @@ impl Global {
             global.write().await.listen_sockets.clear();
         }
     }
+}
+
+async fn accept_connection(
+    global: &GlobalHandle,
+    tables: &TableHandle,
+    stream: TcpStream,
+    role: crate::fsm::Role,
+) -> Option<PeerSession> {
+    let remote_sockaddr = stream.peer_addr().ok()?;
+    let remote_addr = remote_sockaddr.ip();
+    let mut g = global.write().await;
+    let is_restarting = g.selection_deferral.is_some();
+    let confederation = g.confederation.as_ref().map(|c| (c.id, c.members.clone()));
+    let peer = match g.peers.get_mut(&remote_addr) {
+        Some(peer) => {
+            if peer.admin_down {
+                log::warn!(
+                    "admin down; ignore a new passive connection from {}",
+                    remote_addr
+                );
+                return None;
+            }
+            let already_connected = {
+                let arb = peer.context.lock().unwrap();
+                let arb = arb.conn_arbiter.lock().unwrap();
+                match role {
+                    crate::fsm::Role::Active => arb.active_close_tx.is_some(),
+                    crate::fsm::Role::Passive => arb.passive_close_tx.is_some(),
+                }
+            };
+            if already_connected {
+                log::warn!("already has {:?} connection {}", role, remote_addr);
+                return None;
+            }
+            peer.state
+                .fsm
+                .store(SessionState::Active as u8, Ordering::Relaxed);
+            peer
+        }
+        None => {
+            let group = g.peer_group.values().find(|pg| {
+                pg.dynamic_peers
+                    .iter()
+                    .any(|d| d.prefix.contains(&remote_addr))
+            });
+            let Some(group) = group else {
+                log::warn!(
+                    "can't find configuration a new passive connection {}",
+                    remote_addr
+                );
+                return None;
+            };
+            let params = PeerParams {
+                remote_addr,
+                remote_port: Global::BGP_PORT,
+                expected_remote_asn: group.as_number,
+                local_asn: group.local_asn,
+                passive: group.passive,
+                rs_client: group.route_server_client,
+                route_reflector: group.route_reflector.clone(),
+                delete_on_disconnected: true,
+                admin_down: false,
+                state: SessionState::Active,
+                holdtime: group.holdtime.unwrap_or(PeerParams::DEFAULT_HOLD_TIME),
+                connect_retry_time: group
+                    .connect_retry_time
+                    .unwrap_or(PeerParams::DEFAULT_CONNECT_RETRY_TIME),
+                multihop_ttl: group.multihop_ttl,
+                ttl_security: group.ttl_security,
+                password: group.auth_password.clone(),
+                families: group.families.clone(),
+                send_max: group.send_max.clone(),
+                prefix_limits: FnvHashMap::default(),
+                graceful_restart: group.graceful_restart.clone(),
+                bfd_config: None,
+            };
+            let _ = g.add_peer(params, None);
+            g.peers.get_mut(&remote_addr).unwrap()
+        }
+    };
+    if let Some(ttl_min) = peer.config.ttl_security {
+        // GTSM (RFC 5082): send with TTL=255, drop incoming below ttl_min.
+        let _ = stream.set_ttl(255);
+        auth::set_min_ttl(stream.as_raw_fd(), &remote_addr, ttl_min);
+    } else if let Some(ttl) = peer.config.multihop_ttl {
+        if peer.config.expected_remote_asn != peer.config.local_asn {
+            let _ = stream.set_ttl(ttl.into());
+        }
+    } else {
+        let _ = stream.set_ttl(1);
+    }
+    let context = Arc::clone(&peer.context);
+    let (close_tx, close_rx) = tokio::sync::oneshot::channel::<CloseReason>();
+    {
+        let ctx = context.lock().unwrap();
+        let mut arb = ctx.conn_arbiter.lock().unwrap();
+        match role {
+            crate::fsm::Role::Active => arb.active_close_tx = Some(close_tx),
+            crate::fsm::Role::Passive => arb.passive_close_tx = Some(close_tx),
+        }
+    }
+    let peer_role = if peer.config.route_server_client {
+        PeerRole::RsClient
+    } else if peer.config.local_asn != 0 && peer.config.expected_remote_asn == peer.config.local_asn
+    {
+        if peer.config.route_reflector.route_reflector_client {
+            PeerRole::IbgpRrClient
+        } else {
+            PeerRole::Ibgp
+        }
+    } else if confederation
+        .as_ref()
+        .is_some_and(|(_, members)| members.contains(&peer.config.expected_remote_asn))
+    {
+        PeerRole::ConfedEbgp
+    } else {
+        PeerRole::Ebgp
+    };
+    let cluster_id = match peer_role {
+        PeerRole::Ibgp | PeerRole::IbgpRrClient => Some(
+            peer.config
+                .route_reflector
+                .route_reflector_cluster_id
+                .unwrap_or(peer.config.local_router_id),
+        ),
+        _ => None,
+    };
+    let res = PeerResources {
+        local_asn: peer.config.local_asn,
+        local_cap: peer.config.local_cap.to_owned(),
+        is_restarting,
+        role: peer_role,
+        prefix_limits: peer.config.prefix_limits.clone(),
+        state: peer.state.clone(),
+        counter_tx: peer.counter_tx.clone(),
+        counter_rx: peer.counter_rx.clone(),
+        tables: tables.clone(),
+        context,
+        local_router_id: peer.config.local_router_id,
+        cluster_id,
+        confederation_id: confederation.as_ref().map_or(0, |(id, _)| *id),
+    };
+    PeerSession::new(stream, remote_addr, role, Some(close_rx), res)
+}
+
+fn start_grpc_server(
+    global: GlobalHandle,
+    tables: TableHandle,
+    notify: Arc<tokio::sync::Notify>,
+    active_tx: mpsc::UnboundedSender<TcpStream>,
+    addr: SocketAddr,
+) {
+    tokio::spawn(async move {
+        if let Err(err) = tonic::transport::Server::builder()
+            .add_service(GoBgpServiceServer::new(GrpcService::new(
+                notify, active_tx, global, tables,
+            )))
+            .serve(addr)
+            .await
+        {
+            panic!("failed to listen on grpc {}", err);
+        }
+    });
 }
 
 use crate::table_manager::{PeerDownData, PeerUpData, SubscriptionId, TableManager};

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -168,7 +168,7 @@ use crate::fsm::State as SessionState;
 /// `PeerSession` via `Arc`.  All fields are atomics so they can be updated by
 /// the session task without taking the global lock.  Reset at the start of each
 /// new BGP session; the `Arc` itself lives as long as either side holds a clone.
-pub(super) struct SessionAddrs {
+struct SessionAddrs {
     local: SocketAddr,
     remote_port: u16,
 }
@@ -1542,7 +1542,7 @@ fn find_link_local(local: &SocketAddr) -> Option<Ipv6Addr> {
 /// GR state negotiated during the last OPEN exchange.
 /// Stored in DisconnectInfo so PeerSession::run can drive GrState on session drop.
 #[derive(Clone)]
-pub(super) struct NegotiatedGr {
+struct NegotiatedGr {
     /// Intersection of local and remote GR families.
     families: Vec<Family>,
     /// Restart Time from the peer's OPEN GR capability.

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -30,9 +30,10 @@ mod peer_tx;
 mod proto;
 mod rpki;
 mod table_manager;
+use std::str::FromStr;
 
 use clap::{Arg, Command};
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
@@ -70,6 +71,12 @@ async fn main() -> Result<(), std::io::Error> {
                 .long("graceful-restart")
                 .action(clap::ArgAction::SetTrue)
                 .help("set Restart State bit (R) in GR capability; clear after all peers send EOR"),
+        )
+        .arg(
+            Arg::new("api-hosts")
+                .long("api-hosts")
+                .num_args(1)
+                .help("specify the host that the API server listens on (default: 0.0.0.0:50051)"),
         )
         .get_matches();
 
@@ -110,10 +117,17 @@ async fn main() -> Result<(), std::io::Error> {
 
     log::info!("Hello, RustyBGPd ({} cpus)!", num_cpus::get());
 
+    let api_sockaddr = if let Some(api_hosts) = args.get_one::<String>("api-hosts") {
+        SocketAddr::from_str(api_hosts).expect("invalid API host address")
+    } else {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 50051)
+    };
+
     event::main(
         conf,
         args.get_flag("any"),
         args.get_flag("graceful-restart"),
+        api_sockaddr,
     )
     .await;
     Ok(())


### PR DESCRIPTION
Global::serve() has grown large and mixes the gRPC startup concern with the peer-accept loop. Extracting the spawn into a dedicated function separates the two responsibilities and makes each easier to follow.