### PR TITLE
bmp: add Adj-RIB-Out monitoring (RFC 8671)

### DIFF
--- a/daemon/src/bmp.rs
+++ b/daemon/src/bmp.rs
@@ -25,7 +25,7 @@ use tokio_util::sync::CancellationToken;
 
 use rustybgp_packet::{self as packet, Family, bgp, bmp};
 
-use crate::event::{AdjRibInChange, BgpEvent, GlobalHandle, TableHandle};
+use crate::event::{AdjRibInChange, AdjRibOutChange, BgpEvent, GlobalHandle, TableHandle};
 
 /// Net-state snapshot: (family, nlri) -> single-nlri AdjRibInChange per peer.
 type SnapshotMap = FnvHashMap<IpAddr, FnvHashMap<(Family, packet::PathNlri), AdjRibInChange>>;
@@ -121,6 +121,23 @@ fn adj_rib_in_to_bmp_update(change: &AdjRibInChange) -> bgp::Message {
         bgp::Message::Update(bgp::Update::Unreach {
             family: change.family,
             entries: change.nlris.clone(),
+        })
+    }
+}
+
+/// Convert a live `AdjRibOutChange` to the BGP UPDATE used in RouteMonitoring.
+fn adj_rib_out_to_bmp_update(change: &AdjRibOutChange) -> bgp::Message {
+    if let Some(ref attrs) = change.attrs {
+        bgp::Message::Update(bgp::Update::Reach {
+            family: change.family,
+            entries: vec![change.nlri.clone()],
+            nexthop: change.nexthop,
+            attr: attrs.clone(),
+        })
+    } else {
+        bgp::Message::Update(bgp::Update::Unreach {
+            family: change.family,
+            entries: vec![change.nlri.clone()],
         })
     }
 }
@@ -320,6 +337,57 @@ impl BmpClient {
                                         0,
                                         change.source.remote_addr,
                                         change.timestamp
+                                            .duration_since(SystemTime::UNIX_EPOCH)
+                                            .unwrap_or_default()
+                                            .as_secs() as u32,
+                                    ),
+                                    update,
+                                    addpath: change.addpath,
+                                })
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Some(BgpEvent::AdjRibOutPre(change)) => {
+                            let update = adj_rib_out_to_bmp_update(&change);
+                            if lines
+                                .send(&bmp::Message::RouteMonitoring {
+                                    header: bmp::PerPeerHeader::new(
+                                        bmp::Message::PEER_FLAG_ADJ_RIB_OUT,
+                                        change.peer_asn,
+                                        Ipv4Addr::from(change.peer_id),
+                                        0,
+                                        change.peer_addr,
+                                        change
+                                            .timestamp
+                                            .duration_since(SystemTime::UNIX_EPOCH)
+                                            .unwrap_or_default()
+                                            .as_secs() as u32,
+                                    ),
+                                    update,
+                                    addpath: change.addpath,
+                                })
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Some(BgpEvent::AdjRibOutPost(change)) => {
+                            let update = adj_rib_out_to_bmp_update(&change);
+                            if lines
+                                .send(&bmp::Message::RouteMonitoring {
+                                    header: bmp::PerPeerHeader::new(
+                                        bmp::Message::PEER_FLAG_ADJ_RIB_OUT
+                                            | bmp::Message::PEER_FLAG_POST_POLICY,
+                                        change.peer_asn,
+                                        Ipv4Addr::from(change.peer_id),
+                                        0,
+                                        change.peer_addr,
+                                        change
+                                            .timestamp
                                             .duration_since(SystemTime::UNIX_EPOCH)
                                             .unwrap_or_default()
                                             .as_secs() as u32,

--- a/daemon/src/event/export.rs
+++ b/daemon/src/event/export.rs
@@ -15,14 +15,113 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use fnv::{FnvHashMap, FnvHashSet};
+use tokio::sync::mpsc;
 
 use rustybgp_packet::{self as packet, Family, bgp};
 use rustybgp_table as table;
 use table::PeerRole;
 
 use super::*;
+
+/// Carries pre-collected BMP subscriber senders for one export invocation.
+///
+/// Build once per `handle_prefix_update()` call when subscribers exist, then
+/// pass as `Option<&BmpAdjOut>` into `process_nlri_change()`.  Routes that are
+/// skipped (same best, filtered by RTC, etc.) never reach this struct.
+pub(super) struct BmpAdjOut {
+    senders: Vec<mpsc::UnboundedSender<crate::table_manager::BgpEvent>>,
+    peer_addr: IpAddr,
+    peer_asn: u32,
+    peer_id: u32,
+    addpath: bool,
+    timestamp: SystemTime,
+}
+
+impl BmpAdjOut {
+    pub(super) fn new(
+        senders: Vec<mpsc::UnboundedSender<crate::table_manager::BgpEvent>>,
+        peer_addr: IpAddr,
+        peer_asn: u32,
+        peer_id: u32,
+        addpath: bool,
+    ) -> Self {
+        BmpAdjOut {
+            senders,
+            peer_addr,
+            peer_asn,
+            peer_id,
+            addpath,
+            timestamp: SystemTime::now(),
+        }
+    }
+
+    fn send(
+        &self,
+        post: bool,
+        family: Family,
+        nlri: packet::Nlri,
+        path_id: u32,
+        attrs: Option<Arc<Vec<packet::Attribute>>>,
+        nexthop: Option<bgp::Nexthop>,
+    ) {
+        use crate::table_manager::{AdjRibOutChange, BgpEvent};
+        let change = AdjRibOutChange {
+            peer_addr: self.peer_addr,
+            peer_asn: self.peer_asn,
+            peer_id: self.peer_id,
+            family,
+            addpath: self.addpath,
+            nlri: packet::PathNlri { path_id, nlri },
+            attrs,
+            nexthop,
+            timestamp: self.timestamp,
+        };
+        if post {
+            for tx in &self.senders {
+                let _ = tx.send(BgpEvent::AdjRibOutPost(change.clone()));
+            }
+        } else {
+            for tx in &self.senders {
+                let _ = tx.send(BgpEvent::AdjRibOutPre(change.clone()));
+            }
+        }
+    }
+
+    /// Notify pre-policy (after echo-prevention / split-horizon, before export policy).
+    /// `route` is None for withdrawals.
+    pub(super) fn pre(
+        &self,
+        family: Family,
+        nlri: packet::Nlri,
+        path_id: u32,
+        route: Option<(Arc<Vec<packet::Attribute>>, Option<bgp::Nexthop>)>,
+    ) {
+        let (attrs, nh) = match route {
+            Some((a, nh)) => (Some(a), nh),
+            None => (None, None),
+        };
+        self.send(false, family, nlri, path_id, attrs, nh);
+    }
+
+    /// Notify post-policy (after export policy and nexthop/attr rewrite).
+    /// `route` is None for withdrawals.
+    pub(super) fn post(
+        &self,
+        family: Family,
+        nlri: packet::Nlri,
+        path_id: u32,
+        route: Option<(Arc<Vec<packet::Attribute>>, Option<bgp::Nexthop>)>,
+    ) {
+        let (attrs, nh) = match route {
+            Some((a, nh)) => (Some(a), nh),
+            None => (None, None),
+        };
+        self.send(true, family, nlri, path_id, attrs, nh);
+    }
+}
 
 #[derive(Clone)]
 pub(super) struct ExportMap {
@@ -354,6 +453,7 @@ pub(super) fn process_nlri_change<S: NlriSink>(
     export_policy: Option<&table::PolicyAssignment>,
     cluster_id: Option<Ipv4Addr>,
     rpki: Option<&table::RpkiTable>,
+    bmp: Option<&BmpAdjOut>,
 ) {
     if effective_max == 1 {
         // Non-Add-Path fast path: O(1) skip when best unchanged.
@@ -375,6 +475,15 @@ pub(super) fn process_nlri_change<S: NlriSink>(
             }
             Some(best)
         });
+        // BMP Adj-RIB-Out pre-policy: what would be exported before per-peer policy.
+        if let Some(bmp) = bmp {
+            bmp.pre(
+                update.family,
+                update.net.clone(),
+                0,
+                visible_best.map(|b| (Arc::clone(&b.attr), b.nexthop)),
+            );
+        }
         // Apply export policy to the visible best; a rejected best is treated
         // as if no best exists (withdraw if previously advertised).
         let policy_result = visible_best.and_then(|best| {
@@ -404,6 +513,11 @@ pub(super) fn process_nlri_change<S: NlriSink>(
         });
         match policy_result {
             None => {
+                // BMP post-policy Withdraw: always emit so the receiver can track
+                // routes blocked by export policy (not gated by was_sent).
+                if let Some(bmp) = bmp {
+                    bmp.post(update.family, update.net.clone(), 0, None);
+                }
                 if export_map.was_sent(update.family, &update.net) {
                     export_map.mark_withdrawn(update.family, &update.net, 0);
                     sink.unreach(update.net.clone(), 0);
@@ -413,6 +527,15 @@ pub(super) fn process_nlri_change<S: NlriSink>(
                 export_map.mark_sent(update.family, update.net.clone(), 0);
                 let attr = export_ctx.export_attrs(&attr);
                 let nexthop = export_ctx.export_nexthop(nexthop, update.family);
+                // BMP post-policy Reach: use the fully-rewritten attr/nexthop.
+                if let Some(bmp) = bmp {
+                    bmp.post(
+                        update.family,
+                        update.net.clone(),
+                        0,
+                        Some((Arc::clone(&attr), nexthop)),
+                    );
+                }
                 sink.reach(update.net.clone(), 0, nexthop, attr, &best.source);
             }
         }
@@ -470,6 +593,9 @@ pub(super) fn process_nlri_change<S: NlriSink>(
             current_top_n.iter().map(|(pid, _, _, _)| *pid).collect();
         for &pid in sent_ids.difference(&current_ids) {
             export_map.mark_withdrawn(update.family, &update.net, pid);
+            if let Some(bmp) = bmp {
+                bmp.post(update.family, update.net.clone(), pid, None);
+            }
             sink.unreach(update.net.clone(), pid);
         }
 
@@ -481,6 +607,14 @@ pub(super) fn process_nlri_change<S: NlriSink>(
                 export_map.mark_sent(update.family, update.net.clone(), *pid);
                 let attr = export_ctx.export_attrs(attr);
                 let nexthop = export_ctx.export_nexthop(*nexthop, update.family);
+                if let Some(bmp) = bmp {
+                    bmp.post(
+                        update.family,
+                        update.net.clone(),
+                        *pid,
+                        Some((Arc::clone(&attr), nexthop)),
+                    );
+                }
                 sink.reach(update.net.clone(), *pid, nexthop, attr, source);
             }
         }

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -1281,6 +1281,8 @@ impl GoBgpService for GrpcService {
                         }
                     }
                     BgpEvent::AdjRibInPost(_) => continue,
+                    BgpEvent::AdjRibOutPre(_) => continue,
+                    BgpEvent::AdjRibOutPost(_) => continue,
                 };
                 if tx.send(Ok(r)).await.is_err() {
                     break;
@@ -1744,6 +1746,7 @@ impl GoBgpService for GrpcService {
                             export_policy.as_deref(),
                             cluster_id,
                             Some(&rpki),
+                            None,
                         );
                     }
                     let destinations = sink.destinations;

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -159,7 +159,7 @@ pub(super) use peer::{
 };
 
 mod export;
-use export::{AdjOutSink, ExportMap, PeerExportContext};
+use export::{AdjOutSink, BmpAdjOut, ExportMap, PeerExportContext};
 use export::{inject_local_pref_if_absent, is_as_loop, process_nlri_change};
 
 use crate::fsm::State as SessionState;
@@ -1511,7 +1511,7 @@ fn start_grpc_server(
 
 use crate::table_manager::{PeerDownData, PeerUpData, SubscriptionId, TableManager};
 // Re-export for mrt.rs and bmp.rs which import from crate::event.
-pub(crate) use crate::table_manager::{AdjRibInChange, BgpEvent, TableHandle};
+pub(crate) use crate::table_manager::{AdjRibInChange, AdjRibOutChange, BgpEvent, TableHandle};
 
 pub(crate) async fn main(
     bgp: Option<config::BgpConfig>,
@@ -2239,6 +2239,7 @@ impl PeerSession {
                             export_policy.as_deref(),
                             self.cluster_id,
                             Some(&rpki),
+                            None,
                         );
                     }
                 }
@@ -2330,6 +2331,7 @@ impl PeerSession {
                 export_policy.as_deref(),
                 self.cluster_id,
                 Some(&rpki),
+                None,
             );
         }
         for (nlri, path_ids) in old_sent {
@@ -2784,6 +2786,17 @@ impl PeerSession {
         };
         let export_policy = self.tables.export_policy.load_full();
         let rpki = self.tables.rpki.read().unwrap();
+        // Build BMP Adj-RIB-Out context only when subscribers are present.
+        let bmp_senders = self.tables.bmp_senders();
+        let bmp = (!bmp_senders.is_empty()).then(|| {
+            BmpAdjOut::new(
+                bmp_senders,
+                self.remote_addr,
+                self.state.remote_asn.load(Ordering::Relaxed),
+                self.state.remote_id.load(Ordering::Relaxed),
+                effective_max > 1,
+            )
+        });
         process_nlri_change(
             &update,
             effective_max,
@@ -2794,6 +2807,7 @@ impl PeerSession {
             export_policy.as_deref(),
             self.cluster_id,
             Some(&rpki),
+            bmp.as_ref(),
         );
     }
 
@@ -5950,6 +5964,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             assert!(pending.is_empty());
@@ -5971,6 +5986,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
                 None,
@@ -6003,6 +6019,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             assert!(!em.was_sent(Family::IPV4, &net));
@@ -6026,6 +6043,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
                 None,
@@ -6054,6 +6072,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             assert!(pending.is_empty());
@@ -6079,6 +6098,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
             assert!(em.was_sent(Family::IPV4, &net));
             pending.drain_messages(Family::IPV4); // flush
@@ -6091,6 +6111,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
                 None,
@@ -6120,6 +6141,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             assert!(pending.is_empty());
@@ -6141,6 +6163,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
                 None,
@@ -6177,6 +6200,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             assert!(em.contains_path(Family::IPV4, &net, 1));
@@ -6206,6 +6230,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
                 None,
@@ -6240,6 +6265,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
                 None,
@@ -6282,6 +6308,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             assert!(!em.contains_path(Family::IPV4, &net, 1)); // withdrawn
@@ -6311,6 +6338,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
                 None,
@@ -6344,6 +6372,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             assert!(pending.is_empty());
@@ -6373,6 +6402,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ebgp_ctx(),
+                None,
                 None,
                 None,
                 None,
@@ -6430,6 +6460,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             // Split horizon: iBGP-learned route must not be forwarded to iBGP peer
@@ -6455,6 +6486,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ibgp_ctx(),
+                None,
                 None,
                 None,
                 None,
@@ -6485,6 +6517,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             // eBGP-learned route CAN be forwarded to iBGP peer
@@ -6511,6 +6544,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &ibgp_ctx(),
+                None,
                 None,
                 None,
                 None,
@@ -6997,6 +7031,7 @@ mod tests {
                 None,
                 Some(CLUSTER_ID),
                 None,
+                None,
             );
 
             assert!(pending.is_empty());
@@ -7021,6 +7056,7 @@ mod tests {
                 &ibgp_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
                 None,
             );
 
@@ -7049,6 +7085,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
                 None,
             );
 
@@ -7108,6 +7145,7 @@ mod tests {
                 None,
                 Some(CLUSTER_ID),
                 None,
+                None,
             );
 
             let attrs = drain_first_reach_attrs(&mut pending);
@@ -7147,6 +7185,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
                 None,
             );
 
@@ -7189,6 +7228,7 @@ mod tests {
                 None,
                 Some(CLUSTER_ID),
                 None,
+                None,
             );
 
             let attrs = drain_first_reach_attrs(&mut pending);
@@ -7224,6 +7264,7 @@ mod tests {
                 None,
                 Some(CLUSTER_ID),
                 None,
+                None,
             );
 
             let attrs = drain_first_reach_attrs(&mut pending);
@@ -7256,6 +7297,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
                 None,
             );
 
@@ -7292,6 +7334,7 @@ mod tests {
                 &ibgp_rr_client_ctx(),
                 None,
                 Some(CLUSTER_ID),
+                None,
                 None,
             );
 
@@ -7345,6 +7388,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             assert!(!em.was_sent(Family::IPV4, &net));
@@ -7373,6 +7417,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             );
 
             assert!(!em.was_sent(Family::IPV4, &net));
@@ -7398,6 +7443,7 @@ mod tests {
                 &mut em,
                 &mut pending,
                 &rs_client_ctx(),
+                None,
                 None,
                 None,
                 None,

--- a/daemon/src/mrt.rs
+++ b/daemon/src/mrt.rs
@@ -139,6 +139,8 @@ impl MrtDumper {
                             file.write_all(&buf).await?;
                         }
                         Some(BgpEvent::AdjRibInPost(_))
+                        | Some(BgpEvent::AdjRibOutPre(_))
+                        | Some(BgpEvent::AdjRibOutPost(_))
                         | Some(BgpEvent::PeerUp(_))
                         | Some(BgpEvent::PeerDown(_)) => {}
                         None => return Ok(()),

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -64,9 +64,27 @@ pub(crate) struct PeerDownData {
     pub(crate) reason: rustybgp_packet::bmp::PeerDownReason,
 }
 
+/// An Adj-RIB-Out update for one neighbor (RFC 8671).
+/// `attrs` is `None` for withdrawals; `Some` for route announcements.
+#[derive(Clone)]
+pub(crate) struct AdjRibOutChange {
+    /// The neighbor this Adj-RIB-Out entry belongs to.
+    pub(crate) peer_addr: IpAddr,
+    pub(crate) peer_asn: u32,
+    pub(crate) peer_id: u32,
+    pub(crate) family: Family,
+    pub(crate) addpath: bool,
+    pub(crate) nlri: packet::PathNlri,
+    pub(crate) attrs: Option<Arc<Vec<packet::Attribute>>>,
+    pub(crate) nexthop: Option<bgp::Nexthop>,
+    pub(crate) timestamp: std::time::SystemTime,
+}
+
 pub(crate) enum BgpEvent {
     AdjRibIn(AdjRibInChange),
     AdjRibInPost(AdjRibInChange),
+    AdjRibOutPre(AdjRibOutChange),
+    AdjRibOutPost(AdjRibOutChange),
     PeerUp(PeerUpData),
     PeerDown(PeerDownData),
 }
@@ -695,6 +713,14 @@ impl TableManager {
         for tx in subs.values() {
             let _ = tx.send(BgpEvent::PeerDown(data.clone()));
         }
+    }
+
+    /// Collect the current set of BMP/MRT subscriber senders.
+    ///
+    /// Returns an empty Vec when no subscribers are registered, letting callers
+    /// skip Adj-RIB-Out notification cheaply in the common (no-BMP) case.
+    pub(crate) fn bmp_senders(&self) -> Vec<mpsc::UnboundedSender<BgpEvent>> {
+        self.subscribers.lock().unwrap().values().cloned().collect()
     }
 
     /// Register a peer's event channel with every shard atomically.

--- a/packet/src/bmp.rs
+++ b/packet/src/bmp.rs
@@ -35,6 +35,8 @@ impl Message {
     pub const PEER_FLAG_IPV6: u8 = 0x80;
     /// Per-peer header flag: Adj-RIB-In post-policy (RFC 7854 §4.2, L flag).
     pub const PEER_FLAG_POST_POLICY: u8 = 0x40;
+    /// Per-peer header flag: Adj-RIB-Out direction (RFC 8671 §4.1, O flag).
+    pub const PEER_FLAG_ADJ_RIB_OUT: u8 = 0x10;
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
RFC 8671 defines two new BMP Adj-RIB-Out modes distinguished by per-peer header flags: O=0x10 (Adj-RIB-Out direction) and L=0x40 (post-policy).

Pre-policy (O=1, L=0) captures routes visible to a peer after echo prevention and split-horizon, before per-peer export policy is applied. Post-policy (O=1, L=1) captures what the peer actually receives after the full export pipeline including nexthop and attribute rewriting.

For non-Add-Path sessions both hooks fire on every best-path change.  For Add-Path sessions only the post-policy hook fires (mirroring each unreach/reach sent).  No initial snapshot is sent for Adj-RIB-Out because the RFC says SHOULD NOT and GoBGP takes the same approach.

Implementation: BmpAdjOut is built once per handle_prefix_update() call by collecting subscriber senders from TableManager.  It is passed as Option<&BmpAdjOut> into process_nlri_change() so callers without BMP subscribers pay only a pointer-size check.  The initial table dump and do_route_refresh paths pass None since they do not represent live state changes suitable for Adj-RIB-Out monitoring.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>