### PR TITLE
grpc: implement WatchEvent TYPE_EOR

### DIFF
--- a/daemon/src/bmp.rs
+++ b/daemon/src/bmp.rs
@@ -644,6 +644,7 @@ impl BmpClient {
                                 break;
                             }
                         }
+                        Some(BgpEvent::EndOfRib(_)) => {}
                         Some(BgpEvent::EndOfSnapshot) | None => break,
                     }
                 }

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -1288,36 +1288,44 @@ impl GoBgpService for GrpcService {
         let req = request.into_inner();
 
         let want_peer = req.peer.is_some();
-        let (want_table, want_adjin, want_best, want_post_policy, want_init, peer_addr_filter) =
-            if let Some(table) = &req.table {
-                let mut adjin = false;
-                let mut best = false;
-                let mut post_policy = false;
-                let mut init = false;
-                let mut filter_addr: Option<std::net::IpAddr> = None;
-                for f in &table.filters {
-                    use api::watch_event_request::table::filter::Type;
-                    match f.r#type() {
-                        Type::Unspecified | Type::Adjin => adjin = true,
-                        Type::Best => best = true,
-                        Type::PostPolicy => post_policy = true,
-                        Type::Eor => {}
-                    }
-                    if f.init {
-                        init = true;
-                    }
-                    if !f.peer_address.is_empty() {
-                        filter_addr = f.peer_address.parse().ok();
-                    }
+        let (
+            want_table,
+            want_adjin,
+            want_best,
+            want_post_policy,
+            want_eor,
+            want_init,
+            peer_addr_filter,
+        ) = if let Some(table) = &req.table {
+            let mut adjin = false;
+            let mut best = false;
+            let mut post_policy = false;
+            let mut eor = false;
+            let mut init = false;
+            let mut filter_addr: Option<std::net::IpAddr> = None;
+            for f in &table.filters {
+                use api::watch_event_request::table::filter::Type;
+                match f.r#type() {
+                    Type::Unspecified | Type::Adjin => adjin = true,
+                    Type::Best => best = true,
+                    Type::PostPolicy => post_policy = true,
+                    Type::Eor => eor = true,
                 }
-                // No explicit type defaults to pre-policy Adj-RIB-In.
-                if !adjin && !best && !post_policy {
-                    adjin = true;
+                if f.init {
+                    init = true;
                 }
-                (true, adjin, best, post_policy, init, filter_addr)
-            } else {
-                (false, false, false, false, false, None)
-            };
+                if !f.peer_address.is_empty() {
+                    filter_addr = f.peer_address.parse().ok();
+                }
+            }
+            // No explicit type defaults to pre-policy Adj-RIB-In.
+            if !adjin && !best && !post_policy && !eor {
+                adjin = true;
+            }
+            (true, adjin, best, post_policy, eor, init, filter_addr)
+        } else {
+            (false, false, false, false, false, false, None)
+        };
 
         let tables2 = self.tables.clone();
         let global2 = self.global.clone();
@@ -1486,6 +1494,29 @@ impl GoBgpService for GrpcService {
                                 &change.net,
                                 change.attr.as_ref(),
                             )
+                        }
+                        BgpEvent::EndOfRib(data) if want_table && want_eor => {
+                            if matches!(peer_addr_filter, Some(a) if a != data.source.remote_addr)
+                            {
+                                continue;
+                            }
+                            api::WatchEventResponse {
+                                event: Some(api::watch_event_response::Event::Table(
+                                    api::watch_event_response::TableEvent {
+                                        paths: vec![api::Path {
+                                            family: Some(convert::family_to_api(data.family)),
+                                            is_withdraw: true,
+                                            neighbor_ip: data.source.remote_addr.to_string(),
+                                            source_asn: data.source.remote_asn,
+                                            source_id: std::net::Ipv4Addr::from(
+                                                data.source.router_id,
+                                            )
+                                            .to_string(),
+                                            ..Default::default()
+                                        }],
+                                    },
+                                )),
+                            }
                         }
                         _ => continue,
                     };

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -2881,12 +2881,15 @@ impl PeerSession {
             }
         }
 
-        // For UPDATE EndOfRib: signal GR if negotiated.
-        if let Some(family) = eor_family
-            && self.negotiated_gr.is_some()
-        {
-            self.process_effects(vec![GlobalEffect::GrEorReceived { family }], global)
-                .await;
+        // For UPDATE EndOfRib: notify EOR watchers unconditionally; signal GR if negotiated.
+        if let Some(family) = eor_family {
+            if let Some(source) = self.source.get(&family) {
+                self.tables.notify_eor(source.clone(), family);
+            }
+            if self.negotiated_gr.is_some() {
+                self.process_effects(vec![GlobalEffect::GrEorReceived { family }], global)
+                    .await;
+            }
         }
 
         // For RTC EOR: advance state and export VPN routes if suspended.

--- a/daemon/src/mrt.rs
+++ b/daemon/src/mrt.rs
@@ -144,6 +144,7 @@ impl MrtDumper {
                         | Some(BgpEvent::PeerUp(_))
                         | Some(BgpEvent::PeerDown(_))
                         | Some(BgpEvent::LocRib(_))
+                        | Some(BgpEvent::EndOfRib(_))
                         | Some(BgpEvent::EndOfSnapshot) => {}
                         None => return Ok(()),
                     }

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -91,6 +91,13 @@ pub(crate) struct AdjRibOutChange {
     pub(crate) timestamp: std::time::SystemTime,
 }
 
+/// EOR (End-of-RIB) marker received from a peer (RFC 4724 §2).
+#[derive(Clone)]
+pub(crate) struct EndOfRibData {
+    pub(crate) source: Arc<table::Source>,
+    pub(crate) family: Family,
+}
+
 pub(crate) enum BgpEvent {
     AdjRibIn(AdjRibInChange),
     AdjRibInPost(AdjRibInChange),
@@ -100,6 +107,8 @@ pub(crate) enum BgpEvent {
     PeerDown(PeerDownData),
     /// Loc-RIB best-path change for BMP LOCAL monitoring (RFC 9069).
     LocRib(LocRibChange),
+    /// EOR marker received from a peer.
+    EndOfRib(EndOfRibData),
     /// Sentinel sent by `subscribe(true)` after all snapshot events have been queued.
     EndOfSnapshot,
 }
@@ -747,6 +756,13 @@ impl TableManager {
     pub(crate) fn peer_down(&self, data: PeerDownData) {
         for (_, tx) in self.subscribers.load().iter() {
             let _ = tx.send(BgpEvent::PeerDown(data.clone()));
+        }
+    }
+
+    pub(crate) fn notify_eor(&self, source: Arc<table::Source>, family: Family) {
+        let data = EndOfRibData { source, family };
+        for (_, tx) in self.subscribers.load().iter() {
+            let _ = tx.send(BgpEvent::EndOfRib(data.clone()));
         }
     }
 


### PR DESCRIPTION
EOR (End-of-RIB) is defined in RFC 4724 sec. 2 as a marker sent after a peer has finished its initial route advertisement for a given address family.  GoBGP exposes this as TYPE_EOR (value 4) in WatchEvent so that monitoring clients can determine when a peer's initial RIB dump is complete.

Add a dedicated EndOfRibData type (source, family) and BgpEvent::EndOfRib variant so that EOR carries strong compile-time semantics, matching the Rust convention of one type per distinct event.

TableManager::notify_eor() broadcasts EndOfRib to all subscribers unconditionally whenever a peer sends an EOR UPDATE.  The existing GR path (GlobalEffect::GrEorReceived) is preserved alongside it.

grpc.rs parses want_eor from filters, and in the live event loop emits a TableEvent whose single Path has family set and is_withdraw=true (and no NLRI) -- the same representation GoBGP uses for EOR.  peer_address filtering applies.  TYPE_EOR does not support init snapshots because EOR is a transient event, not persistent state.

bmp.rs and mrt.rs ignore EndOfRib in their live loops; BMP handles the EOR UPDATE message directly from the BGP packet stream via its own RouteMonitoring path.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>