### PR TITLE
grpc: advertise VRF import RTs (not export RTs) as RTC NLRI

### DIFF
--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -1866,7 +1866,7 @@ impl GoBgpService for GrpcService {
             .iter()
             .map(convert::rt_from_api)
             .collect::<Result<Vec<_>, _>>()?;
-        let nlris = export_rt
+        let nlris = import_rt
             .iter()
             .map(|rt| packet::PathNlri {
                 path_id: 0,
@@ -1910,7 +1910,7 @@ impl GoBgpService for GrpcService {
         }
         let vrf = self.tables.delete_vrf(&name).map_err(Error::Table)?;
         let nlris = vrf
-            .export_rt
+            .import_rt
             .iter()
             .map(|rt| packet::PathNlri {
                 path_id: 0,


### PR DESCRIPTION
RFC 4684 section 4 requires a BGP speaker to advertise an RTC NLRI for each Route Target it locally *imports*, so that remote peers know which VPN routes to send.  Both add_vrf and delete_vrf were using the export RT set instead, which caused RustyBGP to signal the wrong set of RTs and miss VPN routes whose RT matched only an import RT.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>