### PR TITLE
table,daemon: limit path clones to effective_max in initial dump and …

### DIFF
--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -2449,7 +2449,7 @@ impl PeerSession {
                     let effective_max = family_effective_max.get(f).copied().unwrap_or(1);
                     let addpath_tx = self.pending.get(f).map(|p| p.addpath_tx()).unwrap_or(false);
                     let mut sink = crate::event::export::GroupedSink::new(addpath_tx);
-                    for change in rtable.collect_loc_rib_paths(f) {
+                    for change in rtable.collect_loc_rib_paths_limited(f, effective_max) {
                         if crate::rtc::is_vpn_family(change.family)
                             && let (Some(filter), Some(best)) = (&rtc_filter, change.new_best())
                             && !filter.allows(&best.attr)
@@ -2538,7 +2538,9 @@ impl PeerSession {
         };
         let export_policy = self.tables.export_policy.load_full();
         let effective_max = self.effective_max(family);
-        let changes = self.tables.collect_loc_rib_paths(family);
+        let changes = self
+            .tables
+            .collect_loc_rib_paths_limited(family, effective_max);
         let rpki = self.tables.rpki.read().unwrap();
         // Snapshot and clear the export_map before re-walking the RIB; without
         // this we have no record of what was sent under the old filter and cannot

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -612,6 +612,24 @@ impl TableManager {
         out
     }
 
+    pub(crate) fn collect_loc_rib_paths_limited(
+        &self,
+        family: Family,
+        max_paths: usize,
+    ) -> Vec<table::NlriChange> {
+        let mut out = Vec::new();
+        for shard in &self.shards {
+            out.extend(
+                shard
+                    .lock()
+                    .unwrap()
+                    .rtable
+                    .collect_loc_rib_paths_limited(&family, max_paths),
+            );
+        }
+        out
+    }
+
     /// Enumerate all active RIB families across all shards (deduplicated).
     pub(crate) fn all_families(&self) -> Vec<Family> {
         let mut seen = FnvHashSet::default();

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -811,14 +811,18 @@ impl Table {
     /// Each change has `best_changed` and `any_changed` set to `true` so that
     /// callers treating it as a fresh event (initial dump, route refresh) will
     /// unconditionally advertise every prefix.
-    pub fn collect_loc_rib_paths(&self, family: &Family) -> Vec<NlriChange> {
+    fn collect_loc_rib_paths_impl(&self, family: &Family, max_paths: usize) -> Vec<NlriChange> {
         let Some(t) = self.ribs.get(family) else {
             return Vec::new();
         };
         t.destinations
             .iter()
             .filter_map(|(net, dst)| {
-                let paths: Vec<Path> = dst.unfiltered_iter().map(|e| e.path.clone()).collect();
+                let paths: Vec<Path> = dst
+                    .unfiltered_iter()
+                    .take(max_paths)
+                    .map(|e| e.path.clone())
+                    .collect();
                 if paths.is_empty() {
                     return None;
                 }
@@ -832,6 +836,18 @@ impl Table {
                 })
             })
             .collect()
+    }
+
+    pub fn collect_loc_rib_paths(&self, family: &Family) -> Vec<NlriChange> {
+        self.collect_loc_rib_paths_impl(family, usize::MAX)
+    }
+
+    pub fn collect_loc_rib_paths_limited(
+        &self,
+        family: &Family,
+        max_paths: usize,
+    ) -> Vec<NlriChange> {
+        self.collect_loc_rib_paths_impl(family, max_paths)
     }
 
     pub fn state(&self, family: Family) -> TableState {


### PR DESCRIPTION
…route-refresh

collect_loc_rib_paths clones every path for each destination, but on_established and do_route_refresh only consume effective_max paths per prefix -- 1 for non-Add-Path peers, send_max for Add-Path. Cloning excess paths allocates memory that is immediately discarded.

Add collect_loc_rib_paths_limited(family, max_paths) that stops cloning after max_paths entries.  The existing unbounded variant is kept for MRT, BMP, and gRPC callers that need all paths.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>