### PR TITLE
daemon: default listen port to 179 in config file; reject port: 0

### DIFF
--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -767,14 +767,22 @@ impl Global {
             if let Some(router_id) = global_config.router_id {
                 self.router_id = router_id;
             }
-            if let Some(port) = global_config.port {
-                self.listen_port = match port {
-                    i32::MIN..=-1 => None,
-                    0 => Some(Global::BGP_PORT),
-                    1..=65535 => Some(port as u16),
-                    _ => return Err(Error::InvalidArgument("invalid listen port".to_string())),
+            // When port is absent in the config file, default to BGP_PORT (179).
+            // Explicit port: -1 disables listening; port: 0 is rejected because
+            // it is ambiguous (the gRPC API uses 0 to mean "default", but the
+            // config file should be unambiguous).
+            self.listen_port = match global_config.port {
+                None => Some(Global::BGP_PORT),
+                Some(i32::MIN..=-1) => None,
+                Some(0) => {
+                    return Err(Error::InvalidArgument(
+                        "port 0 is not valid in config; use port: -1 to disable listening"
+                            .to_string(),
+                    ));
                 }
-            }
+                Some(p @ 1..=65535) => Some(p as u16),
+                Some(_) => return Err(Error::InvalidArgument("invalid listen port".to_string())),
+            };
         }
 
         if let Some((id, c)) = config
@@ -9431,6 +9439,70 @@ port = 3323
             dests.len(),
             1,
             "adj-out must show the injected route for an Established peer"
+        );
+    }
+
+    // --- apply_config listen-port tests ---
+
+    fn bare_global() -> Global {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let (bfd_tx, _bfd_rx) = mpsc::unbounded_channel();
+        Global::new(tx, bfd_tx)
+    }
+
+    fn port_config(port: Option<i32>) -> config::BgpConfig {
+        config::BgpConfig {
+            global: Some(config::generate::Global {
+                config: Some(config::generate::GlobalConfig {
+                    r#as: Some(65001),
+                    router_id: Some(std::net::Ipv4Addr::new(10, 0, 0, 1)),
+                    port,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn apply_config_port_absent_defaults_to_179() {
+        let mut g = bare_global();
+        g.apply_config(make_tables(), &port_config(None)).unwrap();
+        assert_eq!(g.listen_port, Some(Global::BGP_PORT));
+    }
+
+    #[test]
+    fn apply_config_port_minus_one_disables_listen() {
+        let mut g = bare_global();
+        g.apply_config(make_tables(), &port_config(Some(-1)))
+            .unwrap();
+        assert_eq!(g.listen_port, None);
+    }
+
+    #[test]
+    fn apply_config_port_valid_sets_port() {
+        let mut g = bare_global();
+        g.apply_config(make_tables(), &port_config(Some(1179)))
+            .unwrap();
+        assert_eq!(g.listen_port, Some(1179));
+    }
+
+    #[test]
+    fn apply_config_port_zero_is_error() {
+        let mut g = bare_global();
+        assert!(
+            g.apply_config(make_tables(), &port_config(Some(0)))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn apply_config_port_out_of_range_is_error() {
+        let mut g = bare_global();
+        assert!(
+            g.apply_config(make_tables(), &port_config(Some(65536)))
+                .is_err()
         );
     }
 }


### PR DESCRIPTION
Previously, if the config file did not specify a `port` field, rustybgpd would not listen on any TCP port, forcing every session to be initiated by rustybgpd.  This was a silent footgun: sessions worked in most e2e tests only because rustybgpd happened to connect first, but any peer that tries to connect inbound (e.g. the FRR side of RFC 7938 unnumbered BGP) could never establish.

Other production BGP daemons (BIRD, FRR) always listen on 179 by default. Align with that behavior: when `port` is absent from the config file, use BGP_PORT (179).  To explicitly disable listening, set `port: -1`.

`port: 0` is rejected in the config file with an InvalidArgument error. The gRPC StartBgp path keeps `listen_port = 0` mapped to BGP_PORT for GoBGP client compatibility, where 0 is the conventional "use default".

Five unit tests cover the new behavior:
  apply_config_port_absent_defaults_to_179
  apply_config_port_minus_one_disables_listen
  apply_config_port_valid_sets_port
  apply_config_port_zero_is_error
  apply_config_port_out_of_range_is_error

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>