### PR TITLE
convert: add L2VpnFlowspec to unsupported family test

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -6248,6 +6248,7 @@ bgp-actions.set-next-hop = "self"
             AfiSafiType::L3VpnIpv4Multicast,
             AfiSafiType::L3VpnIpv6Multicast,
             AfiSafiType::L2VpnVpls,
+            AfiSafiType::L2VpnFlowspec,
             AfiSafiType::Ipv4Encap,
             AfiSafiType::Ipv6Encap,
             AfiSafiType::Opaque,


### PR DESCRIPTION
L2VpnFlowspec has no corresponding Family constant and falls through to the _ => Err(()) arm in family_from_config, but was not listed in the unsupported test, leaving a gap in coverage.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>