### PR TITLE
bmp: accept ALL monitoring policy to enable Adj-RIB-Out monitoring

### DIFF
--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -2670,8 +2670,10 @@ impl GoBgpService for GrpcService {
 
         {
             use api::add_bmp_request::MonitoringPolicy as P;
-            let p = request.policy;
-            if p != P::Pre as i32 && p != P::Post as i32 && p != P::Both as i32 {
+            if !matches!(
+                P::try_from(request.policy),
+                Ok(P::Pre | P::Post | P::Both | P::All)
+            ) {
                 return Err(tonic::Status::new(
                     tonic::Code::InvalidArgument,
                     "unsupported monitoring policy",


### PR DESCRIPTION
AdjRibOutPre and AdjRibOutPost events are already generated in process_nlri_change() and handled by the bmp.rs live loop (RFC 8671), so the only remaining barrier was the grpc.rs policy gate.

LOCAL (RFC 9069 Loc-RIB) remains unsupported until its event infrastructure is implemented.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>