### PR TITLE
peer_tx,daemon: bypass per-NLRI HashMap during initial advertisement

### DIFF
--- a/daemon/src/event/export.rs
+++ b/daemon/src/event/export.rs
@@ -432,6 +432,64 @@ impl NlriSink for AdjOutSink {
     }
 }
 
+type GroupedAttrKey = (Arc<Vec<packet::Attribute>>, Option<bgp::Nexthop>);
+
+/// `NlriSink` that groups routes by (attr, nexthop) directly, bypassing the
+/// per-NLRI HashMap in `PendingTx`.
+///
+/// Used during `on_established` initial advertisement where no unreach can
+/// occur (export_map is empty).  Routes are collected into groups and
+/// converted to `bgp::Message` via `into_messages()`, then passed to
+/// `PendingTx::buffer_messages()`.
+pub(super) struct GroupedSink {
+    addpath_tx: bool,
+    grouped: FnvHashMap<GroupedAttrKey, Vec<packet::PathNlri>>,
+}
+
+impl GroupedSink {
+    pub(super) fn new(addpath_tx: bool) -> Self {
+        GroupedSink {
+            addpath_tx,
+            grouped: FnvHashMap::default(),
+        }
+    }
+
+    pub(super) fn into_messages(self, family: bgp::Family) -> Vec<bgp::Message> {
+        self.grouped
+            .into_iter()
+            .map(|((attr, nexthop), entries)| {
+                bgp::Message::Update(bgp::Update::Reach {
+                    family,
+                    entries,
+                    nexthop,
+                    attr,
+                })
+            })
+            .collect()
+    }
+}
+
+impl NlriSink for GroupedSink {
+    fn reach(
+        &mut self,
+        nlri: packet::Nlri,
+        path_id: u32,
+        nexthop: Option<bgp::Nexthop>,
+        attr: Arc<Vec<packet::Attribute>>,
+        _source: &Arc<table::Source>,
+    ) {
+        let key = packet::PathNlri {
+            path_id: if self.addpath_tx { path_id } else { 0 },
+            nlri,
+        };
+        self.grouped.entry((attr, nexthop)).or_default().push(key);
+    }
+
+    fn unreach(&mut self, _nlri: packet::Nlri, _path_id: u32) {
+        // Initial dump: export_map is empty so this is never called.
+    }
+}
+
 /// Core routing-update logic shared by handle_prefix_update() and unit tests.
 ///
 /// Computes which BGP messages to send based on `update` and the peer's

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -2447,6 +2447,8 @@ impl PeerSession {
                         continue;
                     }
                     let effective_max = family_effective_max.get(f).copied().unwrap_or(1);
+                    let addpath_tx = self.pending.get(f).map(|p| p.addpath_tx()).unwrap_or(false);
+                    let mut sink = crate::event::export::GroupedSink::new(addpath_tx);
                     for change in rtable.collect_loc_rib_paths(f) {
                         if crate::rtc::is_vpn_family(change.family)
                             && let (Some(filter), Some(best)) = (&rtc_filter, change.new_best())
@@ -2454,21 +2456,21 @@ impl PeerSession {
                         {
                             continue;
                         }
-                        let Some(pending) = self.pending.get_mut(&change.family) else {
-                            continue;
-                        };
                         process_nlri_change(
                             &change,
                             effective_max,
                             self.remote_addr,
                             &mut self.export_map,
-                            pending,
+                            &mut sink,
                             &self.export_ctx,
                             export_policy.as_deref(),
                             self.cluster_id,
                             Some(&rpki),
                             None,
                         );
+                    }
+                    if let Some(pending) = self.pending.get_mut(f) {
+                        pending.buffer_messages(sink.into_messages(*f));
                     }
                 }
             });

--- a/daemon/src/peer_tx.rs
+++ b/daemon/src/peer_tx.rs
@@ -30,6 +30,9 @@ pub(crate) struct PendingTx {
     unreach: FnvHashSet<packet::PathNlri>,
     pending_eor: bool,
     addpath_tx: bool,
+    /// Pre-built UPDATE messages from the initial dump.  Drained first by
+    /// `drain_messages()` before incremental reach/unreach processing.
+    buffered: Vec<bgp::Message>,
 }
 
 impl PendingTx {
@@ -39,11 +42,26 @@ impl PendingTx {
             unreach: FnvHashSet::default(),
             pending_eor: true,
             addpath_tx,
+            buffered: Vec::new(),
         }
     }
 
+    pub(crate) fn addpath_tx(&self) -> bool {
+        self.addpath_tx
+    }
+
+    /// Enqueue pre-built UPDATE messages from the initial dump.
+    /// These are emitted before any incremental reach/unreach in `drain_messages()`.
+    pub(crate) fn buffer_messages(&mut self, msgs: Vec<bgp::Message>) {
+        debug_assert!(
+            self.buffered.is_empty(),
+            "buffer_messages called on non-empty buffer"
+        );
+        self.buffered = msgs;
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
-        self.reach.is_empty() && self.unreach.is_empty()
+        self.buffered.is_empty() && self.reach.is_empty() && self.unreach.is_empty()
     }
 
     pub(crate) fn schedule_eor(&mut self) {
@@ -79,7 +97,8 @@ impl PendingTx {
     /// Returns a list of UPDATE messages ready for encoding. The caller is
     /// responsible for encoding and writing them to the wire.
     pub(crate) fn drain_messages(&mut self, family: Family) -> Vec<bgp::Message> {
-        let mut messages = Vec::new();
+        // Start with pre-built messages from the initial dump (GroupedSink).
+        let mut messages = std::mem::take(&mut self.buffered);
 
         // 1. Withdrawals
         if !self.unreach.is_empty() {
@@ -430,6 +449,48 @@ mod tests {
         } else {
             panic!("expected reach Update");
         }
+    }
+
+    #[test]
+    fn buffered_messages_drained_before_reach() {
+        let mut p = PendingTx::new(false);
+        p.drain_messages(Family::IPV4); // consume initial EOR
+        // Simulate pre-built messages from GroupedSink (initial dump).
+        p.buffer_messages(vec![bgp::Message::Update(bgp::Update::Reach {
+            family: Family::IPV4,
+            entries: vec![packet::PathNlri::new(nlri("10.0.0.0/24"))],
+            nexthop: nh(),
+            attr: attr(0),
+        })]);
+        // An incremental reach that arrived after the initial dump.
+        p.reach(nlri("20.0.0.0/24"), 0, nh(), attr(0));
+
+        let msgs = p.drain_messages(Family::IPV4);
+        // buffered (10.0.0.0/24) must come before incremental (20.0.0.0/24).
+        assert_eq!(msgs.len(), 2);
+        let first_nlri = if let bgp::Message::Update(bgp::Update::Reach { entries, .. }) = &msgs[0]
+        {
+            entries[0].nlri.to_string()
+        } else {
+            panic!("expected Reach");
+        };
+        assert!(first_nlri.contains("10.0.0.0"), "buffered must be first");
+    }
+
+    #[test]
+    fn buffered_emptied_after_drain() {
+        let mut p = PendingTx::new(false);
+        p.drain_messages(Family::IPV4); // consume initial EOR
+        p.buffer_messages(vec![bgp::Message::Update(bgp::Update::Reach {
+            family: Family::IPV4,
+            entries: vec![packet::PathNlri::new(nlri("10.0.0.0/24"))],
+            nexthop: nh(),
+            attr: attr(0),
+        })]);
+
+        assert!(!p.is_empty());
+        p.drain_messages(Family::IPV4);
+        assert!(p.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
on_established fills PendingTx one route at a time through PendingTx::reach(), causing a temporary peak of N entries (one per prefix) before the first drain.  With a full BGP table and many peers, this peak is significant: each entry stores (PathNlri, Arc<attr>, Option<Nexthop>) independently.

GroupedSink implements NlriSink and builds the (attr, nexthop) -> Vec<PathNlri> map directly, skipping the per-NLRI intermediate HashMap. The pre-built UPDATE messages are stored in PendingTx::buffered and drained first by flush_tx, before any incremental reach/unreach entries that may have arrived concurrently.

do_route_refresh is unchanged: it uses the existing PendingTx reach/ unreach path because old_sent withdrawals require per-NLRI tracking, and route-refresh is an infrequent event.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>