### PR TITLE
ci: add Long-Lived Graceful Restart e2e job to pull request workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,6 +115,28 @@ jobs:
           RUSTYBGP_DOCKERFILE: Dockerfile
         run: ./run-test.sh
 
+  e2e-llgr:
+    name: Long-Lived Graceful Restart (RFC 9494)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: rustybgpd-musl
+          path: /tmp/rustybgp-prebuilt
+      - name: prepare prebuilt context
+        run: |
+          chmod +x /tmp/rustybgp-prebuilt/rustybgpd
+          cp tests/e2e/shared/Dockerfile.rustybgp-prebuilt /tmp/rustybgp-prebuilt/Dockerfile
+      - name: Run Long-Lived Graceful Restart e2e test
+        working-directory: tests/e2e/long-lived-graceful-restart
+        env:
+          RUSTYBGP_BUILD_CONTEXT: /tmp/rustybgp-prebuilt
+          RUSTYBGP_DOCKERFILE: Dockerfile
+        run: ./run-test.sh
+
   e2e-flowspec:
     name: BGP Flowspec (RFC 8955/8956)
     needs: build


### PR DESCRIPTION
Add e2e-llgr job after e2e-gr-helper so that the GR and LLGR tests are grouped together in the workflow.  The test covers GR+LLGR timer sequencing, NO_LLGR community route dropping, LLGR timer expiry, and session recovery during both stale periods.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>