### PR TITLE
table_manager: unify subscribe_with/subscribe_live into subscribe(bool)

### DIFF
--- a/daemon/src/bmp.rs
+++ b/daemon/src/bmp.rs
@@ -263,8 +263,20 @@ impl BmpClient {
             .await;
 
         let mut snapshot: SnapshotMap = FnvHashMap::default();
-        let subscription = tables.subscribe_with(|change| apply_snapshot(&mut snapshot, change));
-        let rx = subscription.rx;
+        let subscription = tables.subscribe(true);
+        let sub_id = subscription.id;
+        let mut rx = UnboundedReceiverStream::new(subscription.rx);
+
+        // Drain snapshot phase until EndOfSnapshot sentinel.
+        // Concurrent AdjRibIn events that arrived during snapshotting are also
+        // fed to apply_snapshot so the map reflects the net state at subscribe time.
+        while let Some(event) = rx.next().await {
+            match event {
+                BgpEvent::AdjRibIn(change) => apply_snapshot(&mut snapshot, change),
+                BgpEvent::EndOfSnapshot => break,
+                _ => {} // PeerUp/Down reconstructed from global state below
+            }
+        }
 
         // Send PeerUp for all established peers.
         let local_id = global.read().await.router_id;
@@ -273,7 +285,7 @@ impl BmpClient {
         for peer in global.read().await.peers.values() {
             if let Some((addr, peer_header, msg)) = peer.bmp_peer_up(local_id) {
                 if !send_peer_up(&mut sent_peer_up, &mut lines, addr, &msg).await {
-                    tables.unsubscribe(subscription.id);
+                    tables.unsubscribe(sub_id);
                     return;
                 }
                 established_peers.push((addr, peer_header));
@@ -284,14 +296,13 @@ impl BmpClient {
         for (addr, peer_header) in &established_peers {
             for msg in flush_peer_snapshot(&mut snapshot, *addr, peer_header) {
                 if lines.send(&msg).await.is_err() {
-                    tables.unsubscribe(subscription.id);
+                    tables.unsubscribe(sub_id);
                     return;
                 }
             }
         }
 
         // Live event loop.
-        let mut rx = UnboundedReceiverStream::new(rx);
         loop {
             tokio::select! {
                 msg = lines.next() => {
@@ -442,13 +453,13 @@ impl BmpClient {
                                 break;
                             }
                         }
-                        None => break,
+                        Some(BgpEvent::EndOfSnapshot) | None => break,
                     }
                 }
                 _ = cancel.cancelled() => break,
             }
         }
-        tables.unsubscribe(subscription.id);
+        tables.unsubscribe(sub_id);
     }
 
     pub(crate) fn try_connect(

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -1198,7 +1198,7 @@ impl GoBgpService for GrpcService {
     ) -> Result<tonic::Response<Self::WatchEventStream>, tonic::Status> {
         let tables2 = self.tables.clone();
         let global2 = self.global.clone();
-        let subscription = self.tables.subscribe_live();
+        let subscription = self.tables.subscribe(false);
         let sub_id = subscription.id;
         let (tx, rx) = mpsc::channel(1024);
         let cancel = CancellationToken::new();
@@ -1280,9 +1280,10 @@ impl GoBgpService for GrpcService {
                             )),
                         }
                     }
-                    BgpEvent::AdjRibInPost(_) => continue,
-                    BgpEvent::AdjRibOutPre(_) => continue,
-                    BgpEvent::AdjRibOutPost(_) => continue,
+                    BgpEvent::AdjRibInPost(_)
+                    | BgpEvent::AdjRibOutPre(_)
+                    | BgpEvent::AdjRibOutPost(_)
+                    | BgpEvent::EndOfSnapshot => continue,
                 };
                 if tx.send(Ok(r)).await.is_err() {
                     break;

--- a/daemon/src/mrt.rs
+++ b/daemon/src/mrt.rs
@@ -83,7 +83,7 @@ impl MrtDumper {
         cancel: CancellationToken,
         tables: TableHandle,
     ) -> Result<(), Error> {
-        let subscription = tables.subscribe_live();
+        let subscription = tables.subscribe(false);
         let result = self.run_loop(&mut file, subscription.rx, cancel).await;
         tables.unsubscribe(subscription.id);
         result
@@ -142,7 +142,8 @@ impl MrtDumper {
                         | Some(BgpEvent::AdjRibOutPre(_))
                         | Some(BgpEvent::AdjRibOutPost(_))
                         | Some(BgpEvent::PeerUp(_))
-                        | Some(BgpEvent::PeerDown(_)) => {}
+                        | Some(BgpEvent::PeerDown(_))
+                        | Some(BgpEvent::EndOfSnapshot) => {}
                         None => return Ok(()),
                     }
                 }

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -87,6 +87,8 @@ pub(crate) enum BgpEvent {
     AdjRibOutPost(AdjRibOutChange),
     PeerUp(PeerUpData),
     PeerDown(PeerDownData),
+    /// Sentinel sent by `subscribe(true)` after all snapshot events have been queued.
+    EndOfSnapshot,
 }
 
 pub(crate) struct Subscription {
@@ -631,12 +633,15 @@ impl TableManager {
         out
     }
 
-    /// Subscribe with snapshot: calls `on_change` for each current route (per shard, under lock),
-    /// then registers for live AdjRibIn/PeerUp/PeerDown events.
-    pub(crate) fn subscribe_with<F>(&self, mut on_change: F) -> Subscription
-    where
-        F: FnMut(AdjRibInChange),
-    {
+    /// Subscribe to BGP events.
+    ///
+    /// When `want_snapshot` is `true`, snapshot events for all current Adj-RIB-In
+    /// routes are queued into the channel before this function returns, followed by
+    /// a `BgpEvent::EndOfSnapshot` sentinel.  Live events (and any concurrent
+    /// inserts that race with the snapshot) are delivered after the sentinel.
+    ///
+    /// When `want_snapshot` is `false`, only live events are delivered.
+    pub(crate) fn subscribe(&self, want_snapshot: bool) -> Subscription {
         let id = SubscriptionId(
             self.next_sub_id
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
@@ -649,55 +654,46 @@ impl TableManager {
             v.push((id, tx.clone()));
             Arc::new(v)
         });
-        // Snapshot each shard while holding the lock.  Any insert_route() on a shard
-        // that has not yet been snapshotted either:
-        //   (a) acquired the lock before us -> its route appears in the snapshot, or
-        //   (b) acquires the lock after us  -> loads subscribers inside the lock and
-        //       finds our tx (rcu already completed), so the live event is delivered.
-        for shard in &self.shards {
-            let t = shard.lock().unwrap();
-            for f in t.rtable.families().collect::<Vec<_>>() {
-                for reach in t.rtable.iter_reach(f) {
-                    let addpath = t.has_addpath(&reach.source.remote_addr, &f);
-                    on_change(AdjRibInChange {
-                        source: reach.source,
-                        family: f,
-                        addpath,
-                        nlris: vec![reach.net],
-                        attrs: Some(reach.attr),
-                        nexthop: reach.nexthop,
-                        timestamp: reach.timestamp,
-                    });
-                }
-                for reach in t.rtable.iter_reach_post(f) {
-                    let addpath = t.has_addpath(&reach.source.remote_addr, &f);
-                    let _ = tx.send(BgpEvent::AdjRibInPost(AdjRibInChange {
-                        source: reach.source,
-                        family: f,
-                        addpath,
-                        nlris: vec![reach.net],
-                        attrs: Some(reach.attr),
-                        nexthop: reach.nexthop,
-                        timestamp: reach.timestamp,
-                    }));
+        if want_snapshot {
+            // Snapshot each shard while holding the lock.  Any insert_route() on a
+            // shard that has not yet been snapshotted either:
+            //   (a) acquired the lock before us -> its route appears in the snapshot, or
+            //   (b) acquires the lock after us  -> loads subscribers inside the lock and
+            //       finds our tx (rcu already completed), so the live event is delivered.
+            // Concurrent inserts in case (b) may arrive in the channel interleaved with
+            // snapshot events; callers must drain until EndOfSnapshot and accumulate all
+            // AdjRibIn events to obtain the net state at subscription time.
+            for shard in &self.shards {
+                let t = shard.lock().unwrap();
+                for f in t.rtable.families().collect::<Vec<_>>() {
+                    for reach in t.rtable.iter_reach(f) {
+                        let addpath = t.has_addpath(&reach.source.remote_addr, &f);
+                        let _ = tx.send(BgpEvent::AdjRibIn(AdjRibInChange {
+                            source: reach.source,
+                            family: f,
+                            addpath,
+                            nlris: vec![reach.net],
+                            attrs: Some(reach.attr),
+                            nexthop: reach.nexthop,
+                            timestamp: reach.timestamp,
+                        }));
+                    }
+                    for reach in t.rtable.iter_reach_post(f) {
+                        let addpath = t.has_addpath(&reach.source.remote_addr, &f);
+                        let _ = tx.send(BgpEvent::AdjRibInPost(AdjRibInChange {
+                            source: reach.source,
+                            family: f,
+                            addpath,
+                            nlris: vec![reach.net],
+                            attrs: Some(reach.attr),
+                            nexthop: reach.nexthop,
+                            timestamp: reach.timestamp,
+                        }));
+                    }
                 }
             }
+            let _ = tx.send(BgpEvent::EndOfSnapshot);
         }
-        Subscription { rx, id }
-    }
-
-    /// Subscribe for live events only (no snapshot). Used by watch_event gRPC and MRT.
-    pub(crate) fn subscribe_live(&self) -> Subscription {
-        let id = SubscriptionId(
-            self.next_sub_id
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
-        );
-        let (tx, rx) = mpsc::unbounded_channel();
-        self.subscribers.rcu(|cur| {
-            let mut v = (**cur).clone();
-            v.push((id, tx.clone()));
-            Arc::new(v)
-        });
         Subscription { rx, id }
     }
 


### PR DESCRIPTION
The two subscribe variants had an asymmetric interface: subscribe_with delivered snapshot routes via a synchronous callback while subscribe_live used only the channel.  This made callers harder to read and prevented a uniform event loop.

Merge both into subscribe(want_snapshot: bool).  When want_snapshot is true, snapshot events (AdjRibIn/AdjRibInPost per shard) are queued into the channel before the function returns, followed by a new BgpEvent::EndOfSnapshot sentinel.  Concurrent inserts that race with the snapshot are also delivered as AdjRibIn events and may appear interleaved before the sentinel; callers drain until EndOfSnapshot and accumulate all AdjRibIn events via apply_snapshot to get the correct net state.

The BMP session now drains the channel asynchronously until EndOfSnapshot, then proceeds with PeerUp and flush as before.  MRT and watch_event already used live-only subscription and simply pass false.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>