### PR TITLE
cleanup: remove stale allow(dead_code) annotations and dead code

### DIFF
--- a/daemon/src/bfd.rs
+++ b/daemon/src/bfd.rs
@@ -141,11 +141,6 @@ struct PeerHandle {
 /// underlying task via the channel.
 pub(crate) struct BfdHandle {
     tx: mpsc::UnboundedSender<BfdRequest>,
-    #[allow(dead_code)]
-    stats: Arc<ServerStats>,
-    /// Peer states updated by peer tasks; read by gRPC handlers.
-    #[allow(dead_code)]
-    peer_states: Arc<RwLock<HashMap<IpAddr, PeerStateSnapshot>>>,
 }
 
 impl BfdHandle {
@@ -155,13 +150,8 @@ impl BfdHandle {
         let stats = Arc::new(ServerStats::default());
         let peer_states = Arc::new(RwLock::new(HashMap::<IpAddr, PeerStateSnapshot>::new()));
         let (req_tx, req_rx) = mpsc::unbounded_channel();
-        let h = BfdHandle {
-            tx: req_tx,
-            stats: stats.clone(),
-            peer_states: peer_states.clone(),
-        };
         tokio::spawn(server_loop(req_rx, event_tx, stats, peer_states));
-        h
+        BfdHandle { tx: req_tx }
     }
 
     /// Register a BGP peer for BFD monitoring.  Idempotent: a second call for
@@ -174,23 +164,6 @@ impl BfdHandle {
     /// is torn down without notifying BGP (the caller is responsible for that).
     pub(crate) fn remove_peer(&self, addr: IpAddr) {
         let _ = self.tx.send(BfdRequest::RemovePeer { addr });
-    }
-
-    /// Return the current BFD state snapshot for a peer (for gRPC queries).
-    #[allow(dead_code)]
-    pub(crate) fn get_peer_state(&self, addr: IpAddr) -> Option<PeerStateSnapshot> {
-        self.peer_states.read().ok()?.get(&addr).cloned()
-    }
-
-    /// Return server-wide packet counters.
-    #[allow(dead_code)]
-    pub(crate) fn get_server_stats(&self) -> (u64, u64, u64, u64) {
-        (
-            self.stats.rx_packet.load(Ordering::Relaxed),
-            self.stats.rx_error.load(Ordering::Relaxed),
-            self.stats.invalid_packet.load(Ordering::Relaxed),
-            self.stats.unknown_peer.load(Ordering::Relaxed),
-        )
     }
 }
 

--- a/daemon/src/peer_tx.rs
+++ b/daemon/src/peer_tx.rs
@@ -182,21 +182,8 @@ impl PendingTx {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustybgp_table as table;
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::net::Ipv4Addr;
     use std::str::FromStr;
-
-    #[allow(dead_code)]
-    fn src() -> Arc<table::Source> {
-        Arc::new(table::Source::new(
-            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 1)),
-            IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1)),
-            1,
-            2,
-            Ipv4Addr::new(127, 0, 0, 1),
-            table::PeerRole::Ebgp,
-        ))
-    }
 
     fn nlri(net: &str) -> packet::Nlri {
         packet::Nlri::from_str(net).unwrap()

--- a/packet/src/bmp.rs
+++ b/packet/src/bmp.rs
@@ -21,7 +21,6 @@ use tokio_util::codec::{Decoder, Encoder};
 use crate::bgp;
 use crate::error::Error;
 
-#[allow(dead_code)]
 impl Message {
     pub const ROUTE_MONITORING: u8 = 0;
     pub const STATS_REPORTS: u8 = 1;
@@ -109,7 +108,6 @@ impl PerPeerHeader {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Clone)]
 pub enum PeerDownReason {
     LocalNotification(bgp::Message),
@@ -153,7 +151,6 @@ impl PeerDownReason {
     }
 }
 
-#[allow(dead_code)]
 pub enum Message {
     RouteMonitoring {
         header: PerPeerHeader,

--- a/packet/src/mrt.rs
+++ b/packet/src/mrt.rs
@@ -101,7 +101,6 @@ impl MpHeader {
     }
 }
 
-#[allow(dead_code)]
 pub enum Message {
     Mp {
         header: MpHeader,

--- a/packet/src/rpki.rs
+++ b/packet/src/rpki.rs
@@ -29,7 +29,6 @@ pub struct Prefix {
     pub as_number: u32,
 }
 
-#[allow(dead_code)]
 pub enum Message {
     SerialNotify {
         session_id: u16,

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -230,18 +230,6 @@ impl PathAttribute {
         }
     }
 
-    #[allow(dead_code)]
-    fn attr_med(&self) -> u32 {
-        match self
-            .attr
-            .iter()
-            .find(|a| a.code() == packet::Attribute::MULTI_EXIT_DESC)
-        {
-            Some(attr) => attr.value().unwrap(),
-            None => 0,
-        }
-    }
-
     fn attr_originator_id(&self) -> Option<u32> {
         self.attr
             .iter()
@@ -2291,17 +2279,6 @@ mod tests {
         let bytes: Vec<u8> = ids.iter().flat_map(|&id| [0u8, 0, 0, id]).collect();
         Arc::new(vec![
             packet::Attribute::new_with_bin(packet::Attribute::CLUSTER_LIST, bytes).unwrap(),
-        ])
-    }
-
-    #[allow(dead_code)]
-    fn attrs_with_originator(id: u8) -> Arc<Vec<packet::Attribute>> {
-        Arc::new(vec![
-            packet::Attribute::new_with_value(
-                packet::Attribute::ORIGINATOR_ID,
-                u32::from(Ipv4Addr::new(0, 0, 0, id)),
-            )
-            .unwrap(),
         ])
     }
 


### PR DESCRIPTION
Five annotations in the packet crate (bmp, mrt, rpki) suppressed warnings on types that are now fully wired up in the daemon.  Removing them lets the compiler flag any future dead code in those modules.

In table/src/lib.rs, PathAttribute::attr_med() was never called from any production or test path.  In the test module, attrs_with_originator() was defined but not referenced by any test.  Both are deleted.

In daemon/src/bfd.rs, BfdHandle::get_peer_state() and get_server_stats() were stubs prepared for future BFD gRPC queries that have not been implemented yet.  The stats and peer_states Arc fields they depended on are removed from BfdHandle; server_loop() already holds its own Arc clones so no data is lost.

In daemon/src/peer_tx.rs, the test-only src() helper was never called by any test; removed together with the now-unused rustybgp_table and IpAddr imports.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>