### PR TITLE
config: reject per-neighbor apply-policy in YAML

### DIFF
--- a/config/src/validate.rs
+++ b/config/src/validate.rs
@@ -143,6 +143,13 @@ impl Neighbor {
             ));
         }
 
+        if self.apply_policy.is_some() {
+            return Err(ConfigError::InvalidConfiguration(format!(
+                "neighbor {}: per-neighbor apply-policy is not supported; configure policy under global",
+                addr
+            )));
+        }
+
         // Validate per-family add-paths send_max
         if let Some(afi_safis) = self.afi_safis.as_ref() {
             for afi_safi in afi_safis {


### PR DESCRIPTION
Per-neighbor apply-policy was a GoBGP concept that has since been removed from GoBGP.  RustyBGP has never implemented per-peer policy storage; only a single global import and export assignment exists in the policy table.

The YAML loader silently ignored apply-policy under a neighbor, giving users no feedback that their policy had no effect.  Catch this at startup and return an error with a hint to move the policy to global.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>