### PR TITLE
daemon: add value_parser for --router-id argument

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -59,6 +59,7 @@ async fn main() -> Result<(), std::io::Error> {
             Arg::new("id")
                 .long("router-id")
                 .num_args(1)
+                .value_parser(clap::value_parser!(std::net::Ipv4Addr))
                 .help("specify router id"),
         )
         .arg(


### PR DESCRIPTION
clap 4.5.60 tightened type checking: get_one::<Ipv4Addr>() panics at runtime if the argument was not defined with a matching value_parser. Adding value_parser(clap::value_parser!(Ipv4Addr)) to the definition aligns the stored type with the accessor type.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>