### PR TITLE
kernel: require Linux at compile time

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,4 +1,8 @@
 //! Kernel FIB integration via Linux Netlink.
+#![cfg_attr(
+    not(target_os = "linux"),
+    compile_error("rustybgp-kernel requires Linux (uses rtnetlink/Netlink)")
+)]
 //!
 //! # Types
 //!


### PR DESCRIPTION
Non-Linux targets cannot use rtnetlink/Netlink, so the kernel crate has always been Linux-only in practice.  Add a cfg_attr compile_error so the constraint is stated explicitly rather than surfacing as a confusing linker or API error.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>