### PR TITLE
ci: fix missing protoc in release build containers

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -20,9 +20,14 @@ jobs:
             arch: aarch64
     steps:
       - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
       - name: Build static binary
         run: |
-          docker run --rm -v "$(pwd)":/home/rust/src \
+          docker run --rm \
+            -v "$(pwd)":/home/rust/src \
+            -v /usr/bin/protoc:/usr/bin/protoc \
+            -e PROTOC=/usr/bin/protoc \
             ghcr.io/rust-cross/rust-musl-cross:${{ matrix.target }} \
             cargo build --release
       - name: Package

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -21,9 +21,14 @@ jobs:
             arch: aarch64
     steps:
       - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
       - name: Build static binary
         run: |
-          docker run --rm -v "$(pwd)":/home/rust/src \
+          docker run --rm \
+            -v "$(pwd)":/home/rust/src \
+            -v /usr/bin/protoc:/usr/bin/protoc \
+            -e PROTOC=/usr/bin/protoc \
             ghcr.io/rust-cross/rust-musl-cross:${{ matrix.target }} \
             cargo build --release
       - name: Package


### PR DESCRIPTION
The musl-cross Docker images do not include protoc, causing rustybgp-api to fail at build time. Install protoc on the runner host and mount it into the container via PROTOC env var.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>