### PR TITLE
bmp: accept post-policy and both monitoring policies in add_bmp

### DIFF
--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -2667,11 +2667,15 @@ impl GoBgpService for GrpcService {
         let addr = IpAddr::from_str(&request.address)
             .map_err(|_| tonic::Status::new(tonic::Code::InvalidArgument, "invalid address"))?;
 
-        if request.policy != api::add_bmp_request::MonitoringPolicy::Pre as i32 {
-            return Err(tonic::Status::new(
-                tonic::Code::InvalidArgument,
-                "unsupported policy (only pre-policy supporeted",
-            ));
+        {
+            use api::add_bmp_request::MonitoringPolicy as P;
+            let p = request.policy;
+            if p != P::Pre as i32 && p != P::Post as i32 && p != P::Both as i32 {
+                return Err(tonic::Status::new(
+                    tonic::Code::InvalidArgument,
+                    "unsupported monitoring policy",
+                ));
+            }
         }
 
         let sockaddr = SocketAddr::new(addr, request.port as u16);


### PR DESCRIPTION
The add_bmp gRPC handler was rejecting any policy other than PRE. The infrastructure already handles AdjRibInPost events end-to-end: subscribe_with() snapshots post-policy routes at subscribe time, and the bmp.rs live loop forwards AdjRibInPost as RouteMonitoring with the L flag (0x40) set per RFC 7854. Accepting POST and BOTH removes the API-level gate that was the only barrier to using these modes.

LOCAL (RFC 9069 Loc-RIB) and ALL remain unsupported until the Loc-RIB event infrastructure is implemented.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>