### PR TITLE
ci: install protoc inside the build container

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -20,16 +20,11 @@ jobs:
             arch: aarch64
     steps:
       - uses: actions/checkout@v4
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
       - name: Build static binary
         run: |
-          docker run --rm \
-            -v "$(pwd)":/home/rust/src \
-            -v /usr/bin/protoc:/usr/bin/protoc \
-            -e PROTOC=/usr/bin/protoc \
+          docker run --rm -v "$(pwd)":/home/rust/src \
             ghcr.io/rust-cross/rust-musl-cross:${{ matrix.target }} \
-            cargo build --release
+            sh -c "apt-get update -q && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev && cargo build --release"
       - name: Package
         run: |
           cp target/${{ matrix.target }}/release/rustybgpd .

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -21,16 +21,11 @@ jobs:
             arch: aarch64
     steps:
       - uses: actions/checkout@v4
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
       - name: Build static binary
         run: |
-          docker run --rm \
-            -v "$(pwd)":/home/rust/src \
-            -v /usr/bin/protoc:/usr/bin/protoc \
-            -e PROTOC=/usr/bin/protoc \
+          docker run --rm -v "$(pwd)":/home/rust/src \
             ghcr.io/rust-cross/rust-musl-cross:${{ matrix.target }} \
-            cargo build --release
+            sh -c "apt-get update -q && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev && cargo build --release"
       - name: Package
         run: |
           cp target/${{ matrix.target }}/release/rustybgpd .


### PR DESCRIPTION
The musl-cross Docker images do not include protoc. Install protobuf-compiler and libprotobuf-dev inside the container instead of mounting from the host; api/build.rs needs libprotobuf-dev for google/protobuf/timestamp.proto via /usr/include/.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>