### PR TITLE
daemon: use per-peer local address as nexthop for locally originated …

### DIFF
--- a/daemon/src/event/export.rs
+++ b/daemon/src/event/export.rs
@@ -216,7 +216,11 @@ impl PeerExportContext {
     /// eBGP: replace with local_addr (with link-local for IPv6 when available).
     /// iBGP / iBGP-RR-client / RS client: pass through unchanged (next-hop
     /// unchanged).
-    pub(super) fn export_nexthop(&self, nexthop: Option<bgp::Nexthop>) -> Option<bgp::Nexthop> {
+    pub(super) fn export_nexthop(
+        &self,
+        nexthop: Option<bgp::Nexthop>,
+        family: Family,
+    ) -> Option<bgp::Nexthop> {
         let local = || match self.local_addr {
             IpAddr::V4(v4) => bgp::Nexthop::V4(v4),
             IpAddr::V6(v6) => {
@@ -227,9 +231,19 @@ impl PeerExportContext {
                 }
             }
         };
+        let is_flowspec = matches!(
+            family,
+            Family::IPV4_FLOWSPEC
+                | Family::IPV6_FLOWSPEC
+                | Family::IPV4_FLOWSPEC_VPN
+                | Family::IPV6_FLOWSPEC_VPN
+        );
         match (self.role, nexthop) {
             // Flowspec carries no nexthop (RFC 8955 §4): preserve None.
-            (_, None) => None,
+            (_, None) if is_flowspec => None,
+            // No stored nexthop for non-Flowspec (e.g. locally originated RTC):
+            // use per-peer local address.
+            (_, None) => Some(local()),
             (PeerRole::RsClient | PeerRole::Ibgp | PeerRole::IbgpRrClient, Some(nh)) => Some(nh),
             (PeerRole::ConfedEbgp | PeerRole::Ebgp, Some(_)) => Some(local()),
         }
@@ -394,7 +408,7 @@ pub(super) fn process_nlri_change<S: NlriSink>(
             Some((best, attr, nexthop)) => {
                 export_map.mark_sent(update.family, update.net.clone(), 0);
                 let attr = export_ctx.export_attrs(&attr);
-                let nexthop = export_ctx.export_nexthop(nexthop);
+                let nexthop = export_ctx.export_nexthop(nexthop, update.family);
                 sink.reach(update.net.clone(), 0, nexthop, attr, &best.source);
             }
         }
@@ -462,7 +476,7 @@ pub(super) fn process_nlri_change<S: NlriSink>(
             if !already_sent || was_replaced {
                 export_map.mark_sent(update.family, update.net.clone(), *pid);
                 let attr = export_ctx.export_attrs(attr);
-                let nexthop = export_ctx.export_nexthop(*nexthop);
+                let nexthop = export_ctx.export_nexthop(*nexthop, update.family);
                 sink.reach(update.net.clone(), *pid, nexthop, attr, source);
             }
         }

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -6451,7 +6451,7 @@ mod tests {
         fn ebgp_export_rewrites_nexthop() {
             let ctx = ebgp_ctx(); // local_addr = 127.0.0.1
             let original = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
-            let exported = ctx.export_nexthop(Some(original));
+            let exported = ctx.export_nexthop(Some(original), Family::IPV4);
             assert_eq!(
                 exported,
                 Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1))),
@@ -6463,7 +6463,7 @@ mod tests {
         fn ibgp_export_keeps_nexthop() {
             let ctx = ibgp_ctx();
             let original = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
-            let exported = ctx.export_nexthop(Some(original));
+            let exported = ctx.export_nexthop(Some(original), Family::IPV4);
             assert_eq!(exported, Some(original), "iBGP nexthop must be unchanged");
         }
 
@@ -6575,7 +6575,7 @@ mod tests {
         fn confed_ebgp_export_nexthop_rewrites_to_local() {
             let ctx = confed_ebgp_ctx(); // local_addr = 127.0.0.1
             let original = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
-            let exported = ctx.export_nexthop(Some(original));
+            let exported = ctx.export_nexthop(Some(original), Family::IPV4);
             assert_eq!(
                 exported,
                 Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1))),


### PR DESCRIPTION
…non-Flowspec routes

export_nexthop() treated nexthop=None as Flowspec-only (RFC 8955 §4), but locally originated routes such as RTC NLRIs (RFC 4684) are also inserted without a stored nexthop.  With the old logic they were sent with 16 zero bytes as the MP_REACH_NLRI nexthop field.

Distinguish the two cases by checking the family: Flowspec keeps None; all other families fall back to the per-peer local address, which is the correct nexthop for locally originated routes on both eBGP and iBGP sessions.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>