### PR TITLE
bmp: fix TERMINATION and ROUTE_MIRRORING message type constants

### DIFF
--- a/packet/src/bmp.rs
+++ b/packet/src/bmp.rs
@@ -28,8 +28,8 @@ impl Message {
     pub const PEER_DOWN: u8 = 2;
     pub const PEER_UP: u8 = 3;
     pub const INITIATION: u8 = 4;
-    pub const TERMINATION: u8 = 6;
-    pub const ROUTE_MIRRORING: u8 = 7;
+    pub const TERMINATION: u8 = 5;
+    pub const ROUTE_MIRRORING: u8 = 6;
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
RFC 7854 assigns:
  Termination Message    = 5
  Route Mirroring Message = 6

The constants were off by one (6 and 7), which caused BMP Termination and Route Mirroring messages to be encoded with wrong type bytes, breaking interoperability with any RFC-compliant BMP receiver.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>