### PR TITLE
ci: force-update nightly git tag on each master push

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -39,6 +39,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - name: Move nightly tag to current commit
+        run: |
+          git tag -f nightly
+          git push origin -f nightly
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true


### PR DESCRIPTION
softprops/action-gh-release updates release assets but does not move the git tag to the triggering commit. Add an explicit checkout and force-push step so the nightly tag always points to the commit that produced the published binaries.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>