### PR TITLE
bmp: implement LOCAL monitoring policy for Loc-RIB (RFC 9069)

### DIFF
--- a/daemon/src/bmp.rs
+++ b/daemon/src/bmp.rs
@@ -25,7 +25,9 @@ use tokio_util::sync::CancellationToken;
 
 use rustybgp_packet::{self as packet, Family, bgp, bmp};
 
-use crate::event::{AdjRibInChange, AdjRibOutChange, BgpEvent, GlobalHandle, TableHandle};
+use crate::event::{
+    AdjRibInChange, AdjRibOutChange, BgpEvent, GlobalHandle, LocRibChange, TableHandle,
+};
 
 /// BMP monitoring policy: controls which RIB directions are sent to the client.
 #[derive(Clone, Copy, PartialEq)]
@@ -33,6 +35,7 @@ pub(crate) enum BmpPolicy {
     Pre,
     Post,
     Both,
+    Local,
     All,
 }
 
@@ -45,6 +48,9 @@ impl BmpPolicy {
     }
     fn want_adj_rib_out(self) -> bool {
         matches!(self, Self::All)
+    }
+    fn want_loc_rib(self) -> bool {
+        matches!(self, Self::Local | Self::All)
     }
 }
 
@@ -144,6 +150,68 @@ fn adj_rib_in_to_bmp_update(change: &AdjRibInChange) -> bgp::Message {
             family: change.family,
             entries: change.nlris.clone(),
         })
+    }
+}
+
+/// Build the BMP RouteMonitoring message for one Loc-RIB best-path event (RFC 9069).
+fn loc_rib_to_bmp(change: &LocRibChange, router_id: Ipv4Addr, local_asn: u32) -> bmp::Message {
+    let update = if let Some(ref attr) = change.attr {
+        bgp::Message::Update(bgp::Update::Reach {
+            family: change.family,
+            entries: vec![packet::PathNlri {
+                nlri: change.net.clone(),
+                path_id: 0,
+            }],
+            nexthop: change.nexthop,
+            attr: attr.clone(),
+        })
+    } else {
+        bgp::Message::Update(bgp::Update::Unreach {
+            family: change.family,
+            entries: vec![packet::PathNlri {
+                nlri: change.net.clone(),
+                path_id: 0,
+            }],
+        })
+    };
+    bmp::Message::RouteMonitoring {
+        header: bmp::PerPeerHeader::new(
+            0,
+            local_asn,
+            router_id,
+            0,
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            change.timestamp,
+        )
+        .with_peer_type(bmp::Message::PEER_TYPE_LOC_RIB),
+        update,
+        addpath: false,
+    }
+}
+
+/// Build the BMP PeerUp for the Loc-RIB virtual peer (RFC 9069 §3.2).
+fn loc_rib_peer_up(router_id: Ipv4Addr, local_asn: u32) -> bmp::Message {
+    let open = bgp::Message::Open(bgp::Open {
+        as_number: local_asn,
+        holdtime: bgp::HoldTime::DISABLED,
+        router_id: u32::from(router_id),
+        capability: vec![],
+    });
+    bmp::Message::PeerUp {
+        header: bmp::PerPeerHeader::new(
+            0,
+            local_asn,
+            router_id,
+            0,
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            0,
+        )
+        .with_peer_type(bmp::Message::PEER_TYPE_LOC_RIB),
+        local_addr: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        local_port: 0,
+        remote_port: 0,
+        local_open: open.clone(),
+        remote_open: open,
     }
 }
 
@@ -346,6 +414,63 @@ impl BmpClient {
             }
         }
 
+        // Send Loc-RIB snapshot: PeerUp for the virtual peer, then one
+        // RouteMonitoring per best-path prefix, then EoR per family.
+        if policy.want_loc_rib() {
+            let local_asn = global.read().await.asn;
+            let peer_up = loc_rib_peer_up(local_id, local_asn);
+            if lines.send(&peer_up).await.is_err() {
+                tables.unsubscribe(sub_id);
+                return;
+            }
+            let mut families_seen: FnvHashSet<Family> = FnvHashSet::default();
+            for family in tables.all_families() {
+                for change in tables.collect_loc_rib_paths(family) {
+                    let best = change.new_best();
+                    if best.is_none() {
+                        continue;
+                    }
+                    let lrc = LocRibChange {
+                        family: change.family,
+                        net: change.net.clone(),
+                        attr: best.map(|p| p.attr.clone()),
+                        nexthop: best.and_then(|p| p.nexthop),
+                        timestamp: std::time::SystemTime::now()
+                            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs() as u32,
+                    };
+                    let msg = loc_rib_to_bmp(&lrc, local_id, local_asn);
+                    if lines.send(&msg).await.is_err() {
+                        tables.unsubscribe(sub_id);
+                        return;
+                    }
+                    families_seen.insert(family);
+                }
+            }
+            // Send EoR per family seen in the Loc-RIB snapshot.
+            let loc_rib_eor_header = bmp::PerPeerHeader::new(
+                0,
+                local_asn,
+                local_id,
+                0,
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                0,
+            )
+            .with_peer_type(bmp::Message::PEER_TYPE_LOC_RIB);
+            for family in families_seen {
+                let eor = bmp::Message::RouteMonitoring {
+                    header: loc_rib_eor_header.clone(),
+                    update: bgp::Message::eor(family),
+                    addpath: false,
+                };
+                if lines.send(&eor).await.is_err() {
+                    tables.unsubscribe(sub_id);
+                    return;
+                }
+            }
+        }
+
         // Live event loop.
         loop {
             tokio::select! {
@@ -465,6 +590,16 @@ impl BmpClient {
                                 .await
                                 .is_err()
                             {
+                                break;
+                            }
+                        }
+                        Some(BgpEvent::LocRib(change)) => {
+                            if !policy.want_loc_rib() {
+                                continue;
+                            }
+                            let local_asn = global.read().await.asn;
+                            let msg = loc_rib_to_bmp(&change, local_id, local_asn);
+                            if lines.send(&msg).await.is_err() {
                                 break;
                             }
                         }

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -2809,6 +2809,7 @@ impl GoBgpService for GrpcService {
             Ok(P::Pre) => crate::bmp::BmpPolicy::Pre,
             Ok(P::Post) => crate::bmp::BmpPolicy::Post,
             Ok(P::Both) => crate::bmp::BmpPolicy::Both,
+            Ok(P::Local) => crate::bmp::BmpPolicy::Local,
             Ok(P::All) => crate::bmp::BmpPolicy::All,
             _ => {
                 return Err(tonic::Status::new(

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -660,7 +660,7 @@ pub(super) struct ConfederationConfig {
 }
 
 pub(crate) struct Global {
-    asn: u32,
+    pub(crate) asn: u32,
     pub(crate) router_id: Ipv4Addr,
     listen_port: Option<u16>,
     listen_sockets: Vec<RawFd>,
@@ -1512,7 +1512,9 @@ fn start_grpc_server(
 
 use crate::table_manager::{PeerDownData, PeerUpData, SubscriptionId, TableManager};
 // Re-export for mrt.rs and bmp.rs which import from crate::event.
-pub(crate) use crate::table_manager::{AdjRibInChange, AdjRibOutChange, BgpEvent, TableHandle};
+pub(crate) use crate::table_manager::{
+    AdjRibInChange, AdjRibOutChange, BgpEvent, LocRibChange, TableHandle,
+};
 
 pub(crate) async fn main(
     bgp: Option<config::BgpConfig>,

--- a/daemon/src/mrt.rs
+++ b/daemon/src/mrt.rs
@@ -143,6 +143,7 @@ impl MrtDumper {
                         | Some(BgpEvent::AdjRibOutPost(_))
                         | Some(BgpEvent::PeerUp(_))
                         | Some(BgpEvent::PeerDown(_))
+                        | Some(BgpEvent::LocRib(_))
                         | Some(BgpEvent::EndOfSnapshot) => {}
                         None => return Ok(()),
                     }

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -64,6 +64,17 @@ pub(crate) struct PeerDownData {
     pub(crate) reason: rustybgp_packet::bmp::PeerDownReason,
 }
 
+/// A Loc-RIB best-path change for BMP LOCAL monitoring (RFC 9069).
+/// `attr` is `None` for withdrawals (best path removed).
+#[derive(Clone)]
+pub(crate) struct LocRibChange {
+    pub(crate) family: Family,
+    pub(crate) net: packet::Nlri,
+    pub(crate) attr: Option<Arc<Vec<packet::Attribute>>>,
+    pub(crate) nexthop: Option<bgp::Nexthop>,
+    pub(crate) timestamp: u32,
+}
+
 /// An Adj-RIB-Out update for one neighbor (RFC 8671).
 /// `attrs` is `None` for withdrawals; `Some` for route announcements.
 #[derive(Clone)]
@@ -87,6 +98,8 @@ pub(crate) enum BgpEvent {
     AdjRibOutPost(AdjRibOutChange),
     PeerUp(PeerUpData),
     PeerDown(PeerDownData),
+    /// Loc-RIB best-path change for BMP LOCAL monitoring (RFC 9069).
+    LocRib(LocRibChange),
     /// Sentinel sent by `subscribe(true)` after all snapshot events have been queued.
     EndOfSnapshot,
 }
@@ -352,7 +365,7 @@ impl TableManager {
             table::InsertResult::PrefixLimitExceeded => return true,
             table::InsertResult::Changed(update) => {
                 nht_register(kernel_handle.as_deref(), &source, nh, old_nh);
-                t.distribute_update(update, kernel_handle.as_deref());
+                t.distribute_update(update, kernel_handle.as_deref(), &subs);
             }
             table::InsertResult::NoChange => {
                 nht_register(kernel_handle.as_deref(), &source, nh, old_nh);
@@ -397,7 +410,7 @@ impl TableManager {
             t.rtable
                 .remove(source.clone(), family, net.nlri, net.path_id, counter_ref);
         if let Some(update) = change {
-            t.distribute_update(update, kernel_handle.as_deref());
+            t.distribute_update(update, kernel_handle.as_deref(), &subs);
         }
         if let Some(nh) = old_nh
             && !source.is_kernel()
@@ -468,30 +481,33 @@ impl TableManager {
 
     pub(crate) fn drop_families(&self, addr: IpAddr, families: &[Family]) {
         let kernel_handle = self.kernel_handle.load_full();
+        let subs = self.subscribers.load();
         for shard in &self.shards {
             let mut t = shard.lock().unwrap();
             for &family in families {
-                t.disconnected(addr, family, kernel_handle.as_deref());
+                t.disconnected(addr, family, kernel_handle.as_deref(), &subs);
             }
         }
     }
 
     pub(crate) fn drop_stale_families(&self, addr: IpAddr, families: &[Family]) {
         let kernel_handle = self.kernel_handle.load_full();
+        let subs = self.subscribers.load();
         for shard in &self.shards {
             let mut t = shard.lock().unwrap();
             for &family in families {
-                t.drop_stale(addr, family, kernel_handle.as_deref());
+                t.drop_stale(addr, family, kernel_handle.as_deref(), &subs);
             }
         }
     }
 
     pub(crate) fn end_deferral_families(&self, families: &[Family]) {
         let kernel_handle = self.kernel_handle.load_full();
+        let subs = self.subscribers.load();
         for shard in &self.shards {
             let mut t = shard.lock().unwrap();
             for &family in families {
-                t.end_deferral(family, kernel_handle.as_deref());
+                t.end_deferral(family, kernel_handle.as_deref(), &subs);
             }
         }
     }
@@ -549,6 +565,17 @@ impl TableManager {
             out.extend(shard.lock().unwrap().rtable.collect_loc_rib_paths(&family));
         }
         out
+    }
+
+    /// Enumerate all active RIB families across all shards (deduplicated).
+    pub(crate) fn all_families(&self) -> Vec<Family> {
+        let mut seen = FnvHashSet::default();
+        for shard in &self.shards {
+            for f in shard.lock().unwrap().rtable.families() {
+                seen.insert(f);
+            }
+        }
+        seen.into_iter().collect()
     }
 
     /// Collect all adj-in RTC paths for `peer` across all shards (stale and fresh).
@@ -768,15 +795,16 @@ impl TableManager {
         stale_families: &[Family],
     ) {
         let kernel_handle = self.kernel_handle.load_full();
+        let subs = self.subscribers.load();
         for shard in &self.shards {
             let mut t = shard.lock().unwrap();
             t.peer_event_tx.remove(&addr);
             t.addpath.remove(&addr);
             for &family in drop_families {
-                t.disconnected(addr, family, kernel_handle.as_deref());
+                t.disconnected(addr, family, kernel_handle.as_deref(), &subs);
             }
             for &family in stale_families {
-                t.mark_stale(addr, family, kernel_handle.as_deref());
+                t.mark_stale(addr, family, kernel_handle.as_deref(), &subs);
             }
         }
     }
@@ -798,10 +826,11 @@ impl TableManager {
         self.nexthop_invalid.store(Arc::new(new_set));
 
         let kernel_handle = self.kernel_handle.load_full();
+        let subs = self.subscribers.load();
         for shard in &self.shards {
             let mut t = shard.lock().unwrap();
             for change in t.rtable.update_nexthop_validity(addr, reachable) {
-                t.distribute_update(change, kernel_handle.as_deref());
+                t.distribute_update(change, kernel_handle.as_deref(), &subs);
             }
         }
     }
@@ -999,10 +1028,11 @@ impl TableShard {
         addr: IpAddr,
         family: Family,
         kernel_handle: Option<&kernel::KernelHandle>,
+        subs: &[(SubscriptionId, mpsc::UnboundedSender<BgpEvent>)],
     ) {
         let (changes, nexthops) = self.rtable.drop(addr, family);
         for change in changes {
-            self.distribute_update(change, kernel_handle);
+            self.distribute_update(change, kernel_handle, subs);
         }
         if let Some(handle) = kernel_handle {
             for nh in nexthops {
@@ -1016,9 +1046,10 @@ impl TableShard {
         addr: IpAddr,
         family: Family,
         kernel_handle: Option<&kernel::KernelHandle>,
+        subs: &[(SubscriptionId, mpsc::UnboundedSender<BgpEvent>)],
     ) {
         for change in self.rtable.restale(addr, family) {
-            self.distribute_update(change, kernel_handle);
+            self.distribute_update(change, kernel_handle, subs);
         }
     }
 
@@ -1076,6 +1107,7 @@ impl TableShard {
         &self,
         update: table::NlriChange,
         kernel_handle: Option<&kernel::KernelHandle>,
+        subs: &[(SubscriptionId, mpsc::UnboundedSender<BgpEvent>)],
     ) {
         // Kernel route update for rank-1 best (raw, without export policy).
         // kernel_handle is rarely set, so check it first.
@@ -1131,6 +1163,24 @@ impl TableShard {
                         });
                     }
                 }
+            }
+        }
+
+        // Emit Loc-RIB event to BMP subscribers when best-path changes.
+        if update.best_changed && !subs.is_empty() {
+            let best = update.new_best();
+            let change = LocRibChange {
+                family: update.family,
+                net: update.net.clone(),
+                attr: best.map(|p| p.attr.clone()),
+                nexthop: best.and_then(|p| p.nexthop),
+                timestamp: std::time::SystemTime::now()
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs() as u32,
+            };
+            for (_, tx) in subs {
+                let _ = tx.send(BgpEvent::LocRib(change.clone()));
             }
         }
 
@@ -1222,7 +1272,7 @@ impl TableShard {
                 timestamp,
             ) {
                 table::InsertResult::Changed(update) => {
-                    self.distribute_update(update, kernel_handle);
+                    self.distribute_update(update, kernel_handle, subs);
                 }
                 table::InsertResult::NoChange | table::InsertResult::PrefixLimitExceeded => {}
             }
@@ -1234,10 +1284,11 @@ impl TableShard {
         addr: IpAddr,
         family: Family,
         kernel_handle: Option<&kernel::KernelHandle>,
+        subs: &[(SubscriptionId, mpsc::UnboundedSender<BgpEvent>)],
     ) {
         let (changes, nexthops) = self.rtable.drop_stale(addr, family, None);
         for change in changes {
-            self.distribute_update(change, kernel_handle);
+            self.distribute_update(change, kernel_handle, subs);
         }
         if let Some(handle) = kernel_handle {
             for nh in nexthops {
@@ -1246,9 +1297,14 @@ impl TableShard {
         }
     }
 
-    fn end_deferral(&mut self, family: Family, kernel_handle: Option<&kernel::KernelHandle>) {
+    fn end_deferral(
+        &mut self,
+        family: Family,
+        kernel_handle: Option<&kernel::KernelHandle>,
+        subs: &[(SubscriptionId, mpsc::UnboundedSender<BgpEvent>)],
+    ) {
         for change in self.rtable.end_deferral(family) {
-            self.distribute_update(change, kernel_handle);
+            self.distribute_update(change, kernel_handle, subs);
         }
     }
 }

--- a/packet/src/bmp.rs
+++ b/packet/src/bmp.rs
@@ -31,6 +31,11 @@ impl Message {
     pub const TERMINATION: u8 = 5;
     pub const ROUTE_MIRRORING: u8 = 6;
 
+    /// Per-peer type: Global Instance Peer (RFC 7854 §4.2).
+    pub const PEER_TYPE_GLOBAL: u8 = 0;
+    /// Per-peer type: Loc-RIB Instance Peer (RFC 9069 §3.1).
+    pub const PEER_TYPE_LOC_RIB: u8 = 3;
+
     /// Per-peer header flag: peer address is IPv6 (RFC 7854 §4.2, V flag).
     pub const PEER_FLAG_IPV6: u8 = 0x80;
     /// Per-peer header flag: Adj-RIB-In post-policy (RFC 7854 §4.2, L flag).
@@ -41,6 +46,8 @@ impl Message {
 
 #[derive(Clone)]
 pub struct PerPeerHeader {
+    /// Peer Type field (RFC 7854 §4.2): 0 = Global, 3 = Loc-RIB (RFC 9069).
+    peer_type: u8,
     /// Caller-supplied per-peer flags (L, O, A, …).
     /// The V (IPv6) flag is computed from `remote_addr` at encode time.
     flags: u8,
@@ -61,6 +68,7 @@ impl PerPeerHeader {
         timestamp: u32,
     ) -> Self {
         PerPeerHeader {
+            peer_type: Message::PEER_TYPE_GLOBAL,
             flags,
             asn,
             id,
@@ -77,9 +85,13 @@ impl PerPeerHeader {
         }
     }
 
+    /// Set peer_type to Loc-RIB Instance Peer (RFC 9069 §3.1).
+    pub fn with_peer_type(self, peer_type: u8) -> Self {
+        PerPeerHeader { peer_type, ..self }
+    }
+
     fn encode(&self, c: &mut BytesMut) -> Result<(), Error> {
-        // peer type: 0 = Global Instance Peer
-        c.put_u8(0);
+        c.put_u8(self.peer_type);
         let wire_flags = self.flags
             | if self.remote_addr.is_ipv6() {
                 Message::PEER_FLAG_IPV6


### PR DESCRIPTION
RFC 9069 defines Loc-RIB monitoring using Peer Type 3 ("Loc-RIB Instance Peer").  A BMP client requesting LOCAL (or ALL) policy now receives the router's best-path RIB rather than per-peer Adj-RIB-In.

Key changes:

- packet/bmp: add PEER_TYPE_LOC_RIB (3) constant and peer_type field to PerPeerHeader; encode() now uses self.peer_type instead of hardcoded 0; add with_peer_type() builder.

- table_manager: add LocRibChange struct and BgpEvent::LocRib variant. distribute_update() gains a subs parameter and emits BgpEvent::LocRib to all BMP subscribers whenever the best path changes.  The subs slice is loaded at TableManager level and threaded into TableShard methods (disconnected, mark_stale, drop_stale, end_deferral, soft_reset_in) to cover all call sites consistently.

- bmp: add Local variant to BmpPolicy with want_loc_rib() helper. serve() sends a Loc-RIB PeerUp (virtual peer with peer_type=3) at connect time, then a snapshot of all best paths via collect_loc_rib_paths() / all_families(), followed by one EoR per family.  Live BgpEvent::LocRib events are forwarded as RouteMonitoring messages with the Loc-RIB peer header.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>