### PR TITLE
daemon: apply PeerGroup settings to static peers

### DIFF
--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -800,8 +800,18 @@ impl GoBgpService for GrpcService {
         request: tonic::Request<api::AddPeerRequest>,
     ) -> Result<tonic::Response<api::AddPeerResponse>, tonic::Status> {
         let api_peer = request.into_inner().peer.ok_or(Error::EmptyArgument)?;
-        let params = PeerParams::try_from(&api_peer)?;
+        let mut params = PeerParams::try_from(&api_peer)?;
         let mut global = self.global.write().await;
+        let pg_name = api_peer
+            .conf
+            .as_ref()
+            .map(|c| c.peer_group.as_str())
+            .unwrap_or_default();
+        if !pg_name.is_empty()
+            && let Some(pg) = global.peer_group.get(pg_name)
+        {
+            params.apply_peer_group(pg);
+        }
         if let Some(password) = params.password.as_ref() {
             for fd in &global.listen_sockets {
                 auth::set_md5sig(*fd, &params.remote_addr, password);

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -1073,7 +1073,11 @@ impl Global {
             let mut server = global.write().await;
             for p in peers {
                 match PeerParams::try_from(p) {
-                    Ok(params) => {
+                    Ok(mut params) => {
+                        let pg_name = p.config.as_ref().and_then(|c| c.peer_group.as_deref());
+                        if let Some(pg) = pg_name.and_then(|name| server.peer_group.get(name)) {
+                            params.apply_peer_group(pg);
+                        }
                         if let Err(e) = server.add_peer(params, Some(active_tx.clone())) {
                             log::error!("failed to add peer from config: {}", e);
                         }
@@ -4284,6 +4288,69 @@ mod tests {
         };
         let pg = PeerGroup::from(&cfg_pg);
         assert_eq!(pg.ttl_security, Some(255u8));
+    }
+
+    // --- PeerParams::apply_peer_group tests ---
+
+    fn make_pg_for_apply() -> PeerGroup {
+        PeerGroup::from(&make_config_peer_group())
+    }
+
+    fn make_minimal_neighbor_config(addr: &str) -> config::Neighbor {
+        config::Neighbor {
+            config: Some(config::NeighborConfig {
+                neighbor_address: Some(addr.parse().unwrap()),
+                peer_as: Some(0),
+                peer_group: Some("test-grp".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn apply_peer_group_fills_password() {
+        let n = make_minimal_neighbor_config("10.0.0.1");
+        let mut params = PeerParams::try_from(&n).unwrap();
+        assert!(params.password.is_none());
+        params.apply_peer_group(&make_pg_for_apply());
+        assert_eq!(params.password, Some("test-secret".to_string()));
+    }
+
+    #[test]
+    fn apply_peer_group_does_not_override_existing_password() {
+        let mut n = make_minimal_neighbor_config("10.0.0.1");
+        n.config.as_mut().unwrap().auth_password = Some("peer-secret".to_string());
+        let mut params = PeerParams::try_from(&n).unwrap();
+        params.apply_peer_group(&make_pg_for_apply());
+        assert_eq!(params.password, Some("peer-secret".to_string()));
+    }
+
+    #[test]
+    fn apply_peer_group_fills_holdtime() {
+        let n = make_minimal_neighbor_config("10.0.0.1");
+        let mut params = PeerParams::try_from(&n).unwrap();
+        assert_eq!(params.holdtime, PeerParams::DEFAULT_HOLD_TIME);
+        params.apply_peer_group(&make_pg_for_apply());
+        assert_eq!(params.holdtime, 90);
+    }
+
+    #[test]
+    fn apply_peer_group_fills_as_number() {
+        let n = make_minimal_neighbor_config("10.0.0.1");
+        let mut params = PeerParams::try_from(&n).unwrap();
+        assert_eq!(params.expected_remote_asn, 0);
+        params.apply_peer_group(&make_pg_for_apply());
+        assert_eq!(params.expected_remote_asn, 65002);
+    }
+
+    #[test]
+    fn apply_peer_group_does_not_override_existing_as_number() {
+        let mut n = make_minimal_neighbor_config("10.0.0.1");
+        n.config.as_mut().unwrap().peer_as = Some(65100);
+        let mut params = PeerParams::try_from(&n).unwrap();
+        params.apply_peer_group(&make_pg_for_apply());
+        assert_eq!(params.expected_remote_asn, 65100);
     }
 
     #[tokio::test]

--- a/daemon/src/event/peer.rs
+++ b/daemon/src/event/peer.rs
@@ -183,6 +183,54 @@ impl PeerParams {
         local_cap
     }
 
+    /// Apply peer group settings as fallback for fields not explicitly set on
+    /// this peer.  Called after constructing `PeerParams` from a config or API
+    /// request when the peer belongs to a named peer group.
+    pub(crate) fn apply_peer_group(&mut self, pg: &PeerGroup) {
+        if self.expected_remote_asn == 0 && pg.as_number != 0 {
+            self.expected_remote_asn = pg.as_number;
+        }
+        if self.local_asn == 0 && pg.local_asn != 0 {
+            self.local_asn = pg.local_asn;
+        }
+        if self.holdtime == Self::DEFAULT_HOLD_TIME
+            && let Some(h) = pg.holdtime
+        {
+            self.holdtime = h;
+        }
+        if self.connect_retry_time == Self::DEFAULT_CONNECT_RETRY_TIME
+            && let Some(t) = pg.connect_retry_time
+        {
+            self.connect_retry_time = t;
+        }
+        if self.password.is_none() {
+            self.password = pg.auth_password.clone();
+        }
+        if self.multihop_ttl.is_none() {
+            self.multihop_ttl = pg.multihop_ttl;
+        }
+        if self.ttl_security.is_none() {
+            self.ttl_security = pg.ttl_security;
+        }
+        if self.families.is_empty() {
+            self.families = pg.families.clone();
+            self.send_max = pg.send_max.clone();
+        }
+        if self.graceful_restart.is_none() {
+            self.graceful_restart = pg.graceful_restart.clone();
+        }
+        if !self.passive && pg.passive {
+            self.passive = true;
+        }
+        if !self.rs_client && pg.route_server_client {
+            self.rs_client = true;
+        }
+        if !self.route_reflector.route_reflector_client && pg.route_reflector.route_reflector_client
+        {
+            self.route_reflector = pg.route_reflector.clone();
+        }
+    }
+
     /// Build a `Peer` from these params.
     ///
     /// `local_router_id` is needed to construct `PeerFsm` for collision


### PR DESCRIPTION
Static peers configured with a peer_group reference did not inherit any PeerGroup settings (auth_password, holdtime, families, etc.) because no inheritance step existed: PeerParams was constructed from the neighbor stanza alone and peer_group was treated as a label only.

Add PeerParams::apply_peer_group() that copies each PeerGroup field into the PeerParams when the peer has not set that field itself, using type-appropriate "unset" sentinels (None, 0, empty map, or the DEFAULT_* constants).  Call it from both the config-file loading path and the gRPC AddPeer handler, matching the behavior of GoBGP's OverwriteNeighborConfigWithPeerGroup.

Dynamic peers still receive PeerGroup settings at session-accept time (where they are already handled), so the new call sites cover only static peers.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>