### PR TITLE
convert: use RouteTargetMembershipNlri for RTC NLRI in API responses

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -276,12 +276,22 @@ pub(crate) fn nlri_to_api(f: &Nlri) -> api::Nlri {
             })),
         },
         Nlri::Evpn(n) => evpn_nlri_to_api(n),
-        Nlri::Rtc(n) => api::Nlri {
-            nlri: Some(api::nlri::Nlri::Prefix(api::IpAddressPrefix {
-                prefix: n.to_string(),
-                prefix_len: 0,
-            })),
-        },
+        Nlri::Rtc(n) => {
+            use packet::rtc::MatchType;
+            let (asn, rt) = match &n.match_type {
+                MatchType::Wildcard => (0, None),
+                MatchType::AsWildcard { origin_as } => (*origin_as, None),
+                MatchType::ExactMatch {
+                    origin_as,
+                    route_target,
+                } => (*origin_as, Some(rt_to_api(route_target))),
+            };
+            api::Nlri {
+                nlri: Some(api::nlri::Nlri::RouteTargetMembership(
+                    api::RouteTargetMembershipNlri { asn, rt },
+                )),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The gRPC API has a dedicated RouteTargetMembershipNlri message (NLRI oneof tag 12) for AFI=1/SAFI=132 paths.  nlri_to_api() was wrapping RTC NLRIs in IpAddressPrefix instead, so gobgp CLI received an unrecognised variant and displayed "?" for the Network column.

Wildcard and AS-wildcard match types carry no RT, so rt is set to None; exact-match uses the existing rt_to_api() helper to build the typed RouteTarget from the 8-byte wire value.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>