### PR TITLE
tests/e2e: add BMP end-to-end tests (pre, post, local-rib, all)

### DIFF
--- a/tests/e2e/bmp-all/docker-compose.yml
+++ b/tests/e2e/bmp-all/docker-compose.yml
@@ -1,0 +1,58 @@
+networks:
+  bmp-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.20.0/24
+          gateway: 172.30.20.254
+
+services:
+  rusty:
+    build:
+      context: ${RUSTYBGP_BUILD_CONTEXT:-../../..}
+      dockerfile: ${RUSTYBGP_DOCKERFILE:-tests/e2e/shared/Dockerfile.rustybgp}
+      args:
+        RUST_TARGET: ${RUST_TARGET:-aarch64-unknown-linux-musl}
+    container_name: rusty
+    privileged: true
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.1
+    volumes:
+      - ./rustybgp.yaml:/etc/rustybgp.yaml:ro
+      - ./entrypoint-rusty.sh:/entrypoint.sh:ro
+
+  gobgp-peer-a:
+    build:
+      context: ../../..
+      dockerfile: tests/e2e/shared/Dockerfile.gobgp
+    container_name: gobgp-peer-a
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.2
+    volumes:
+      - ./gobgp-peer-a/gobgpd.conf:/etc/gobgpd.conf:ro
+      - ./gobgp-peer-a/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  gobgp-peer-b:
+    build:
+      context: ../../..
+      dockerfile: tests/e2e/shared/Dockerfile.gobgp
+    container_name: gobgp-peer-b
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.3
+    volumes:
+      - ./gobgp-peer-b/gobgpd.conf:/etc/gobgpd.conf:ro
+      - ./gobgp-peer-b/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  bmp-receiver:
+    build:
+      context: ../shared/bmp-receiver
+      dockerfile: Dockerfile
+    container_name: bmp-receiver
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.10

--- a/tests/e2e/bmp-all/entrypoint-rusty.sh
+++ b/tests/e2e/bmp-all/entrypoint-rusty.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+rustybgpd -f /etc/rustybgp.yaml &
+BGPD_PID=$!
+
+MAX_ATTEMPTS=30
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    if gobgp global 2>/dev/null; then
+        echo "rustybgpd gRPC API is ready"
+        break
+    fi
+    if [ "$i" -eq "$MAX_ATTEMPTS" ]; then
+        echo "rustybgpd gRPC API not ready after $MAX_ATTEMPTS attempts"
+        exit 1
+    fi
+    sleep 1
+done
+
+wait $BGPD_PID

--- a/tests/e2e/bmp-all/gobgp-peer-a/entrypoint.sh
+++ b/tests/e2e/bmp-all/gobgp-peer-a/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+gobgpd -f /etc/gobgpd.conf &
+BGPD_PID=$!
+
+for i in $(seq 1 30); do
+    if gobgp global 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+# Announce one initial route; 10.2.0.0/24 will be injected later by the test script
+gobgp global rib add 10.1.0.0/24 nexthop 172.30.20.2
+
+wait $BGPD_PID

--- a/tests/e2e/bmp-all/gobgp-peer-a/gobgpd.conf
+++ b/tests/e2e/bmp-all/gobgp-peer-a/gobgpd.conf
@@ -1,0 +1,11 @@
+[global.config]
+  as = 65002
+  router-id = "172.30.20.2"
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "172.30.20.1"
+    peer-as = 65001
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"

--- a/tests/e2e/bmp-all/gobgp-peer-b/entrypoint.sh
+++ b/tests/e2e/bmp-all/gobgp-peer-b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+# peer-b only receives routes; no announcements
+gobgpd -f /etc/gobgpd.conf

--- a/tests/e2e/bmp-all/gobgp-peer-b/gobgpd.conf
+++ b/tests/e2e/bmp-all/gobgp-peer-b/gobgpd.conf
@@ -1,0 +1,11 @@
+[global.config]
+  as = 65003
+  router-id = "172.30.20.3"
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "172.30.20.1"
+    peer-as = 65001
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"

--- a/tests/e2e/bmp-all/run-test.sh
+++ b/tests/e2e/bmp-all/run-test.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+# BMP All-Policy End-to-End Test
+#
+# Topology:
+#   [gobgp-peer-a (AS 65002)] -- [rusty (AS 65001)] --> [bmp-receiver :11019]
+#                               [gobgp-peer-b (AS 65003)]
+#
+# Network: bmp-net 172.30.20.0/24
+#   rusty:         172.30.20.1
+#   gobgp-peer-a:  172.30.20.2  (announces routes)
+#   gobgp-peer-b:  172.30.20.3  (receives only)
+#   bmp-receiver:  172.30.20.10
+#
+# Export policy: deny 10.2.0.0/24 to gobgp-peer-b (allow everything else)
+# BMP policy: all (pre + post + local-rib + adj-rib-out pre + adj-rib-out post)
+#
+# Test flow:
+#   - peer-a announces 10.1.0.0/24 before BMP connects
+#   - BMP added with 'all' policy -> snapshot: pre, post, loc-rib for 10.1.0.0/24
+#   - peer-a announces 10.2.0.0/24 (denied by export to peer-b) -> live events
+#   - peer-a announces 10.3.0.0/24 (allowed by export to peer-b) -> live events
+#
+# Snapshot test scenarios:
+#   1. Initiation received
+#   2. PeerUp for peer-a and peer-b
+#   3. Pre-policy RouteMonitoring for 10.1.0.0/24 (snapshot)
+#   4. Post-policy RouteMonitoring for 10.1.0.0/24 (snapshot)
+#   5. Loc-RIB RouteMonitoring for 10.1.0.0/24 (snapshot)
+#   6. No Adj-RIB-Out in snapshot
+#
+# Live event test scenarios:
+#   7. Pre-policy RouteMonitoring for 10.2.0.0/24 (live)
+#   8. Post-policy RouteMonitoring for 10.2.0.0/24 (live)
+#   9. Loc-RIB RouteMonitoring for 10.2.0.0/24 (live)
+#  10. Adj-RIB-Out pre to peer-b for 10.2.0.0/24 (live; before export policy)
+#  11. Adj-RIB-Out post to peer-b for 10.2.0.0/24 absent (denied by export policy)
+#  12. Adj-RIB-Out pre to peer-b for 10.3.0.0/24 (live)
+#  13. Adj-RIB-Out post to peer-b for 10.3.0.0/24 (live; passes export policy)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+source ../shared/helpers.sh
+
+PASS=0
+FAIL=0
+
+pass() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+bmp_has() {
+    local desc="$1"
+    local filter="$2"
+    local count
+    count=$(docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | wc -l)
+    if [ "$count" -ge 1 ]; then
+        pass "$desc"
+    else
+        fail "$desc"
+        echo "    Filter: $filter"
+        echo "    BMP log (last 30):"
+        docker logs bmp-receiver 2>/dev/null | tail -30 | sed 's/^/      /'
+    fi
+}
+
+bmp_absent() {
+    local desc="$1"
+    local filter="$2"
+    local count
+    count=$(docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | wc -l)
+    if [ "$count" -eq 0 ]; then
+        pass "$desc"
+    else
+        fail "$desc"
+        echo "    Filter: $filter"
+        echo "    Unexpected matches:"
+        docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | head -5 | sed 's/^/      /'
+    fi
+}
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    docker compose down --volumes --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== BMP All-Policy End-to-End Test ==="
+echo ""
+
+echo "Building and starting containers..."
+docker compose up -d --build --force-recreate 2>&1
+
+echo "Waiting for BGP sessions..."
+MAX_WAIT=60
+A_OK=false
+B_OK=false
+for i in $(seq 1 $MAX_WAIT); do
+    if ! $A_OK && [ "$(gobgp_bgp_state gobgp-peer-a 172.30.20.1)" = "Established" ]; then
+        A_OK=true
+        echo "  gobgp-peer-a <-> rusty established after ${i}s"
+    fi
+    if ! $B_OK && [ "$(gobgp_bgp_state gobgp-peer-b 172.30.20.1)" = "Established" ]; then
+        B_OK=true
+        echo "  gobgp-peer-b <-> rusty established after ${i}s"
+    fi
+    if $A_OK && $B_OK; then
+        break
+    fi
+    if [ "$i" -eq "$MAX_WAIT" ]; then
+        echo "BGP sessions did not fully establish within ${MAX_WAIT}s"
+        docker logs rusty 2>&1 | tail -20
+    fi
+    sleep 1
+done
+
+# Wait for 10.1.0.0/24 to propagate before connecting BMP
+sleep 5
+
+echo "Adding BMP with 'all' policy (snapshot)..."
+docker exec rusty gobgp bmp add 172.30.20.10 all
+
+echo "Waiting for BMP snapshot (Loc-RIB EoR expected)..."
+for i in $(seq 1 30); do
+    if docker logs bmp-receiver 2>/dev/null | jq -e 'select(.type == "RouteMonitoring" and .eor == true and .peer_type == 3)' >/dev/null 2>&1; then
+        echo "  Loc-RIB EoR received after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+echo ""
+echo "--- Test Results (snapshot) ---"
+
+# Test 1: Initiation
+bmp_has "Initiation received" '.type == "Initiation"'
+
+# Test 2: PeerUp for peer-a
+bmp_has "PeerUp for peer-a (172.30.20.2)" \
+    '.type == "PeerUp" and .peer_addr == "172.30.20.2" and .peer_asn == 65002'
+
+# Test 3: PeerUp for peer-b
+bmp_has "PeerUp for peer-b (172.30.20.3)" \
+    '.type == "PeerUp" and .peer_addr == "172.30.20.3" and .peer_asn == 65003'
+
+# Test 4: Pre-policy RouteMonitoring for 10.1.0.0/24 (snapshot)
+bmp_has "Snapshot: pre-policy 10.1.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.1.0.0/24" and .post_policy == false and .adj_rib_out == false and .withdraw == false'
+
+# Test 5: Post-policy RouteMonitoring for 10.1.0.0/24 (snapshot)
+bmp_has "Snapshot: post-policy 10.1.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.1.0.0/24" and .post_policy == true and .adj_rib_out == false and .withdraw == false'
+
+# Test 6: Loc-RIB RouteMonitoring for 10.1.0.0/24 (snapshot)
+bmp_has "Snapshot: Loc-RIB 10.1.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.1.0.0/24" and .peer_type == 3 and .withdraw == false'
+
+# Test 7: No Adj-RIB-Out for 10.1.0.0/24 in snapshot (adj-out only in live events)
+bmp_absent "Snapshot: no Adj-RIB-Out for 10.1.0.0/24 (adj-out is live-only)" \
+    '.type == "RouteMonitoring" and .prefix == "10.1.0.0/24" and .adj_rib_out == true'
+
+echo ""
+echo "--- Live event tests ---"
+
+echo "Injecting 10.2.0.0/24 from peer-a (denied by export to peer-b)..."
+docker exec gobgp-peer-a gobgp global rib add 10.2.0.0/24 nexthop 172.30.20.2
+
+echo "Injecting 10.3.0.0/24 from peer-a (allowed by export to peer-b)..."
+docker exec gobgp-peer-a gobgp global rib add 10.3.0.0/24 nexthop 172.30.20.2
+
+echo "Waiting for live Adj-RIB-Out events..."
+for i in $(seq 1 30); do
+    if docker logs bmp-receiver 2>/dev/null | jq -e 'select(.type == "RouteMonitoring" and .adj_rib_out == true and .prefix == "10.3.0.0/24" and .post_policy == true)' >/dev/null 2>&1; then
+        echo "  Adj-RIB-Out post for 10.3.0.0/24 received after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+# Test 8: Pre-policy RouteMonitoring for 10.2.0.0/24 (live)
+bmp_has "Live: pre-policy 10.2.0.0/24 from peer-a" \
+    '.type == "RouteMonitoring" and .prefix == "10.2.0.0/24" and .post_policy == false and .adj_rib_out == false and .withdraw == false'
+
+# Test 9: Post-policy RouteMonitoring for 10.2.0.0/24 (live, accepted by import policy)
+bmp_has "Live: post-policy 10.2.0.0/24 from peer-a" \
+    '.type == "RouteMonitoring" and .prefix == "10.2.0.0/24" and .post_policy == true and .adj_rib_out == false and .withdraw == false'
+
+# Test 10: Loc-RIB RouteMonitoring for 10.2.0.0/24 (live)
+bmp_has "Live: Loc-RIB 10.2.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.2.0.0/24" and .peer_type == 3 and .withdraw == false'
+
+# Test 11: Adj-RIB-Out pre to peer-b for 10.2.0.0/24 (before export policy)
+bmp_has "Live: Adj-RIB-Out pre to peer-b for 10.2.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.2.0.0/24" and .adj_rib_out == true and .post_policy == false and .peer_addr == "172.30.20.3"'
+
+# Test 12: Adj-RIB-Out post to peer-b for 10.2.0.0/24 must be absent (denied by export policy).
+# Withdraw events are expected (route denied = withdrawn from post view); check only REACH is absent.
+bmp_absent "Live: Adj-RIB-Out post to peer-b for 10.2.0.0/24 absent (denied by export)" \
+    '.type == "RouteMonitoring" and .prefix == "10.2.0.0/24" and .adj_rib_out == true and .post_policy == true and .peer_addr == "172.30.20.3" and .withdraw == false'
+
+# Test 13: Adj-RIB-Out pre to peer-b for 10.3.0.0/24
+bmp_has "Live: Adj-RIB-Out pre to peer-b for 10.3.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.3.0.0/24" and .adj_rib_out == true and .post_policy == false and .peer_addr == "172.30.20.3"'
+
+# Test 14: Adj-RIB-Out post to peer-b for 10.3.0.0/24 (passes export policy)
+bmp_has "Live: Adj-RIB-Out post to peer-b for 10.3.0.0/24 (passes export)" \
+    '.type == "RouteMonitoring" and .prefix == "10.3.0.0/24" and .adj_rib_out == true and .post_policy == true and .peer_addr == "172.30.20.3"'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/e2e/bmp-all/rustybgp.yaml
+++ b/tests/e2e/bmp-all/rustybgp.yaml
@@ -1,0 +1,42 @@
+global:
+  config:
+    as: 65001
+    router-id: "172.30.20.1"
+  apply-policy:
+    config:
+      export-policy-list:
+        - deny-10-2
+      default-export-policy: accept-route
+
+neighbors:
+  - config:
+      neighbor-address: "172.30.20.2"
+      peer-as: 65002
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast
+
+  - config:
+      neighbor-address: "172.30.20.3"
+      peer-as: 65003
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast
+
+defined-sets:
+  prefix-sets:
+    - prefix-set-name: prefix-10-2
+      prefix-list:
+        - ip-prefix: "10.2.0.0/24"
+          masklength-range: "24..24"
+
+policy-definitions:
+  - name: deny-10-2
+    statements:
+      - name: s1
+        conditions:
+          match-prefix-set:
+            prefix-set: prefix-10-2
+            match-set-options: any
+        actions:
+          route-disposition: reject-route

--- a/tests/e2e/bmp-local/docker-compose.yml
+++ b/tests/e2e/bmp-local/docker-compose.yml
@@ -1,0 +1,58 @@
+networks:
+  bmp-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.20.0/24
+          gateway: 172.30.20.254
+
+services:
+  rusty:
+    build:
+      context: ${RUSTYBGP_BUILD_CONTEXT:-../../..}
+      dockerfile: ${RUSTYBGP_DOCKERFILE:-tests/e2e/shared/Dockerfile.rustybgp}
+      args:
+        RUST_TARGET: ${RUST_TARGET:-aarch64-unknown-linux-musl}
+    container_name: rusty
+    privileged: true
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.1
+    volumes:
+      - ./rustybgp.yaml:/etc/rustybgp.yaml:ro
+      - ./entrypoint-rusty.sh:/entrypoint.sh:ro
+
+  gobgp-peer-a:
+    build:
+      context: ../../..
+      dockerfile: tests/e2e/shared/Dockerfile.gobgp
+    container_name: gobgp-peer-a
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.2
+    volumes:
+      - ./gobgp-peer-a/gobgpd.conf:/etc/gobgpd.conf:ro
+      - ./gobgp-peer-a/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  gobgp-peer-b:
+    build:
+      context: ../../..
+      dockerfile: tests/e2e/shared/Dockerfile.gobgp
+    container_name: gobgp-peer-b
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.3
+    volumes:
+      - ./gobgp-peer-b/gobgpd.conf:/etc/gobgpd.conf:ro
+      - ./gobgp-peer-b/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  bmp-receiver:
+    build:
+      context: ../shared/bmp-receiver
+      dockerfile: Dockerfile
+    container_name: bmp-receiver
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.10

--- a/tests/e2e/bmp-local/entrypoint-rusty.sh
+++ b/tests/e2e/bmp-local/entrypoint-rusty.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+rustybgpd -f /etc/rustybgp.yaml &
+BGPD_PID=$!
+
+MAX_ATTEMPTS=30
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    if gobgp global 2>/dev/null; then
+        echo "rustybgpd gRPC API is ready"
+        break
+    fi
+    if [ "$i" -eq $MAX_ATTEMPTS ]; then
+        echo "rustybgpd gRPC API not ready after $MAX_ATTEMPTS attempts"
+        exit 1
+    fi
+    sleep 1
+done
+
+wait $BGPD_PID

--- a/tests/e2e/bmp-local/gobgp-peer-a/entrypoint.sh
+++ b/tests/e2e/bmp-local/gobgp-peer-a/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+gobgpd -f /etc/gobgpd.conf &
+BGPD_PID=$!
+
+for i in $(seq 1 30); do
+    if gobgp global 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+# Announce 10.1.0.0/24 (competes with peer-b) and 10.2.0.0/24 (unique)
+gobgp global rib add 10.1.0.0/24 nexthop 172.30.20.2
+gobgp global rib add 10.2.0.0/24 nexthop 172.30.20.2
+
+wait $BGPD_PID

--- a/tests/e2e/bmp-local/gobgp-peer-a/gobgpd.conf
+++ b/tests/e2e/bmp-local/gobgp-peer-a/gobgpd.conf
@@ -1,0 +1,11 @@
+[global.config]
+  as = 65002
+  router-id = "172.30.20.2"
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "172.30.20.1"
+    peer-as = 65001
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"

--- a/tests/e2e/bmp-local/gobgp-peer-b/entrypoint.sh
+++ b/tests/e2e/bmp-local/gobgp-peer-b/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+gobgpd -f /etc/gobgpd.conf &
+BGPD_PID=$!
+
+for i in $(seq 1 30); do
+    if gobgp global 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+# Announce 10.1.0.0/24 (same prefix as peer-a; peer-a wins via lower router-id)
+gobgp global rib add 10.1.0.0/24 nexthop 172.30.20.3
+
+wait $BGPD_PID

--- a/tests/e2e/bmp-local/gobgp-peer-b/gobgpd.conf
+++ b/tests/e2e/bmp-local/gobgp-peer-b/gobgpd.conf
@@ -1,0 +1,11 @@
+[global.config]
+  as = 65003
+  router-id = "172.30.20.3"
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "172.30.20.1"
+    peer-as = 65001
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"

--- a/tests/e2e/bmp-local/run-test.sh
+++ b/tests/e2e/bmp-local/run-test.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# BMP Local-RIB End-to-End Test (RFC 9069)
+#
+# Topology:
+#   [gobgp-peer-a (AS 65002, router-id 172.30.20.2)] \
+#                                                      -- [rusty (AS 65001)] --> [bmp-receiver :11019]
+#   [gobgp-peer-b (AS 65003, router-id 172.30.20.3)] /
+#
+# Network: bmp-net 172.30.20.0/24
+#   rusty:         172.30.20.1
+#   gobgp-peer-a:  172.30.20.2
+#   gobgp-peer-b:  172.30.20.3
+#   bmp-receiver:  172.30.20.10
+#
+# peer-a announces: 10.1.0.0/24 and 10.2.0.0/24
+# peer-b announces: 10.1.0.0/24 (duplicate; peer-a wins via lower router-id 172.30.20.2 < 172.30.20.3)
+# BMP policy: local-rib, added via gobgp CLI after BGP convergence
+#
+# Test scenarios:
+#   1. Initiation received
+#   2. PeerUp for virtual Loc-RIB peer (peer_type=3, peer_addr=0.0.0.0)
+#   3. Loc-RIB RouteMonitoring for 10.1.0.0/24 with nexthop 172.30.20.2 (peer-a won)
+#   4. Loc-RIB RouteMonitoring for 10.2.0.0/24 with nexthop 172.30.20.2 (only from peer-a)
+#   5. EoR for Loc-RIB (peer_type=3)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+source ../shared/helpers.sh
+
+PASS=0
+FAIL=0
+
+pass() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+bmp_has() {
+    local desc="$1"
+    local filter="$2"
+    local count
+    count=$(docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | wc -l)
+    if [ "$count" -ge 1 ]; then
+        pass "$desc"
+    else
+        fail "$desc"
+        echo "    Filter: $filter"
+        echo "    BMP log (last 20):"
+        docker logs bmp-receiver 2>/dev/null | tail -20 | sed 's/^/      /'
+    fi
+}
+
+bmp_absent() {
+    local desc="$1"
+    local filter="$2"
+    local count
+    count=$(docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | wc -l)
+    if [ "$count" -eq 0 ]; then
+        pass "$desc"
+    else
+        fail "$desc"
+        echo "    Filter: $filter"
+        echo "    Unexpected matches:"
+        docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | head -5 | sed 's/^/      /'
+    fi
+}
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    docker compose down --volumes --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== BMP Local-RIB (RFC 9069) End-to-End Test ==="
+echo ""
+
+echo "Building and starting containers..."
+docker compose up -d --build --force-recreate 2>&1
+
+echo "Waiting for BGP sessions..."
+MAX_WAIT=60
+A_OK=false
+B_OK=false
+for i in $(seq 1 $MAX_WAIT); do
+    if ! $A_OK && [ "$(gobgp_bgp_state gobgp-peer-a 172.30.20.1)" = "Established" ]; then
+        A_OK=true
+        echo "  gobgp-peer-a <-> rusty established after ${i}s"
+    fi
+    if ! $B_OK && [ "$(gobgp_bgp_state gobgp-peer-b 172.30.20.1)" = "Established" ]; then
+        B_OK=true
+        echo "  gobgp-peer-b <-> rusty established after ${i}s"
+    fi
+    if $A_OK && $B_OK; then
+        break
+    fi
+    if [ "$i" -eq "$MAX_WAIT" ]; then
+        echo "BGP sessions did not fully establish within ${MAX_WAIT}s"
+        docker logs rusty 2>&1 | tail -20
+    fi
+    sleep 1
+done
+
+# Wait for routes to propagate and best-path selection to complete
+sleep 5
+
+echo "Adding BMP with 'local-rib' policy (snapshot)..."
+docker exec rusty gobgp bmp add 172.30.20.10 local-rib
+
+echo "Waiting for BMP Loc-RIB EoR..."
+for i in $(seq 1 30); do
+    if docker logs bmp-receiver 2>/dev/null | jq -e 'select(.type == "RouteMonitoring" and .eor == true and .peer_type == 3)' >/dev/null 2>&1; then
+        echo "  Loc-RIB EoR received after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+echo ""
+echo "--- Test Results ---"
+
+# Test 1: Initiation message
+bmp_has "Initiation received" '.type == "Initiation"'
+
+# Test 2: PeerUp for virtual Loc-RIB peer (peer_type=3, peer_addr=0.0.0.0)
+bmp_has "PeerUp for Loc-RIB virtual peer (peer_type=3)" \
+    '.type == "PeerUp" and .peer_type == 3 and .peer_addr == "0.0.0.0"'
+
+# Test 3: Loc-RIB RouteMonitoring for 10.1.0.0/24 with nexthop from peer-a (best path)
+bmp_has "Loc-RIB RouteMonitoring 10.1.0.0/24 nexthop=172.30.20.2 (peer-a wins)" \
+    '.type == "RouteMonitoring" and .peer_type == 3 and .prefix == "10.1.0.0/24" and .nexthop == "172.30.20.2" and .withdraw == false'
+
+# Test 4: Loc-RIB RouteMonitoring for 10.1.0.0/24 must not use peer-b's nexthop
+bmp_absent "Loc-RIB 10.1.0.0/24 with nexthop=172.30.20.3 absent (peer-b lost)" \
+    '.type == "RouteMonitoring" and .peer_type == 3 and .prefix == "10.1.0.0/24" and .nexthop == "172.30.20.3"'
+
+# Test 5: Loc-RIB RouteMonitoring for 10.2.0.0/24 from peer-a
+bmp_has "Loc-RIB RouteMonitoring 10.2.0.0/24" \
+    '.type == "RouteMonitoring" and .peer_type == 3 and .prefix == "10.2.0.0/24" and .withdraw == false'
+
+# Test 6: EoR for Loc-RIB
+bmp_has "EoR for Loc-RIB (peer_type=3, afi=1, safi=1)" \
+    '.type == "RouteMonitoring" and .eor == true and .peer_type == 3 and .afi == 1 and .safi == 1'
+
+# Test 7: No adj-rib-in messages (local-rib only)
+bmp_absent "No pre-policy adj-rib-in messages" \
+    '.type == "RouteMonitoring" and .peer_type == 0 and .post_policy == false and .adj_rib_out == false'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/e2e/bmp-local/rustybgp.yaml
+++ b/tests/e2e/bmp-local/rustybgp.yaml
@@ -1,0 +1,19 @@
+global:
+  config:
+    as: 65001
+    router-id: "172.30.20.1"
+
+neighbors:
+  - config:
+      neighbor-address: "172.30.20.2"
+      peer-as: 65002
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast
+
+  - config:
+      neighbor-address: "172.30.20.3"
+      peer-as: 65003
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast

--- a/tests/e2e/bmp-post/docker-compose.yml
+++ b/tests/e2e/bmp-post/docker-compose.yml
@@ -1,0 +1,45 @@
+networks:
+  bmp-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.20.0/24
+          gateway: 172.30.20.254
+
+services:
+  rusty:
+    build:
+      context: ${RUSTYBGP_BUILD_CONTEXT:-../../..}
+      dockerfile: ${RUSTYBGP_DOCKERFILE:-tests/e2e/shared/Dockerfile.rustybgp}
+      args:
+        RUST_TARGET: ${RUST_TARGET:-aarch64-unknown-linux-musl}
+    container_name: rusty
+    privileged: true
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.1
+    volumes:
+      - ./rustybgp.yaml:/etc/rustybgp.yaml:ro
+      - ./entrypoint-rusty.sh:/entrypoint.sh:ro
+
+  gobgp-peer:
+    build:
+      context: ../../..
+      dockerfile: tests/e2e/shared/Dockerfile.gobgp
+    container_name: gobgp-peer
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.2
+    volumes:
+      - ./gobgp-peer/gobgpd.conf:/etc/gobgpd.conf:ro
+      - ./gobgp-peer/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  bmp-receiver:
+    build:
+      context: ../shared/bmp-receiver
+      dockerfile: Dockerfile
+    container_name: bmp-receiver
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.10

--- a/tests/e2e/bmp-post/entrypoint-rusty.sh
+++ b/tests/e2e/bmp-post/entrypoint-rusty.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+rustybgpd -f /etc/rustybgp.yaml &
+BGPD_PID=$!
+
+MAX_ATTEMPTS=30
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    if gobgp global 2>/dev/null; then
+        echo "rustybgpd gRPC API is ready"
+        break
+    fi
+    if [ "$i" -eq "$MAX_ATTEMPTS" ]; then
+        echo "rustybgpd gRPC API not ready after $MAX_ATTEMPTS attempts"
+        exit 1
+    fi
+    sleep 1
+done
+
+wait $BGPD_PID

--- a/tests/e2e/bmp-post/gobgp-peer/entrypoint.sh
+++ b/tests/e2e/bmp-post/gobgp-peer/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+gobgpd -f /etc/gobgpd.conf &
+BGPD_PID=$!
+
+for i in $(seq 1 30); do
+    if gobgp global 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+gobgp global rib add 10.1.0.0/24 nexthop 172.30.20.2
+gobgp global rib add 10.2.0.0/24 nexthop 172.30.20.2
+
+wait $BGPD_PID

--- a/tests/e2e/bmp-post/gobgp-peer/gobgpd.conf
+++ b/tests/e2e/bmp-post/gobgp-peer/gobgpd.conf
@@ -1,0 +1,11 @@
+[global.config]
+  as = 65002
+  router-id = "172.30.20.2"
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "172.30.20.1"
+    peer-as = 65001
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"

--- a/tests/e2e/bmp-post/run-test.sh
+++ b/tests/e2e/bmp-post/run-test.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# BMP Both-Policy End-to-End Test
+#
+# Topology:
+#   [gobgp-peer (AS 65002)] -- [rusty (AS 65001)] --> [bmp-receiver :11019]
+#
+# Network: bmp-net 172.30.20.0/24
+#   rusty:        172.30.20.1
+#   gobgp-peer:   172.30.20.2
+#   bmp-receiver: 172.30.20.10
+#
+# Import policy on rusty: deny 10.2.0.0/24 from gobgp-peer
+# BMP policy: both (pre + post), added via gobgp CLI after BGP convergence
+#
+# Test scenarios:
+#   1. Initiation received
+#   2. PeerUp for gobgp-peer (snapshot)
+#   3. Pre-policy RouteMonitoring for 10.1.0.0/24 (accepted by import policy)
+#   4. Pre-policy RouteMonitoring for 10.2.0.0/24 (denied by import policy, visible pre)
+#   5. Post-policy RouteMonitoring for 10.1.0.0/24 (accepted)
+#   6. Post-policy RouteMonitoring for 10.2.0.0/24 absent (denied by import policy)
+#   7. EoR for pre-policy
+#   8. EoR for post-policy
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+source ../shared/helpers.sh
+
+PASS=0
+FAIL=0
+
+pass() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+bmp_has() {
+    local desc="$1"
+    local filter="$2"
+    local count
+    count=$(docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | wc -l)
+    if [ "$count" -ge 1 ]; then
+        pass "$desc"
+    else
+        fail "$desc"
+        echo "    Filter: $filter"
+        echo "    BMP log (last 20):"
+        docker logs bmp-receiver 2>/dev/null | tail -20 | sed 's/^/      /'
+    fi
+}
+
+bmp_absent() {
+    local desc="$1"
+    local filter="$2"
+    local count
+    count=$(docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | wc -l)
+    if [ "$count" -eq 0 ]; then
+        pass "$desc"
+    else
+        fail "$desc"
+        echo "    Filter: $filter"
+        echo "    Unexpected matches:"
+        docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | head -5 | sed 's/^/      /'
+    fi
+}
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    docker compose down --volumes --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== BMP Both-Policy End-to-End Test ==="
+echo ""
+
+echo "Building and starting containers..."
+docker compose up -d --build --force-recreate 2>&1
+
+echo "Waiting for BGP session..."
+MAX_WAIT=60
+for i in $(seq 1 $MAX_WAIT); do
+    if [ "$(gobgp_bgp_state gobgp-peer 172.30.20.1)" = "Established" ]; then
+        echo "  gobgp-peer <-> rusty established after ${i}s"
+        break
+    fi
+    if [ "$i" -eq "$MAX_WAIT" ]; then
+        echo "BGP session did not establish within ${MAX_WAIT}s"
+        docker logs rusty 2>&1 | tail -20
+    fi
+    sleep 1
+done
+
+# Wait for routes to propagate before adding BMP
+sleep 5
+
+echo "Adding BMP with 'both' policy (snapshot)..."
+docker exec rusty gobgp bmp add 172.30.20.10 both
+
+echo "Waiting for BMP snapshot (EoR for post-policy expected)..."
+for i in $(seq 1 30); do
+    if docker logs bmp-receiver 2>/dev/null | jq -e 'select(.type == "RouteMonitoring" and .eor == true and .post_policy == true)' >/dev/null 2>&1; then
+        echo "  BMP post-policy EoR received after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+echo ""
+echo "--- Test Results ---"
+
+# Test 1: Initiation message
+bmp_has "Initiation received" '.type == "Initiation"'
+
+# Test 2: PeerUp for gobgp-peer
+bmp_has "PeerUp for 172.30.20.2" '.type == "PeerUp" and .peer_addr == "172.30.20.2" and .peer_asn == 65002'
+
+# Test 3: Pre-policy RouteMonitoring for 10.1.0.0/24 (accepted by import policy)
+bmp_has "Pre-policy RouteMonitoring 10.1.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.1.0.0/24" and .post_policy == false and .withdraw == false'
+
+# Test 4: Pre-policy RouteMonitoring for 10.2.0.0/24 (denied, but visible pre-policy)
+bmp_has "Pre-policy RouteMonitoring 10.2.0.0/24 (denied route visible pre-policy)" \
+    '.type == "RouteMonitoring" and .prefix == "10.2.0.0/24" and .post_policy == false and .withdraw == false'
+
+# Test 5: Post-policy RouteMonitoring for 10.1.0.0/24 (accepted)
+bmp_has "Post-policy RouteMonitoring 10.1.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.1.0.0/24" and .post_policy == true and .withdraw == false'
+
+# Test 6: Post-policy RouteMonitoring for 10.2.0.0/24 must be absent (denied by import policy)
+bmp_absent "Post-policy RouteMonitoring 10.2.0.0/24 absent (denied by import policy)" \
+    '.type == "RouteMonitoring" and .prefix == "10.2.0.0/24" and .post_policy == true and .withdraw == false'
+
+# Test 7: EoR for pre-policy
+bmp_has "EoR for pre-policy (afi=1, safi=1)" \
+    '.type == "RouteMonitoring" and .eor == true and .afi == 1 and .safi == 1 and .post_policy == false'
+
+# Test 8: EoR for post-policy
+bmp_has "EoR for post-policy (afi=1, safi=1)" \
+    '.type == "RouteMonitoring" and .eor == true and .afi == 1 and .safi == 1 and .post_policy == true'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/e2e/bmp-post/rustybgp.yaml
+++ b/tests/e2e/bmp-post/rustybgp.yaml
@@ -1,0 +1,35 @@
+global:
+  config:
+    as: 65001
+    router-id: "172.30.20.1"
+  apply-policy:
+    config:
+      import-policy-list:
+        - deny-10-2
+      default-import-policy: accept-route
+
+neighbors:
+  - config:
+      neighbor-address: "172.30.20.2"
+      peer-as: 65002
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast
+
+defined-sets:
+  prefix-sets:
+    - prefix-set-name: prefix-10-2
+      prefix-list:
+        - ip-prefix: "10.2.0.0/24"
+          masklength-range: "24..24"
+
+policy-definitions:
+  - name: deny-10-2
+    statements:
+      - name: s1
+        conditions:
+          match-prefix-set:
+            prefix-set: prefix-10-2
+            match-set-options: any
+        actions:
+          route-disposition: reject-route

--- a/tests/e2e/bmp-pre/docker-compose.yml
+++ b/tests/e2e/bmp-pre/docker-compose.yml
@@ -1,0 +1,45 @@
+networks:
+  bmp-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.20.0/24
+          gateway: 172.30.20.254
+
+services:
+  rusty:
+    build:
+      context: ${RUSTYBGP_BUILD_CONTEXT:-../../..}
+      dockerfile: ${RUSTYBGP_DOCKERFILE:-tests/e2e/shared/Dockerfile.rustybgp}
+      args:
+        RUST_TARGET: ${RUST_TARGET:-aarch64-unknown-linux-musl}
+    container_name: rusty
+    privileged: true
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.1
+    volumes:
+      - ./rustybgp.yaml:/etc/rustybgp.yaml:ro
+      - ./entrypoint-rusty.sh:/entrypoint.sh:ro
+
+  gobgp-peer:
+    build:
+      context: ../../..
+      dockerfile: tests/e2e/shared/Dockerfile.gobgp
+    container_name: gobgp-peer
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.2
+    volumes:
+      - ./gobgp-peer/gobgpd.conf:/etc/gobgpd.conf:ro
+      - ./gobgp-peer/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  bmp-receiver:
+    build:
+      context: ../shared/bmp-receiver
+      dockerfile: Dockerfile
+    container_name: bmp-receiver
+    networks:
+      bmp-net:
+        ipv4_address: 172.30.20.10

--- a/tests/e2e/bmp-pre/entrypoint-rusty.sh
+++ b/tests/e2e/bmp-pre/entrypoint-rusty.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+rustybgpd -f /etc/rustybgp.yaml &
+BGPD_PID=$!
+
+MAX_ATTEMPTS=30
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    if gobgp global 2>/dev/null; then
+        echo "rustybgpd gRPC API is ready"
+        break
+    fi
+    if [ "$i" -eq "$MAX_ATTEMPTS" ]; then
+        echo "rustybgpd gRPC API not ready after $MAX_ATTEMPTS attempts"
+        exit 1
+    fi
+    sleep 1
+done
+
+wait $BGPD_PID

--- a/tests/e2e/bmp-pre/gobgp-peer/entrypoint.sh
+++ b/tests/e2e/bmp-pre/gobgp-peer/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+gobgpd -f /etc/gobgpd.conf &
+BGPD_PID=$!
+
+for i in $(seq 1 30); do
+    if gobgp global 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+gobgp global rib add 10.1.0.0/24 nexthop 172.30.20.2
+
+wait $BGPD_PID

--- a/tests/e2e/bmp-pre/gobgp-peer/gobgpd.conf
+++ b/tests/e2e/bmp-pre/gobgp-peer/gobgpd.conf
@@ -1,0 +1,11 @@
+[global.config]
+  as = 65002
+  router-id = "172.30.20.2"
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "172.30.20.1"
+    peer-as = 65001
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"

--- a/tests/e2e/bmp-pre/run-test.sh
+++ b/tests/e2e/bmp-pre/run-test.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# BMP Pre-Policy End-to-End Test
+#
+# Topology:
+#   [gobgp-peer (AS 65002)] -- [rusty (AS 65001)] --> [bmp-receiver :11019]
+#
+# Network: bmp-net 172.30.20.0/24
+#   rusty:        172.30.20.1
+#   gobgp-peer:   172.30.20.2
+#   bmp-receiver: 172.30.20.10
+#
+# BMP policy: pre-policy (configured in rustybgp.yaml from start)
+#
+# Test scenarios:
+#   1. Initiation message received from rusty
+#   2. PeerUp for gobgp-peer (live event)
+#   3. RouteMonitoring pre-policy for 10.1.0.0/24 (live event)
+#   4. End-of-RIB for IPv4 unicast (live event)
+#   5. Live: new route 10.2.0.0/24 announced
+#   6. Live: route 10.1.0.0/24 withdrawn
+#   7. Live: PeerDown when gobgp-peer stops
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+source ../shared/helpers.sh
+
+PASS=0
+FAIL=0
+
+pass() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+bmp_has() {
+    local desc="$1"
+    local filter="$2"
+    local count
+    count=$(docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | wc -l)
+    if [ "$count" -ge 1 ]; then
+        pass "$desc"
+    else
+        fail "$desc"
+        echo "    Filter: $filter"
+        echo "    BMP log (last 20):"
+        docker logs bmp-receiver 2>/dev/null | tail -20 | sed 's/^/      /'
+    fi
+}
+
+bmp_absent() {
+    local desc="$1"
+    local filter="$2"
+    local count
+    count=$(docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | wc -l)
+    if [ "$count" -eq 0 ]; then
+        pass "$desc"
+    else
+        fail "$desc"
+        echo "    Filter: $filter"
+        echo "    Unexpected matches:"
+        docker logs bmp-receiver 2>/dev/null | jq -c "select($filter)" | head -5 | sed 's/^/      /'
+    fi
+}
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    docker compose down --volumes --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== BMP Pre-Policy End-to-End Test ==="
+echo ""
+
+echo "Building and starting containers..."
+docker compose up -d --build --force-recreate 2>&1
+
+echo "Waiting for BGP session..."
+MAX_WAIT=60
+PEER_OK=false
+for i in $(seq 1 $MAX_WAIT); do
+    if [ "$(gobgp_bgp_state gobgp-peer 172.30.20.1)" = "Established" ]; then
+        PEER_OK=true
+        echo "  gobgp-peer <-> rusty established after ${i}s"
+        break
+    fi
+    if [ "$i" -eq "$MAX_WAIT" ]; then
+        echo "BGP session did not establish within ${MAX_WAIT}s"
+        docker logs rusty 2>&1 | tail -20
+    fi
+    sleep 1
+done
+
+# Wait for BMP messages to arrive (Initiation + PeerUp + RouteMonitoring + EoR)
+echo "Waiting for BMP Initiation..."
+for i in $(seq 1 30); do
+    if docker logs bmp-receiver 2>/dev/null | jq -e 'select(.type == "Initiation")' >/dev/null 2>&1; then
+        echo "  BMP Initiation received after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+# Wait for EoR to confirm all initial messages delivered
+for i in $(seq 1 30); do
+    if docker logs bmp-receiver 2>/dev/null | jq -e 'select(.type == "RouteMonitoring" and .eor == true)' >/dev/null 2>&1; then
+        echo "  BMP EoR received after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+echo ""
+echo "--- Test Results (initial BMP messages) ---"
+
+# Test 1: Initiation message received
+bmp_has "Initiation received" '.type == "Initiation"'
+
+# Test 2: PeerUp for gobgp-peer
+bmp_has "PeerUp for 172.30.20.2" '.type == "PeerUp" and .peer_addr == "172.30.20.2" and .peer_asn == 65002'
+
+# Test 3: RouteMonitoring pre-policy for 10.1.0.0/24
+bmp_has "RouteMonitoring pre-policy 10.1.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.1.0.0/24" and .post_policy == false and .adj_rib_out == false and .withdraw == false'
+
+# Test 4: No post-policy messages (pre-policy only)
+bmp_absent "No post-policy RouteMonitoring" '.type == "RouteMonitoring" and .post_policy == true'
+
+# Test 5: EoR for IPv4 unicast
+bmp_has "EoR for IPv4 unicast (pre-policy)" \
+    '.type == "RouteMonitoring" and .eor == true and .afi == 1 and .safi == 1 and .post_policy == false'
+
+# --- Live event tests ---
+echo ""
+echo "--- Live event tests ---"
+
+echo "Injecting new route 10.2.0.0/24..."
+docker exec gobgp-peer gobgp global rib add 10.2.0.0/24 nexthop 172.30.20.2
+sleep 3
+
+# Test 6: Live RouteMonitoring for new route
+bmp_has "Live RouteMonitoring for 10.2.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.2.0.0/24" and .post_policy == false and .withdraw == false'
+
+echo "Withdrawing 10.1.0.0/24..."
+docker exec gobgp-peer gobgp global rib del 10.1.0.0/24
+sleep 3
+
+# Test 7: Live RouteMonitoring withdraw for 10.1.0.0/24
+bmp_has "Live RouteMonitoring withdraw 10.1.0.0/24" \
+    '.type == "RouteMonitoring" and .prefix == "10.1.0.0/24" and .withdraw == true'
+
+echo "Stopping gobgp-peer..."
+docker compose stop gobgp-peer
+sleep 5
+
+# Test 8: PeerDown received
+bmp_has "PeerDown for 172.30.20.2" \
+    '.type == "PeerDown" and .peer_addr == "172.30.20.2"'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/e2e/bmp-pre/rustybgp.yaml
+++ b/tests/e2e/bmp-pre/rustybgp.yaml
@@ -1,0 +1,18 @@
+global:
+  config:
+    as: 65001
+    router-id: "172.30.20.1"
+
+bmp-servers:
+  - config:
+      address: "172.30.20.10"
+      port: 11019
+      route-monitoring-policy: pre-policy
+
+neighbors:
+  - config:
+      neighbor-address: "172.30.20.2"
+      peer-as: 65002
+    afi-safis:
+      - config:
+          afi-safi-name: ipv4-unicast

--- a/tests/e2e/shared/bmp-receiver/Dockerfile
+++ b/tests/e2e/shared/bmp-receiver/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.23-alpine AS builder
+WORKDIR /src
+COPY go.mod .
+COPY main.go .
+RUN go mod tidy && go build -o /bmp-receiver .
+
+FROM alpine:3.21
+COPY --from=builder /bmp-receiver /usr/local/bin/bmp-receiver
+ENTRYPOINT ["bmp-receiver"]

--- a/tests/e2e/shared/bmp-receiver/go.mod
+++ b/tests/e2e/shared/bmp-receiver/go.mod
@@ -1,0 +1,5 @@
+module bmp-receiver
+
+go 1.23
+
+require github.com/osrg/gobgp/v3 v3.37.0

--- a/tests/e2e/shared/bmp-receiver/main.go
+++ b/tests/e2e/shared/bmp-receiver/main.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+
+	bgpPkg "github.com/osrg/gobgp/v3/pkg/packet/bgp"
+	"github.com/osrg/gobgp/v3/pkg/packet/bmp"
+)
+
+func main() {
+	ln, err := net.Listen("tcp", ":11019")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen: %v\n", err)
+		os.Exit(1)
+	}
+	log.Printf("bmp-receiver listening on :11019")
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			log.Printf("accept: %v", err)
+			continue
+		}
+		go handleConn(conn)
+	}
+}
+
+func handleConn(conn net.Conn) {
+	defer conn.Close()
+	log.Printf("connection from %s", conn.RemoteAddr())
+	for {
+		raw, err := readBMPMessage(conn)
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("read: %v", err)
+			}
+			return
+		}
+		msg, err := bmp.ParseBMPMessage(raw)
+		if err != nil {
+			log.Printf("parse: %v", err)
+			continue
+		}
+		handleMsg(msg)
+	}
+}
+
+func readBMPMessage(conn net.Conn) ([]byte, error) {
+	hdr := make([]byte, bmp.BMP_HEADER_SIZE)
+	if _, err := io.ReadFull(conn, hdr); err != nil {
+		return nil, err
+	}
+	msgLen := binary.BigEndian.Uint32(hdr[1:5])
+	if msgLen < uint32(bmp.BMP_HEADER_SIZE) {
+		return nil, fmt.Errorf("invalid BMP message length: %d", msgLen)
+	}
+	rest := make([]byte, msgLen-uint32(bmp.BMP_HEADER_SIZE))
+	if _, err := io.ReadFull(conn, rest); err != nil {
+		return nil, err
+	}
+	return append(hdr, rest...), nil
+}
+
+func emit(m map[string]interface{}) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		log.Printf("marshal: %v", err)
+		return
+	}
+	fmt.Println(string(data))
+}
+
+func handleMsg(msg *bmp.BMPMessage) {
+	switch body := msg.Body.(type) {
+	case *bmp.BMPInitiation:
+		m := map[string]interface{}{"type": "Initiation"}
+		for _, tlv := range body.Info {
+			if s, ok := tlv.(*bmp.BMPInfoTLVString); ok {
+				switch s.Type {
+				case bmp.BMP_INIT_TLV_TYPE_SYS_NAME:
+					m["sysname"] = s.Value
+				case bmp.BMP_INIT_TLV_TYPE_SYS_DESCR:
+					m["sysdescr"] = s.Value
+				}
+			}
+		}
+		emit(m)
+
+	case *bmp.BMPPeerUpNotification:
+		ph := &msg.PeerHeader
+		emit(map[string]interface{}{
+			"type":        "PeerUp",
+			"peer_type":   ph.PeerType,
+			"peer_addr":   ph.PeerAddress.String(),
+			"peer_asn":    ph.PeerAS,
+			"bgp_id":      ph.PeerBGPID.String(),
+			"post_policy": ph.IsPostPolicy(),
+			"adj_rib_out": ph.IsAdjRIBOut(),
+			"local_addr":  body.LocalAddress.String(),
+		})
+
+	case *bmp.BMPPeerDownNotification:
+		ph := &msg.PeerHeader
+		emit(map[string]interface{}{
+			"type":      "PeerDown",
+			"peer_type": ph.PeerType,
+			"peer_addr": ph.PeerAddress.String(),
+			"peer_asn":  ph.PeerAS,
+			"reason":    body.Reason,
+		})
+
+	case *bmp.BMPRouteMonitoring:
+		ph := &msg.PeerHeader
+		update, ok := body.BGPUpdate.Body.(*bgpPkg.BGPUpdate)
+		if !ok {
+			return
+		}
+		postPolicy := ph.IsPostPolicy()
+		adjRIBOut := ph.IsAdjRIBOut()
+		peerType := ph.PeerType
+
+		// Detect EoR: empty update with no path attributes (IPv4 EoR)
+		if len(update.NLRI) == 0 && len(update.WithdrawnRoutes) == 0 {
+			// Check for MP_UNREACH_NLRI EoR (non-IPv4) or plain IPv4 EoR
+			afi, safi := uint16(bgpPkg.AFI_IP), uint8(bgpPkg.SAFI_UNICAST)
+			isEoR := true
+			for _, pa := range update.PathAttributes {
+				if pa.GetType() == bgpPkg.BGP_ATTR_TYPE_MP_UNREACH_NLRI {
+					mp := pa.(*bgpPkg.PathAttributeMpUnreachNLRI)
+					if len(mp.Value) == 0 {
+						afi = mp.AFI
+						safi = mp.SAFI
+					} else {
+						isEoR = false
+					}
+				} else {
+					isEoR = false
+					break
+				}
+			}
+			if isEoR {
+				emit(map[string]interface{}{
+					"type":        "RouteMonitoring",
+					"peer_type":   peerType,
+					"peer_addr":   ph.PeerAddress.String(),
+					"peer_asn":    ph.PeerAS,
+					"post_policy": postPolicy,
+					"adj_rib_out": adjRIBOut,
+					"eor":         true,
+					"afi":         afi,
+					"safi":        safi,
+				})
+				return
+			}
+		}
+
+		// Extract nexthop from path attributes
+		nexthop := ""
+		for _, pa := range update.PathAttributes {
+			switch pa.GetType() {
+			case bgpPkg.BGP_ATTR_TYPE_NEXT_HOP:
+				nexthop = pa.(*bgpPkg.PathAttributeNextHop).Value.String()
+			case bgpPkg.BGP_ATTR_TYPE_MP_REACH_NLRI:
+				mp := pa.(*bgpPkg.PathAttributeMpReachNLRI)
+				if len(mp.Nexthop) > 0 {
+					nexthop = mp.Nexthop.String()
+				}
+				for _, nlri := range mp.Value {
+					emit(map[string]interface{}{
+						"type":        "RouteMonitoring",
+						"peer_type":   peerType,
+						"peer_addr":   ph.PeerAddress.String(),
+						"peer_asn":    ph.PeerAS,
+						"post_policy": postPolicy,
+						"adj_rib_out": adjRIBOut,
+						"prefix":      nlri.String(),
+						"nexthop":     nexthop,
+						"withdraw":    false,
+					})
+				}
+			case bgpPkg.BGP_ATTR_TYPE_MP_UNREACH_NLRI:
+				mp := pa.(*bgpPkg.PathAttributeMpUnreachNLRI)
+				for _, nlri := range mp.Value {
+					emit(map[string]interface{}{
+						"type":        "RouteMonitoring",
+						"peer_type":   peerType,
+						"peer_addr":   ph.PeerAddress.String(),
+						"peer_asn":    ph.PeerAS,
+						"post_policy": postPolicy,
+						"adj_rib_out": adjRIBOut,
+						"prefix":      nlri.String(),
+						"withdraw":    true,
+					})
+				}
+			}
+		}
+
+		// IPv4 unicast reach
+		for _, nlri := range update.NLRI {
+			emit(map[string]interface{}{
+				"type":        "RouteMonitoring",
+				"peer_type":   peerType,
+				"peer_addr":   ph.PeerAddress.String(),
+				"peer_asn":    ph.PeerAS,
+				"post_policy": postPolicy,
+				"adj_rib_out": adjRIBOut,
+				"prefix":      nlri.String(),
+				"nexthop":     nexthop,
+				"withdraw":    false,
+			})
+		}
+
+		// IPv4 unicast withdraw
+		for _, nlri := range update.WithdrawnRoutes {
+			emit(map[string]interface{}{
+				"type":        "RouteMonitoring",
+				"peer_type":   peerType,
+				"peer_addr":   ph.PeerAddress.String(),
+				"peer_asn":    ph.PeerAS,
+				"post_policy": postPolicy,
+				"adj_rib_out": adjRIBOut,
+				"prefix":      nlri.String(),
+				"withdraw":    true,
+			})
+		}
+
+	case *bmp.BMPTermination:
+		emit(map[string]interface{}{"type": "Termination"})
+	}
+}


### PR DESCRIPTION
Four new Docker Compose-based tests verify the BMP monitoring policies that were added in the recent BMP implementation commits:

- bmp-pre: verifies Adj-RIB-In pre-policy snapshot and live events (Initiation, PeerUp, RouteMonitoring REACH/WITHDRAW, EoR, PeerDown)
- bmp-post: verifies both-policy snapshot against a global import policy that denies 10.2.0.0/24; confirms denied routes appear pre-policy but not post-policy
- bmp-local: verifies Loc-RIB (RFC 9069) snapshot with two competing peers for 10.1.0.0/24; confirms best-path selection via peer-type=3 virtual peer
- bmp-all: verifies all-policy (pre+post+local-rib+adj-rib-out); snapshot checks, then live injection to confirm Adj-RIB-Out pre/post events against a global export policy that denies 10.2.0.0/24

The BMP receiver is a Go program using the GoBGP library (v3.37.0) that prints one JSON line per BMP message.  Test scripts use jq to verify the JSON output.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>