### PR TITLE
bmp: add Adj-RIB-In post-policy monitoring (RFC 7854 L flag)

### DIFF
--- a/daemon/src/bmp.rs
+++ b/daemon/src/bmp.rs
@@ -80,6 +80,7 @@ fn flush_peer_snapshot(
             });
             messages.push(bmp::Message::RouteMonitoring {
                 header: bmp::PerPeerHeader::new(
+                    0,
                     change.source.remote_asn,
                     Ipv4Addr::from(change.source.router_id),
                     0,
@@ -289,6 +290,31 @@ impl BmpClient {
                             if lines
                                 .send(&bmp::Message::RouteMonitoring {
                                     header: bmp::PerPeerHeader::new(
+                                        0,
+                                        change.source.remote_asn,
+                                        Ipv4Addr::from(change.source.router_id),
+                                        0,
+                                        change.source.remote_addr,
+                                        change.timestamp
+                                            .duration_since(SystemTime::UNIX_EPOCH)
+                                            .unwrap_or_default()
+                                            .as_secs() as u32,
+                                    ),
+                                    update,
+                                    addpath: change.addpath,
+                                })
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Some(BgpEvent::AdjRibInPost(change)) => {
+                            let update = adj_rib_in_to_bmp_update(&change);
+                            if lines
+                                .send(&bmp::Message::RouteMonitoring {
+                                    header: bmp::PerPeerHeader::new(
+                                        bmp::Message::PEER_FLAG_POST_POLICY,
                                         change.source.remote_asn,
                                         Ipv4Addr::from(change.source.router_id),
                                         0,
@@ -311,6 +337,7 @@ impl BmpClient {
                             let remote_id = Ipv4Addr::from(data.peer_id);
                             let m = bmp::Message::PeerUp {
                                 header: bmp::PerPeerHeader::new(
+                                    0,
                                     data.peer_asn,
                                     remote_id,
                                     0,
@@ -332,6 +359,7 @@ impl BmpClient {
                         Some(BgpEvent::PeerDown(data)) => {
                             let m = bmp::Message::PeerDown {
                                 header: bmp::PerPeerHeader::new(
+                                    0,
                                     data.peer_asn,
                                     Ipv4Addr::from(data.peer_id),
                                     0,
@@ -469,6 +497,7 @@ mod tests {
 
     fn dummy_header(addr: &str) -> bmp::PerPeerHeader {
         bmp::PerPeerHeader::new(
+            0,
             65000,
             "192.0.2.1".parse().unwrap(),
             0,

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -1280,6 +1280,7 @@ impl GoBgpService for GrpcService {
                             )),
                         }
                     }
+                    BgpEvent::AdjRibInPost(_) => continue,
                 };
                 if tx.send(Ok(r)).await.is_err() {
                     break;

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -423,6 +423,7 @@ impl Peer {
         let remote_asn = self.state.remote_asn.load(Ordering::Relaxed);
         let remote_id = Ipv4Addr::from(self.state.remote_id.load(Ordering::Relaxed));
         let peer_header = bmp::PerPeerHeader::new(
+            0,
             remote_asn,
             remote_id,
             0,

--- a/daemon/src/mrt.rs
+++ b/daemon/src/mrt.rs
@@ -112,7 +112,9 @@ impl MrtDumper {
                             codec.encode(&msg, &mut buf)?;
                             file.write_all(&buf).await?;
                         }
-                        Some(BgpEvent::PeerUp(_)) | Some(BgpEvent::PeerDown(_)) => {}
+                        Some(BgpEvent::AdjRibInPost(_))
+                        | Some(BgpEvent::PeerUp(_))
+                        | Some(BgpEvent::PeerDown(_)) => {}
                         None => return Ok(()),
                     }
                 }

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -66,6 +66,7 @@ pub(crate) struct PeerDownData {
 
 pub(crate) enum BgpEvent {
     AdjRibIn(AdjRibInChange),
+    AdjRibInPost(AdjRibInChange),
     PeerUp(PeerUpData),
     PeerDown(PeerDownData),
 }
@@ -279,6 +280,25 @@ impl TableManager {
         let original_attr = Arc::clone(&attr);
         let (filtered, post_policy_attr) =
             self.apply_import(import_policy.as_deref(), &source, &net.nlri, &attr, &mut nh);
+        if filtered {
+            t.notify_adj_rib_in_post(
+                source.clone(),
+                family,
+                std::slice::from_ref(&net),
+                None,
+                None,
+                timestamp,
+            );
+        } else {
+            t.notify_adj_rib_in_post(
+                source.clone(),
+                family,
+                std::slice::from_ref(&net),
+                Some(&post_policy_attr),
+                nh,
+                timestamp,
+            );
+        }
         let nexthop_invalid_flag = nh.is_some_and(|n| nht_set.contains(&n.addr()));
         let pl = prefix_limit.as_ref().map(|(max, counter)| (*max, counter));
         match t.rtable.insert(
@@ -319,6 +339,14 @@ impl TableManager {
         let idx = self.dealer(&net.nlri);
         let mut t = self.shards[idx].lock().unwrap();
         t.notify_adj_rib_in(
+            source.clone(),
+            family,
+            std::slice::from_ref(&net),
+            None,
+            None,
+            timestamp,
+        );
+        t.notify_adj_rib_in_post(
             source.clone(),
             family,
             std::slice::from_ref(&net),
@@ -605,6 +633,20 @@ impl TableManager {
                         nexthop: reach.nexthop,
                         timestamp: reach.timestamp,
                     });
+                }
+                // Post-policy snapshot sent via channel; arrives before any live events
+                // for this shard because t.subscribers.insert() follows below.
+                for reach in t.rtable.iter_reach_post(f) {
+                    let addpath = t.has_addpath(&reach.source.remote_addr, &f);
+                    let _ = tx.send(BgpEvent::AdjRibInPost(AdjRibInChange {
+                        source: reach.source,
+                        family: f,
+                        addpath,
+                        nlris: vec![reach.net],
+                        attrs: Some(reach.attr),
+                        nexthop: reach.nexthop,
+                        timestamp: reach.timestamp,
+                    }));
                 }
             }
             t.subscribers.insert(id, tx.clone());
@@ -966,6 +1008,29 @@ impl TableShard {
         }
     }
 
+    fn notify_adj_rib_in_post(
+        &self,
+        source: Arc<table::Source>,
+        family: Family,
+        nets: &[packet::PathNlri],
+        attrs: Option<&Arc<Vec<packet::Attribute>>>,
+        nexthop: Option<bgp::Nexthop>,
+        timestamp: std::time::SystemTime,
+    ) {
+        let addpath = self.has_addpath(&source.remote_addr, &family);
+        for tx in self.subscribers.values() {
+            let _ = tx.send(BgpEvent::AdjRibInPost(AdjRibInChange {
+                source: source.clone(),
+                family,
+                addpath,
+                nlris: nets.to_owned(),
+                attrs: attrs.cloned(),
+                nexthop,
+                timestamp,
+            }));
+        }
+    }
+
     fn distribute_update(
         &self,
         update: table::NlriChange,
@@ -1062,6 +1127,29 @@ impl TableShard {
             } else {
                 (false, Arc::clone(&original_attr))
             };
+            let path_nlri = packet::PathNlri {
+                nlri: net.clone(),
+                path_id: remote_path_id,
+            };
+            if filtered {
+                self.notify_adj_rib_in_post(
+                    source.clone(),
+                    family,
+                    &[path_nlri],
+                    None,
+                    None,
+                    timestamp,
+                );
+            } else {
+                self.notify_adj_rib_in_post(
+                    source.clone(),
+                    family,
+                    &[path_nlri],
+                    Some(&post_policy_attr),
+                    nh,
+                    timestamp,
+                );
+            }
             let nexthop_invalid_flag = nh.is_some_and(|n| nexthop_invalid.contains(&n.addr()));
             // Propagate policy-induced nexthop change into NHT tracking.
             if !source.is_kernel()

--- a/packet/src/bmp.rs
+++ b/packet/src/bmp.rs
@@ -30,10 +30,18 @@ impl Message {
     pub const INITIATION: u8 = 4;
     pub const TERMINATION: u8 = 5;
     pub const ROUTE_MIRRORING: u8 = 6;
+
+    /// Per-peer header flag: peer address is IPv6 (RFC 7854 §4.2, V flag).
+    pub const PEER_FLAG_IPV6: u8 = 0x80;
+    /// Per-peer header flag: Adj-RIB-In post-policy (RFC 7854 §4.2, L flag).
+    pub const PEER_FLAG_POST_POLICY: u8 = 0x40;
 }
 
 #[derive(Clone)]
 pub struct PerPeerHeader {
+    /// Caller-supplied per-peer flags (L, O, A, …).
+    /// The V (IPv6) flag is computed from `remote_addr` at encode time.
+    flags: u8,
     pub asn: u32,
     id: Ipv4Addr,
     distinguisher: u64,
@@ -43,6 +51,7 @@ pub struct PerPeerHeader {
 
 impl PerPeerHeader {
     pub fn new(
+        flags: u8,
         asn: u32,
         id: Ipv4Addr,
         distinguisher: u64,
@@ -50,6 +59,7 @@ impl PerPeerHeader {
         timestamp: u32,
     ) -> Self {
         PerPeerHeader {
+            flags,
             asn,
             id,
             distinguisher,
@@ -59,14 +69,15 @@ impl PerPeerHeader {
     }
 
     fn encode(&self, c: &mut BytesMut) -> Result<(), Error> {
-        // type
+        // peer type: 0 = Global Instance Peer
         c.put_u8(0);
-        // only adj-in is supported
-        let mut flags = 0;
-        if self.remote_addr.is_ipv6() {
-            flags |= 1;
-        }
-        c.put_u8(flags);
+        let wire_flags = self.flags
+            | if self.remote_addr.is_ipv6() {
+                Message::PEER_FLAG_IPV6
+            } else {
+                0
+            };
+        c.put_u8(wire_flags);
         c.put_u64(self.distinguisher);
         Message::encode_ip(c, &self.remote_addr);
         c.put_u32(self.asn);

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -847,6 +847,32 @@ impl Table {
             })
     }
 
+    /// Post-import-policy Adj-RIB-In snapshot: filtered entries are excluded
+    /// and `path.attr` (post-policy attributes) is returned.
+    pub fn iter_reach_post(&self, family: Family) -> impl Iterator<Item = Reach> + '_ {
+        self.ribs
+            .get(&family)
+            .unwrap_or_else(|| self.ribs.get(&Family::EMPTY).unwrap())
+            .destinations
+            .iter()
+            .flat_map(move |(net, dst)| {
+                dst.entry
+                    .iter()
+                    .filter(|e| !e.is_filtered())
+                    .map(move |e| Reach {
+                        source: e.path.source.clone(),
+                        family,
+                        net: packet::bgp::PathNlri {
+                            nlri: net.clone(),
+                            path_id: e.remote_path_id,
+                        },
+                        attr: e.path.attr.clone(),
+                        nexthop: e.path.nexthop,
+                        timestamp: e.timestamp,
+                    })
+            })
+    }
+
     pub fn families(&self) -> impl Iterator<Item = Family> + '_ {
         self.ribs.keys().filter(|f| **f != Family::EMPTY).copied()
     }


### PR DESCRIPTION
RFC 7854 §4.2 defines an L flag (bit 6 = 0x40) in the per-peer header to distinguish pre-policy (L=0) and post-policy (L=1) Adj-RIB-In Route Monitoring messages.  RustyBGP previously sent only pre-policy messages with flags=0.

Changes:

packet/src/bmp.rs
- Add PEER_FLAG_IPV6 (0x80) and PEER_FLAG_POST_POLICY (0x40) constants.
- Add a `flags` field to PerPeerHeader and expose it via new().
- Fix the IPv6 flag encoding: was 0x01 (wrong bit), now 0x80 per RFC.
- The V (IPv6) bit is merged in encode() so callers need not set it.

table/src/lib.rs
- Add iter_reach_post(): same as iter_reach() but skips filtered entries and returns path.attr (post-policy) instead of original_attr.

daemon/src/table_manager.rs
- Add BgpEvent::AdjRibInPost variant.
- Add TableShard::notify_adj_rib_in_post() mirroring notify_adj_rib_in().
- insert_route(): call notify_adj_rib_in_post() after apply_import(); sends Reach for accepted routes, Withdraw for filtered ones.
- remove_route(): call notify_adj_rib_in_post() with attrs=None.
- TableShard::soft_reset_in(): same pattern - notify_adj_rib_in_post() after each path's policy re-evaluation.
- subscribe_with(): send AdjRibInPost events via tx during snapshot so the initial burst arrives before any live events for each shard.

daemon/src/bmp.rs
- Handle BgpEvent::AdjRibInPost with PEER_FLAG_POST_POLICY in the live event loop.
- Update all PerPeerHeader::new() call sites to pass flags=0 (pre) or PEER_FLAG_POST_POLICY (post).

daemon/src/event/grpc.rs, mrt.rs
- Add AdjRibInPost match arms: watch_event skips it (pre-policy only semantics preserved), MRT ignores it (records pre-policy).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>