### PR TITLE
config,daemon: unify send_max limit to 255 and parse it via gRPC

### DIFF
--- a/config/src/validate.rs
+++ b/config/src/validate.rs
@@ -163,3 +163,83 @@ impl Neighbor {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_global() -> Global {
+        Global {
+            config: Some(GlobalConfig {
+                r#as: Some(65001),
+                router_id: Some(std::net::Ipv4Addr::new(10, 0, 0, 1)),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn neighbor(peer_group: Option<&str>, peer_as: Option<u32>, addr: Option<&str>) -> Neighbor {
+        Neighbor {
+            config: Some(NeighborConfig {
+                peer_group: peer_group.map(str::to_string),
+                peer_as,
+                neighbor_address: addr.and_then(|a| a.parse().ok()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn neighbor_in_peer_group_missing_peer_as_passes() {
+        assert!(
+            neighbor(Some("grp"), None, Some("10.0.0.1"))
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn neighbor_in_peer_group_zero_peer_as_passes() {
+        assert!(
+            neighbor(Some("grp"), Some(0), Some("10.0.0.1"))
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn neighbor_without_peer_group_missing_peer_as_fails() {
+        assert!(neighbor(None, None, Some("10.0.0.1")).validate().is_err());
+    }
+
+    #[test]
+    fn neighbor_without_peer_group_zero_peer_as_fails() {
+        assert!(
+            neighbor(None, Some(0), Some("10.0.0.1"))
+                .validate()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn bgp_config_with_peer_group_zero_peer_as_passes() {
+        let cfg = BgpConfig {
+            global: Some(valid_global()),
+            neighbors: Some(vec![neighbor(Some("grp"), Some(0), Some("10.0.0.1"))]),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn bgp_config_with_peer_group_missing_peer_as_passes() {
+        let cfg = BgpConfig {
+            global: Some(valid_global()),
+            neighbors: Some(vec![neighbor(Some("grp"), None, Some("10.0.0.1"))]),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_ok());
+    }
+}

--- a/config/src/validate.rs
+++ b/config/src/validate.rs
@@ -129,14 +129,18 @@ impl Neighbor {
             return Ok(());
         }
 
-        let asn = config
-            .peer_as
-            .as_ref()
-            .ok_or_else(|| ConfigError::InvalidConfiguration("empty peer as".to_string()))?;
-        if *asn == 0 {
-            return Err(ConfigError::InvalidConfiguration(
-                "zero as number".to_string(),
-            ));
+        // Peers in a peer group may omit peer_as (ASN=0) and inherit the AS
+        // from the group; peer_as=0 is also valid when the group accepts any AS.
+        if config.peer_group.is_none() {
+            let asn = config
+                .peer_as
+                .as_ref()
+                .ok_or_else(|| ConfigError::InvalidConfiguration("empty peer as".to_string()))?;
+            if *asn == 0 {
+                return Err(ConfigError::InvalidConfiguration(
+                    "zero as number".to_string(),
+                ));
+            }
         }
 
         let addr = config.neighbor_address.as_ref().ok_or_else(|| {

--- a/config/src/validate.rs
+++ b/config/src/validate.rs
@@ -156,22 +156,6 @@ impl Neighbor {
             )));
         }
 
-        // Validate per-family add-paths send_max
-        if let Some(afi_safis) = self.afi_safis.as_ref() {
-            for afi_safi in afi_safis {
-                if let Some(ap) = afi_safi.add_paths.as_ref()
-                    && let Some(c) = ap.config.as_ref()
-                    && let Some(sm) = c.send_max
-                    && sm > 32
-                {
-                    return Err(ConfigError::InvalidConfiguration(format!(
-                        "neighbor {} afi-safi {:?}: send-max {} exceeds maximum of 32",
-                        addr, afi_safi, sm
-                    )));
-                }
-            }
-        }
-
         Ok(())
     }
 }

--- a/config/src/validate.rs
+++ b/config/src/validate.rs
@@ -145,6 +145,18 @@ fn validate_gr_restart_time(restart_time: u16) -> Result<(), ConfigError> {
     Ok(())
 }
 
+/// The Linux TCP_MD5SIG key buffer is 80 bytes; passwords longer than that
+/// cannot be set via setsockopt and must be rejected.
+fn validate_auth_password(password: &str) -> Result<(), ConfigError> {
+    if password.len() > 80 {
+        return Err(ConfigError::InvalidConfiguration(format!(
+            "auth-password length {} exceeds maximum of 80 bytes",
+            password.len()
+        )));
+    }
+    Ok(())
+}
+
 /// RFC 9494 §3: the LLGR stale time is a 24-bit field in the capability.
 /// Values 0-16777215 (0xFF_FFFF) are valid.
 fn validate_llgr_stale_time(stale_time: u32) -> Result<(), ConfigError> {
@@ -217,6 +229,10 @@ impl Neighbor {
             }
         }
 
+        if let Some(pw) = config.auth_password.as_deref().filter(|s| !s.is_empty()) {
+            validate_auth_password(pw)?;
+        }
+
         if self.add_paths.is_some() {
             return Err(ConfigError::InvalidConfiguration(
                 "use per-family addpath config".to_string(),
@@ -263,6 +279,14 @@ impl PeerGroup {
                     validate_llgr_stale_time(st)?;
                 }
             }
+        }
+        if let Some(pw) = self
+            .config
+            .as_ref()
+            .and_then(|c| c.auth_password.as_deref())
+            .filter(|s| !s.is_empty())
+        {
+            validate_auth_password(pw)?;
         }
         Ok(())
     }
@@ -588,6 +612,71 @@ mod tests {
     fn peer_group_llgr_stale_time_overflow_fails() {
         assert!(
             peer_group_with_llgr_stale_time(0x100_0000)
+                .validate()
+                .is_err()
+        );
+    }
+
+    // --- auth_password length ---
+
+    fn neighbor_with_auth_password(peer_as: u32, password: &str) -> Neighbor {
+        Neighbor {
+            config: Some(NeighborConfig {
+                neighbor_address: Some("10.0.0.1".parse().unwrap()),
+                peer_as: Some(peer_as),
+                auth_password: Some(password.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn peer_group_with_auth_password(password: &str) -> PeerGroup {
+        PeerGroup {
+            config: Some(PeerGroupConfig {
+                auth_password: Some(password.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn neighbor_auth_password_80_bytes_passes() {
+        assert!(
+            neighbor_with_auth_password(65001, &"a".repeat(80))
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn neighbor_auth_password_empty_passes() {
+        assert!(neighbor_with_auth_password(65001, "").validate().is_ok());
+    }
+
+    #[test]
+    fn neighbor_auth_password_81_bytes_fails() {
+        assert!(
+            neighbor_with_auth_password(65001, &"a".repeat(81))
+                .validate()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn peer_group_auth_password_80_bytes_passes() {
+        assert!(
+            peer_group_with_auth_password(&"a".repeat(80))
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn peer_group_auth_password_81_bytes_fails() {
+        assert!(
+            peer_group_with_auth_password(&"a".repeat(81))
                 .validate()
                 .is_err()
         );

--- a/config/src/validate.rs
+++ b/config/src/validate.rs
@@ -134,6 +134,17 @@ fn validate_hold_time(hold_time: f64) -> Result<(), ConfigError> {
     Ok(())
 }
 
+/// RFC 4724 §3: restart_time is a 12-bit field in the OPEN message.
+/// Values 0–4095 are valid; larger values cannot be encoded.
+fn validate_gr_restart_time(restart_time: u16) -> Result<(), ConfigError> {
+    if restart_time > 4095 {
+        return Err(ConfigError::InvalidConfiguration(format!(
+            "graceful-restart restart-time {restart_time} exceeds maximum of 4095"
+        )));
+    }
+    Ok(())
+}
+
 impl Neighbor {
     fn validate(&self) -> Result<(), ConfigError> {
         let config = self.config.as_ref().ok_or_else(|| {
@@ -173,6 +184,15 @@ impl Neighbor {
             validate_hold_time(h)?;
         }
 
+        if let Some(rt) = self
+            .graceful_restart
+            .as_ref()
+            .and_then(|gr| gr.config.as_ref())
+            .and_then(|c| c.restart_time)
+        {
+            validate_gr_restart_time(rt)?;
+        }
+
         if self.add_paths.is_some() {
             return Err(ConfigError::InvalidConfiguration(
                 "use per-family addpath config".to_string(),
@@ -199,6 +219,14 @@ impl PeerGroup {
             .and_then(|c| c.hold_time)
         {
             validate_hold_time(h)?;
+        }
+        if let Some(rt) = self
+            .graceful_restart
+            .as_ref()
+            .and_then(|gr| gr.config.as_ref())
+            .and_then(|c| c.restart_time)
+        {
+            validate_gr_restart_time(rt)?;
         }
         Ok(())
     }
@@ -373,5 +401,71 @@ mod tests {
             ..Default::default()
         };
         assert!(cfg.validate().is_err());
+    }
+
+    // --- graceful_restart restart_time ---
+
+    fn neighbor_with_gr_restart_time(peer_as: u32, restart_time: u16) -> Neighbor {
+        Neighbor {
+            config: Some(NeighborConfig {
+                neighbor_address: Some("10.0.0.1".parse().unwrap()),
+                peer_as: Some(peer_as),
+                ..Default::default()
+            }),
+            graceful_restart: Some(GracefulRestart {
+                config: Some(GracefulRestartConfig {
+                    restart_time: Some(restart_time),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn peer_group_with_gr_restart_time(restart_time: u16) -> PeerGroup {
+        PeerGroup {
+            graceful_restart: Some(GracefulRestart {
+                config: Some(GracefulRestartConfig {
+                    restart_time: Some(restart_time),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn neighbor_gr_restart_time_4095_passes() {
+        assert!(
+            neighbor_with_gr_restart_time(65001, 4095)
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn neighbor_gr_restart_time_0_passes() {
+        assert!(neighbor_with_gr_restart_time(65001, 0).validate().is_ok());
+    }
+
+    #[test]
+    fn neighbor_gr_restart_time_4096_fails() {
+        assert!(
+            neighbor_with_gr_restart_time(65001, 4096)
+                .validate()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn peer_group_gr_restart_time_4095_passes() {
+        assert!(peer_group_with_gr_restart_time(4095).validate().is_ok());
+    }
+
+    #[test]
+    fn peer_group_gr_restart_time_4096_fails() {
+        assert!(peer_group_with_gr_restart_time(4096).validate().is_err());
     }
 }

--- a/config/src/validate.rs
+++ b/config/src/validate.rs
@@ -145,6 +145,17 @@ fn validate_gr_restart_time(restart_time: u16) -> Result<(), ConfigError> {
     Ok(())
 }
 
+/// RFC 9494 §3: the LLGR stale time is a 24-bit field in the capability.
+/// Values 0-16777215 (0xFF_FFFF) are valid.
+fn validate_llgr_stale_time(stale_time: u32) -> Result<(), ConfigError> {
+    if stale_time > 0xFF_FFFF {
+        return Err(ConfigError::InvalidConfiguration(format!(
+            "long-lived-graceful-restart restart-time {stale_time} exceeds maximum of 16777215"
+        )));
+    }
+    Ok(())
+}
+
 impl Neighbor {
     fn validate(&self) -> Result<(), ConfigError> {
         let config = self.config.as_ref().ok_or_else(|| {
@@ -193,6 +204,19 @@ impl Neighbor {
             validate_gr_restart_time(rt)?;
         }
 
+        if let Some(afi_safis) = self.afi_safis.as_ref() {
+            for a in afi_safis {
+                if let Some(st) = a
+                    .long_lived_graceful_restart
+                    .as_ref()
+                    .and_then(|llgr| llgr.config.as_ref())
+                    .and_then(|c| c.restart_time)
+                {
+                    validate_llgr_stale_time(st)?;
+                }
+            }
+        }
+
         if self.add_paths.is_some() {
             return Err(ConfigError::InvalidConfiguration(
                 "use per-family addpath config".to_string(),
@@ -227,6 +251,18 @@ impl PeerGroup {
             .and_then(|c| c.restart_time)
         {
             validate_gr_restart_time(rt)?;
+        }
+        if let Some(afi_safis) = self.afi_safis.as_ref() {
+            for a in afi_safis {
+                if let Some(st) = a
+                    .long_lived_graceful_restart
+                    .as_ref()
+                    .and_then(|llgr| llgr.config.as_ref())
+                    .and_then(|c| c.restart_time)
+                {
+                    validate_llgr_stale_time(st)?;
+                }
+            }
         }
         Ok(())
     }
@@ -467,5 +503,93 @@ mod tests {
     #[test]
     fn peer_group_gr_restart_time_4096_fails() {
         assert!(peer_group_with_gr_restart_time(4096).validate().is_err());
+    }
+
+    // --- LLGR stale_time ---
+
+    fn neighbor_with_llgr_stale_time(peer_as: u32, stale_time: u32) -> Neighbor {
+        Neighbor {
+            config: Some(NeighborConfig {
+                neighbor_address: Some("10.0.0.1".parse().unwrap()),
+                peer_as: Some(peer_as),
+                ..Default::default()
+            }),
+            afi_safis: Some(vec![AfiSafi {
+                config: Some(AfiSafiConfig {
+                    afi_safi_name: Some(AfiSafiType::Ipv4Unicast),
+                    ..Default::default()
+                }),
+                long_lived_graceful_restart: Some(LongLivedGracefulRestart {
+                    config: Some(LongLivedGracefulRestartConfig {
+                        enabled: Some(true),
+                        restart_time: Some(stale_time),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }
+    }
+
+    fn peer_group_with_llgr_stale_time(stale_time: u32) -> PeerGroup {
+        PeerGroup {
+            afi_safis: Some(vec![AfiSafi {
+                config: Some(AfiSafiConfig {
+                    afi_safi_name: Some(AfiSafiType::Ipv4Unicast),
+                    ..Default::default()
+                }),
+                long_lived_graceful_restart: Some(LongLivedGracefulRestart {
+                    config: Some(LongLivedGracefulRestartConfig {
+                        enabled: Some(true),
+                        restart_time: Some(stale_time),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn neighbor_llgr_stale_time_max_passes() {
+        assert!(
+            neighbor_with_llgr_stale_time(65001, 0xFF_FFFF)
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn neighbor_llgr_stale_time_0_passes() {
+        assert!(neighbor_with_llgr_stale_time(65001, 0).validate().is_ok());
+    }
+
+    #[test]
+    fn neighbor_llgr_stale_time_overflow_fails() {
+        assert!(
+            neighbor_with_llgr_stale_time(65001, 0x100_0000)
+                .validate()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn peer_group_llgr_stale_time_max_passes() {
+        assert!(
+            peer_group_with_llgr_stale_time(0xFF_FFFF)
+                .validate()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn peer_group_llgr_stale_time_overflow_fails() {
+        assert!(
+            peer_group_with_llgr_stale_time(0x100_0000)
+                .validate()
+                .is_err()
+        );
     }
 }

--- a/config/src/validate.rs
+++ b/config/src/validate.rs
@@ -78,6 +78,12 @@ impl BgpConfig {
             }
         }
 
+        if let Some(peer_groups) = self.peer_groups.as_ref() {
+            for pg in peer_groups {
+                pg.validate()?;
+            }
+        }
+
         if let Some(bmp_servers) = self.bmp_servers.as_ref() {
             for n in bmp_servers {
                 n.validate()?;
@@ -117,6 +123,17 @@ impl BmpServer {
     }
 }
 
+/// RFC 4271 §4.2: hold time is a 2-byte field.  Valid values are 0
+/// (disabled) or 3–65535.  Values 1 and 2 are explicitly forbidden.
+fn validate_hold_time(hold_time: f64) -> Result<(), ConfigError> {
+    if hold_time != 0.0 && !(3.0..=65535.0).contains(&hold_time) {
+        return Err(ConfigError::InvalidConfiguration(format!(
+            "hold-time {hold_time} is invalid: must be 0 or 3-65535"
+        )));
+    }
+    Ok(())
+}
+
 impl Neighbor {
     fn validate(&self) -> Result<(), ConfigError> {
         let config = self.config.as_ref().ok_or_else(|| {
@@ -147,6 +164,15 @@ impl Neighbor {
             ConfigError::InvalidConfiguration("empty neighbor address".to_string())
         })?;
 
+        if let Some(h) = self
+            .timers
+            .as_ref()
+            .and_then(|t| t.config.as_ref())
+            .and_then(|c| c.hold_time)
+        {
+            validate_hold_time(h)?;
+        }
+
         if self.add_paths.is_some() {
             return Err(ConfigError::InvalidConfiguration(
                 "use per-family addpath config".to_string(),
@@ -160,6 +186,20 @@ impl Neighbor {
             )));
         }
 
+        Ok(())
+    }
+}
+
+impl PeerGroup {
+    fn validate(&self) -> Result<(), ConfigError> {
+        if let Some(h) = self
+            .timers
+            .as_ref()
+            .and_then(|t| t.config.as_ref())
+            .and_then(|c| c.hold_time)
+        {
+            validate_hold_time(h)?;
+        }
         Ok(())
     }
 }
@@ -241,5 +281,97 @@ mod tests {
             ..Default::default()
         };
         assert!(cfg.validate().is_ok());
+    }
+
+    fn neighbor_with_hold_time(peer_as: u32, hold_time: f64) -> Neighbor {
+        Neighbor {
+            config: Some(NeighborConfig {
+                neighbor_address: Some("10.0.0.1".parse().unwrap()),
+                peer_as: Some(peer_as),
+                ..Default::default()
+            }),
+            timers: Some(Timers {
+                config: Some(TimersConfig {
+                    hold_time: Some(hold_time),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn peer_group_with_hold_time(hold_time: f64) -> PeerGroup {
+        PeerGroup {
+            timers: Some(Timers {
+                config: Some(TimersConfig {
+                    hold_time: Some(hold_time),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    // --- hold_time: Neighbor ---
+
+    #[test]
+    fn neighbor_hold_time_zero_passes() {
+        assert!(neighbor_with_hold_time(65001, 0.0).validate().is_ok());
+    }
+
+    #[test]
+    fn neighbor_hold_time_3_passes() {
+        assert!(neighbor_with_hold_time(65001, 3.0).validate().is_ok());
+    }
+
+    #[test]
+    fn neighbor_hold_time_65535_passes() {
+        assert!(neighbor_with_hold_time(65001, 65535.0).validate().is_ok());
+    }
+
+    #[test]
+    fn neighbor_hold_time_1_fails() {
+        assert!(neighbor_with_hold_time(65001, 1.0).validate().is_err());
+    }
+
+    #[test]
+    fn neighbor_hold_time_2_fails() {
+        assert!(neighbor_with_hold_time(65001, 2.0).validate().is_err());
+    }
+
+    #[test]
+    fn neighbor_hold_time_65536_fails() {
+        assert!(neighbor_with_hold_time(65001, 65536.0).validate().is_err());
+    }
+
+    // --- hold_time: PeerGroup ---
+
+    #[test]
+    fn peer_group_hold_time_90_passes() {
+        assert!(peer_group_with_hold_time(90.0).validate().is_ok());
+    }
+
+    #[test]
+    fn peer_group_hold_time_2_fails() {
+        assert!(peer_group_with_hold_time(2.0).validate().is_err());
+    }
+
+    #[test]
+    fn peer_group_hold_time_65536_fails() {
+        assert!(peer_group_with_hold_time(65536.0).validate().is_err());
+    }
+
+    // --- BgpConfig: peer_groups hold_time propagated ---
+
+    #[test]
+    fn bgp_config_peer_group_invalid_hold_time_fails() {
+        let cfg = BgpConfig {
+            global: Some(valid_global()),
+            peer_groups: Some(vec![peer_group_with_hold_time(1.0)]),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
     }
 }

--- a/config/src/validate.rs
+++ b/config/src/validate.rs
@@ -90,6 +90,12 @@ impl BgpConfig {
             }
         }
 
+        if let Some(vrfs) = self.vrfs.as_ref() {
+            for v in vrfs {
+                v.validate()?;
+            }
+        }
+
         Ok(())
     }
 }
@@ -117,6 +123,22 @@ impl BmpServer {
         {
             return Err(ConfigError::InvalidConfiguration(
                 "unsupported monitoring policy".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Vrf {
+    fn validate(&self) -> Result<(), ConfigError> {
+        let name = self
+            .config
+            .as_ref()
+            .and_then(|c| c.name.as_deref())
+            .unwrap_or("");
+        if name.is_empty() {
+            return Err(ConfigError::InvalidConfiguration(
+                "vrf name is empty".to_string(),
             ));
         }
         Ok(())
@@ -680,5 +702,36 @@ mod tests {
                 .validate()
                 .is_err()
         );
+    }
+
+    // --- VRF name ---
+
+    fn bgp_config_with_vrf(name: Option<&str>) -> BgpConfig {
+        BgpConfig {
+            global: Some(valid_global()),
+            vrfs: Some(vec![Vrf {
+                config: Some(VrfConfig {
+                    name: name.map(str::to_string),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn vrf_with_name_passes() {
+        assert!(bgp_config_with_vrf(Some("vrf1")).validate().is_ok());
+    }
+
+    #[test]
+    fn vrf_with_empty_name_fails() {
+        assert!(bgp_config_with_vrf(Some("")).validate().is_err());
+    }
+
+    #[test]
+    fn vrf_with_missing_name_fails() {
+        assert!(bgp_config_with_vrf(None).validate().is_err());
     }
 }

--- a/daemon/src/auth.rs
+++ b/daemon/src/auth.rs
@@ -38,7 +38,7 @@ impl TcpMd5sig {
                 libc::AF_INET6 as u16
             }
         };
-        let k = std::ffi::CString::new(password).unwrap().into_bytes();
+        let k = password.into_bytes();
         let keylen = k.len();
         let mut key = [0; 80];
         key[..std::cmp::min(keylen, 80)].clone_from_slice(&k[..std::cmp::min(keylen, 80)]);

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -670,6 +670,17 @@ pub(super) struct GrpcService {
     path_uuid_map: tokio::sync::Mutex<FnvHashMap<uuid::Uuid, (Family, Vec<packet::PathNlri>)>>,
 }
 
+/// Validate and convert a `uint32` port from a gRPC request to `u16`.
+/// Returns `InvalidArgument` for values outside the valid port range 1–65535.
+fn check_port(port: u32) -> Result<u16, tonic::Status> {
+    u16::try_from(port).ok().filter(|&p| p > 0).ok_or_else(|| {
+        tonic::Status::new(
+            tonic::Code::InvalidArgument,
+            format!("port {port} is out of valid range 1-65535"),
+        )
+    })
+}
+
 impl GrpcService {
     pub(super) fn new(
         init: Arc<tokio::sync::Notify>,
@@ -2677,7 +2688,7 @@ impl GoBgpService for GrpcService {
         let addr = IpAddr::from_str(&request.address)
             .map_err(|_| tonic::Status::new(tonic::Code::InvalidArgument, "invalid address"))?;
 
-        let sockaddr = SocketAddr::new(addr, request.port as u16);
+        let sockaddr = SocketAddr::new(addr, check_port(request.port)?);
         match self.global.write().await.add_rpki_client(sockaddr) {
             Err(()) => {
                 return Err(tonic::Status::new(
@@ -2698,7 +2709,7 @@ impl GoBgpService for GrpcService {
         let request = request.into_inner();
         let addr = IpAddr::from_str(&request.address)
             .map_err(|_| tonic::Status::new(tonic::Code::InvalidArgument, "invalid address"))?;
-        let sockaddr = SocketAddr::new(addr, request.port as u16);
+        let sockaddr = SocketAddr::new(addr, check_port(request.port)?);
         if self.global.write().await.remove_rpki_client(sockaddr) {
             Ok(tonic::Response::new(api::DeleteRpkiResponse {}))
         } else {
@@ -2755,7 +2766,7 @@ impl GoBgpService for GrpcService {
         let request = request.into_inner();
         let addr = IpAddr::from_str(&request.address)
             .map_err(|_| tonic::Status::new(tonic::Code::InvalidArgument, "invalid address"))?;
-        let sockaddr = SocketAddr::new(addr, request.port as u16);
+        let sockaddr = SocketAddr::new(addr, check_port(request.port)?);
         let (cancel, soft_reset, state) = {
             let mut global = self.global.write().await;
             match global.rpki_clients.get_mut(&sockaddr) {
@@ -2791,7 +2802,7 @@ impl GoBgpService for GrpcService {
         let request = request.into_inner();
         let addr = IpAddr::from_str(&request.address)
             .map_err(|_| tonic::Status::new(tonic::Code::InvalidArgument, "invalid address"))?;
-        let sockaddr = SocketAddr::new(addr, request.port as u16);
+        let sockaddr = SocketAddr::new(addr, check_port(request.port)?);
         let mut global = self.global.write().await;
         match global.rpki_clients.get_mut(&sockaddr) {
             None => Err(tonic::Status::new(
@@ -2817,7 +2828,7 @@ impl GoBgpService for GrpcService {
         let request = request.into_inner();
         let addr = IpAddr::from_str(&request.address)
             .map_err(|_| tonic::Status::new(tonic::Code::InvalidArgument, "invalid address"))?;
-        let sockaddr = SocketAddr::new(addr, request.port as u16);
+        let sockaddr = SocketAddr::new(addr, check_port(request.port)?);
         if request.soft {
             let global = self.global.read().await;
             return match global.rpki_clients.get(&sockaddr) {
@@ -3022,7 +3033,7 @@ impl GoBgpService for GrpcService {
             }
         };
 
-        let sockaddr = SocketAddr::new(addr, request.port as u16);
+        let sockaddr = SocketAddr::new(addr, check_port(request.port)?);
         match self.global.write().await.add_bmp_client(sockaddr) {
             Err(()) => {
                 return Err(tonic::Status::new(
@@ -3050,7 +3061,7 @@ impl GoBgpService for GrpcService {
         let request = request.into_inner();
         let addr = IpAddr::from_str(&request.address)
             .map_err(|_| tonic::Status::new(tonic::Code::InvalidArgument, "invalid address"))?;
-        let sockaddr = SocketAddr::new(addr, request.port as u16);
+        let sockaddr = SocketAddr::new(addr, check_port(request.port)?);
         if self.global.write().await.remove_bmp_client(sockaddr) {
             Ok(tonic::Response::new(api::DeleteBmpResponse {}))
         } else {

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -273,6 +273,10 @@ impl TryFrom<&api::Peer> for PeerParams {
             (addr, None)
         };
 
+        if neighbor_interface.is_none() && conf.peer_asn == 0 {
+            return Err(Error::InvalidArgument("peer ASN must be non-zero".into()));
+        }
+
         let mut families: FnvHashMap<Family, u8> = FnvHashMap::default();
         let mut send_max: FnvHashMap<Family, usize> = FnvHashMap::default();
         for af in p

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -273,7 +273,7 @@ impl TryFrom<&api::Peer> for PeerParams {
             (addr, None)
         };
 
-        if neighbor_interface.is_none() && conf.peer_asn == 0 {
+        if neighbor_interface.is_none() && conf.peer_group.is_empty() && conf.peer_asn == 0 {
             return Err(Error::InvalidArgument("peer ASN must be non-zero".into()));
         }
 

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -341,13 +341,13 @@ impl TryFrom<&api::Peer> for PeerParams {
 
         Ok(PeerParams {
             remote_addr,
-            remote_port: p.transport.as_ref().map_or(Global::BGP_PORT, |x| {
-                if x.remote_port != 0 {
-                    x.remote_port as u16
+            remote_port: p.transport.as_ref().map_or(Ok(Global::BGP_PORT), |x| {
+                if x.remote_port == 0 {
+                    Ok(Global::BGP_PORT)
                 } else {
-                    Global::BGP_PORT
+                    check_port(x.remote_port)
                 }
-            }),
+            })?,
             // Unnumbered BGP (RFC 7938) accepts any AS; override peer_asn with 0.
             expected_remote_asn: if neighbor_interface.is_some() {
                 0
@@ -672,13 +672,12 @@ pub(super) struct GrpcService {
 
 /// Validate and convert a `uint32` port from a gRPC request to `u16`.
 /// Returns `InvalidArgument` for values outside the valid port range 1–65535.
-fn check_port(port: u32) -> Result<u16, tonic::Status> {
-    u16::try_from(port).ok().filter(|&p| p > 0).ok_or_else(|| {
-        tonic::Status::new(
-            tonic::Code::InvalidArgument,
-            format!("port {port} is out of valid range 1-65535"),
-        )
-    })
+/// The `?` operator converts `Error` to `tonic::Status` in async handlers.
+fn check_port(port: u32) -> Result<u16, Error> {
+    u16::try_from(port)
+        .ok()
+        .filter(|&p| p > 0)
+        .ok_or_else(|| Error::InvalidArgument(format!("port {port} is out of valid range 1-65535")))
 }
 
 impl GrpcService {

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -273,16 +273,33 @@ impl TryFrom<&api::Peer> for PeerParams {
             (addr, None)
         };
 
-        let families: FnvHashMap<Family, u8> = p
+        let mut families: FnvHashMap<Family, u8> = FnvHashMap::default();
+        let mut send_max: FnvHashMap<Family, usize> = FnvHashMap::default();
+        for af in p
             .afi_safis
             .iter()
             .filter(|x| x.config.as_ref().is_some_and(|x| x.family.is_some()))
-            .map(|x| {
-                let f =
-                    convert::family_from_api(x.config.as_ref().unwrap().family.as_ref().unwrap());
-                (f, 0u8)
-            })
-            .collect();
+        {
+            let f = convert::family_from_api(af.config.as_ref().unwrap().family.as_ref().unwrap());
+            let (rx, sm) = af
+                .add_paths
+                .as_ref()
+                .and_then(|ap| ap.config.as_ref())
+                .map(|c| (c.receive, c.send_max))
+                .unwrap_or((false, 0));
+            if sm > peer::ADDPATH_SEND_MAX_LIMIT as u32 {
+                return Err(Error::InvalidArgument(format!(
+                    "send_max {sm} exceeds maximum of {}",
+                    peer::ADDPATH_SEND_MAX_LIMIT,
+                )));
+            }
+            let tx = sm > 0;
+            let mode = u8::from(rx) | (u8::from(tx) << 1);
+            families.insert(f, mode);
+            if sm > 0 {
+                send_max.insert(f, sm as usize);
+            }
+        }
 
         let graceful_restart = { parse_gr_api(p.graceful_restart.as_ref(), &p.afi_safis) };
         let llgr = parse_llgr_api(&p.afi_safis);
@@ -373,7 +390,7 @@ impl TryFrom<&api::Peer> for PeerParams {
                 Some(conf.auth_password.clone())
             },
             families,
-            send_max: FnvHashMap::default(),
+            send_max,
             prefix_limits: FnvHashMap::default(),
             graceful_restart,
             llgr,

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -307,7 +307,7 @@ impl TryFrom<&api::Peer> for PeerParams {
 
         check_gr_restart_time(p.graceful_restart.as_ref())?;
         let graceful_restart = { parse_gr_api(p.graceful_restart.as_ref(), &p.afi_safis) };
-        let llgr = parse_llgr_api(&p.afi_safis);
+        let llgr = parse_llgr_api(&p.afi_safis)?;
 
         let holdtime = {
             let t = p
@@ -446,30 +446,36 @@ fn parse_gr_api(
 }
 
 /// Build LlgrPeerConfig from gRPC AfiSafi per-family long_lived_graceful_restart config.
-fn parse_llgr_api(afi_safis: &[api::AfiSafi]) -> Option<LlgrPeerConfig> {
+/// Returns `InvalidArgument` when any family's stale_time exceeds the 24-bit limit (RFC 9494 §3).
+fn parse_llgr_api(afi_safis: &[api::AfiSafi]) -> Result<Option<LlgrPeerConfig>, Error> {
     const DEFAULT_STALE_TIME: u32 = 600;
-    let families: Vec<(Family, u32)> = afi_safis
-        .iter()
-        .filter(|a| {
-            a.long_lived_graceful_restart
-                .as_ref()
-                .is_some_and(|llgr| llgr.config.as_ref().is_some_and(|c| c.enabled))
-        })
-        .filter_map(|a| {
-            let f = a.config.as_ref()?.family.as_ref()?;
-            let stale_time = a
-                .long_lived_graceful_restart
-                .as_ref()
-                .and_then(|llgr| llgr.config.as_ref())
-                .map(|c| c.restart_time)
-                .unwrap_or(DEFAULT_STALE_TIME);
-            Some((convert::family_from_api(f), stale_time))
-        })
-        .collect();
-    if families.is_empty() {
-        return None;
+    const MAX_STALE_TIME: u32 = 0xFF_FFFF; // 24-bit field
+    let mut families: Vec<(Family, u32)> = Vec::new();
+    for a in afi_safis {
+        let llgr = match a.long_lived_graceful_restart.as_ref() {
+            Some(l) if l.config.as_ref().is_some_and(|c| c.enabled) => l,
+            _ => continue,
+        };
+        let f = match a.config.as_ref().and_then(|c| c.family.as_ref()) {
+            Some(f) => convert::family_from_api(f),
+            None => continue,
+        };
+        let stale_time = llgr
+            .config
+            .as_ref()
+            .map(|c| c.restart_time)
+            .unwrap_or(DEFAULT_STALE_TIME);
+        if stale_time > MAX_STALE_TIME {
+            return Err(Error::InvalidArgument(format!(
+                "llgr stale_time {stale_time} exceeds maximum of {MAX_STALE_TIME}"
+            )));
+        }
+        families.push((f, stale_time));
     }
-    Some(LlgrPeerConfig { families })
+    if families.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(LlgrPeerConfig { families }))
 }
 
 fn peer_group_to_api(name: &str, pg: &PeerGroup) -> api::PeerGroup {
@@ -648,7 +654,7 @@ impl From<api::PeerGroup> for PeerGroup {
                 .collect(),
             send_max: FnvHashMap::default(),
             graceful_restart: parse_gr_api(p.graceful_restart.as_ref(), &p.afi_safis),
-            llgr: parse_llgr_api(&p.afi_safis),
+            llgr: parse_llgr_api(&p.afi_safis).unwrap_or(None),
         }
     }
 }
@@ -1688,6 +1694,7 @@ impl GoBgpService for GrpcService {
         }
         parse_ttl_security(pg.ttl_security.as_ref()).map_err(tonic::Status::from)?;
         check_gr_restart_time(pg.graceful_restart.as_ref()).map_err(tonic::Status::from)?;
+        parse_llgr_api(&pg.afi_safis).map_err(tonic::Status::from)?;
 
         match self
             .global
@@ -1745,6 +1752,7 @@ impl GoBgpService for GrpcService {
             .clone();
         parse_ttl_security(pg.ttl_security.as_ref()).map_err(tonic::Status::from)?;
         check_gr_restart_time(pg.graceful_restart.as_ref()).map_err(tonic::Status::from)?;
+        parse_llgr_api(&pg.afi_safis).map_err(tonic::Status::from)?;
         let updated = PeerGroup::from(pg);
         let mut global = self.global.write().await;
         match global.peer_group.get_mut(&name) {

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -338,6 +338,7 @@ impl TryFrom<&api::Peer> for PeerParams {
                 PeerParams::DEFAULT_CONNECT_RETRY_TIME
             }
         };
+        let ttl_security = parse_ttl_security(p.ttl_security.as_ref())?;
 
         Ok(PeerParams {
             remote_addr,
@@ -382,18 +383,7 @@ impl TryFrom<&api::Peer> for PeerParams {
                     None
                 }
             }),
-            ttl_security: p.ttl_security.as_ref().and_then(|ts| {
-                if ts.enabled {
-                    let min = if ts.ttl_min == 0 {
-                        255
-                    } else {
-                        ts.ttl_min as u8
-                    };
-                    Some(min)
-                } else {
-                    None
-                }
-            }),
+            ttl_security,
             password: if conf.auth_password.is_empty() {
                 None
             } else {
@@ -668,6 +658,29 @@ pub(super) struct GrpcService {
     pub(super) global: GlobalHandle,
     pub(super) tables: TableHandle,
     path_uuid_map: tokio::sync::Mutex<FnvHashMap<uuid::Uuid, (Family, Vec<packet::PathNlri>)>>,
+}
+
+/// Validate and convert `api::TtlSecurity` to the internal `Option<u8>`.
+/// Returns `InvalidArgument` when `ttl_min` does not fit in a u8 (> 255).
+/// ttl_min=0 means "use 255 (single-hop default)"; 1–255 are passed as-is.
+fn parse_ttl_security(ts: Option<&api::TtlSecurity>) -> Result<Option<u8>, Error> {
+    let Some(ts) = ts else {
+        return Ok(None);
+    };
+    if !ts.enabled {
+        return Ok(None);
+    }
+    if ts.ttl_min > u8::MAX as u32 {
+        return Err(Error::InvalidArgument(format!(
+            "ttl_min {} exceeds maximum of 255",
+            ts.ttl_min
+        )));
+    }
+    Ok(Some(if ts.ttl_min == 0 {
+        255
+    } else {
+        ts.ttl_min as u8
+    }))
 }
 
 /// Validate and convert a `uint32` port from a gRPC request to `u16`.
@@ -1657,6 +1670,7 @@ impl GoBgpService for GrpcService {
             ))
             .into());
         }
+        parse_ttl_security(pg.ttl_security.as_ref()).map_err(tonic::Status::from)?;
 
         match self
             .global
@@ -1712,6 +1726,7 @@ impl GoBgpService for GrpcService {
             .ok_or(Error::EmptyArgument)?
             .peer_group_name
             .clone();
+        parse_ttl_security(pg.ttl_security.as_ref()).map_err(tonic::Status::from)?;
         let updated = PeerGroup::from(pg);
         let mut global = self.global.write().await;
         match global.peer_group.get_mut(&name) {

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -315,6 +315,12 @@ impl TryFrom<&api::Peer> for PeerParams {
                 .map(|x| &x.config)
                 .map_or(0, |x| x.as_ref().map_or(0, |x| x.hold_time));
             if t != 0 {
+                // RFC 4271 §4.2: hold time is a 2-byte field; 0 or 3-65535.
+                if !(3..=65535).contains(&t) {
+                    return Err(Error::InvalidArgument(format!(
+                        "hold_time {t} is invalid: must be 0 or 3-65535"
+                    )));
+                }
                 t
             } else {
                 PeerParams::DEFAULT_HOLD_TIME
@@ -1626,6 +1632,21 @@ impl GoBgpService for GrpcService {
             .peer_group
             .ok_or(Error::EmptyArgument)?;
         let conf = pg.conf.as_ref().ok_or(Error::EmptyArgument)?;
+
+        // RFC 4271 §4.2: hold time is a 2-byte field; 0 or 3-65535.
+        if let Some(ht) = pg
+            .timers
+            .as_ref()
+            .and_then(|t| t.config.as_ref())
+            .map(|c| c.hold_time)
+            .filter(|&h| h != 0)
+            && !(3..=65535).contains(&ht)
+        {
+            return Err(Error::InvalidArgument(format!(
+                "hold_time {ht} is invalid: must be 0 or 3-65535"
+            ))
+            .into());
+        }
 
         match self
             .global

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -259,6 +259,9 @@ impl TryFrom<&api::Peer> for PeerParams {
 
     fn try_from(p: &api::Peer) -> Result<Self, Self::Error> {
         let conf = p.conf.as_ref().ok_or(Error::EmptyArgument)?;
+        if !conf.auth_password.is_empty() {
+            check_auth_password(&conf.auth_password)?;
+        }
         // When neighbor_interface is set the remote address is not known at
         // parse time; it will be resolved via NDP in add_peer/update_peer.
         let (remote_addr, neighbor_interface) = if !conf.neighbor_interface.is_empty() {
@@ -700,6 +703,18 @@ fn check_gr_restart_time(gr: Option<&api::GracefulRestart>) -> Result<(), Error>
         return Err(Error::InvalidArgument(format!(
             "graceful_restart restart_time {} exceeds maximum of 4095",
             gr.restart_time
+        )));
+    }
+    Ok(())
+}
+
+/// Validate an MD5 TCP authentication password (RFC 2385 / Linux TCP_MD5SIG).
+/// The kernel key buffer is 80 bytes; passwords longer than that cannot be set.
+fn check_auth_password(password: &str) -> Result<(), Error> {
+    if password.len() > 80 {
+        return Err(Error::InvalidArgument(format!(
+            "auth_password length {} exceeds maximum of 80 bytes",
+            password.len()
         )));
     }
     Ok(())
@@ -1695,6 +1710,14 @@ impl GoBgpService for GrpcService {
         parse_ttl_security(pg.ttl_security.as_ref()).map_err(tonic::Status::from)?;
         check_gr_restart_time(pg.graceful_restart.as_ref()).map_err(tonic::Status::from)?;
         parse_llgr_api(&pg.afi_safis).map_err(tonic::Status::from)?;
+        if let Some(pw) = pg
+            .conf
+            .as_ref()
+            .map(|c| c.auth_password.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            check_auth_password(pw).map_err(tonic::Status::from)?;
+        }
 
         match self
             .global
@@ -1753,6 +1776,14 @@ impl GoBgpService for GrpcService {
         parse_ttl_security(pg.ttl_security.as_ref()).map_err(tonic::Status::from)?;
         check_gr_restart_time(pg.graceful_restart.as_ref()).map_err(tonic::Status::from)?;
         parse_llgr_api(&pg.afi_safis).map_err(tonic::Status::from)?;
+        if let Some(pw) = pg
+            .conf
+            .as_ref()
+            .map(|c| c.auth_password.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            check_auth_password(pw).map_err(tonic::Status::from)?;
+        }
         let updated = PeerGroup::from(pg);
         let mut global = self.global.write().await;
         match global.peer_group.get_mut(&name) {

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -305,6 +305,7 @@ impl TryFrom<&api::Peer> for PeerParams {
             }
         }
 
+        check_gr_restart_time(p.graceful_restart.as_ref())?;
         let graceful_restart = { parse_gr_api(p.graceful_restart.as_ref(), &p.afi_safis) };
         let llgr = parse_llgr_api(&p.afi_safis);
 
@@ -681,6 +682,21 @@ fn parse_ttl_security(ts: Option<&api::TtlSecurity>) -> Result<Option<u8>, Error
     } else {
         ts.ttl_min as u8
     }))
+}
+
+/// Validate the GracefulRestart restart_time field (RFC 4724 §3).
+/// restart_time is a 12-bit field in the OPEN message; values > 4095 are invalid.
+fn check_gr_restart_time(gr: Option<&api::GracefulRestart>) -> Result<(), Error> {
+    if let Some(gr) = gr
+        && gr.enabled
+        && gr.restart_time > 4095
+    {
+        return Err(Error::InvalidArgument(format!(
+            "graceful_restart restart_time {} exceeds maximum of 4095",
+            gr.restart_time
+        )));
+    }
+    Ok(())
 }
 
 /// Validate and convert a `uint32` port from a gRPC request to `u16`.
@@ -1671,6 +1687,7 @@ impl GoBgpService for GrpcService {
             .into());
         }
         parse_ttl_security(pg.ttl_security.as_ref()).map_err(tonic::Status::from)?;
+        check_gr_restart_time(pg.graceful_restart.as_ref()).map_err(tonic::Status::from)?;
 
         match self
             .global
@@ -1727,6 +1744,7 @@ impl GoBgpService for GrpcService {
             .peer_group_name
             .clone();
         parse_ttl_security(pg.ttl_security.as_ref()).map_err(tonic::Status::from)?;
+        check_gr_restart_time(pg.graceful_restart.as_ref()).map_err(tonic::Status::from)?;
         let updated = PeerGroup::from(pg);
         let mut global = self.global.write().await;
         match global.peer_group.get_mut(&name) {

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -10030,6 +10030,105 @@ port = 3323
             .is_err()
         );
     }
+
+    // --- ttl_min validation ---
+
+    fn peer_with_ttl_min(addr: &str, asn: u32, ttl_min: u32) -> api::AddPeerRequest {
+        api::AddPeerRequest {
+            peer: Some(api::Peer {
+                conf: Some(api::PeerConf {
+                    neighbor_address: addr.to_string(),
+                    peer_asn: asn,
+                    ..Default::default()
+                }),
+                ttl_security: Some(api::TtlSecurity {
+                    enabled: true,
+                    ttl_min,
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn peer_group_with_ttl_min(name: &str, ttl_min: u32) -> api::AddPeerGroupRequest {
+        api::AddPeerGroupRequest {
+            peer_group: Some(api::PeerGroup {
+                conf: Some(api::PeerGroupConf {
+                    peer_group_name: name.to_string(),
+                    ..Default::default()
+                }),
+                ttl_security: Some(api::TtlSecurity {
+                    enabled: true,
+                    ttl_min,
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_peer_ttl_min_255_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_ttl_min(
+                "10.0.0.1", 65001, 255
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_ttl_min_1_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_ttl_min("10.0.0.1", 65001, 1)))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_ttl_min_0_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_ttl_min("10.0.0.1", 65001, 0)))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_ttl_min_256_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_ttl_min(
+                "10.0.0.1", 65001, 256
+            )))
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_ttl_min_255_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_ttl_min("g", 255)))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_ttl_min_256_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_ttl_min("g", 256)))
+                .await
+                .is_err()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -10129,6 +10129,103 @@ port = 3323
                 .is_err()
         );
     }
+
+    // --- graceful_restart restart_time validation ---
+
+    fn peer_with_gr_restart_time(addr: &str, asn: u32, restart_time: u32) -> api::AddPeerRequest {
+        api::AddPeerRequest {
+            peer: Some(api::Peer {
+                conf: Some(api::PeerConf {
+                    neighbor_address: addr.to_string(),
+                    peer_asn: asn,
+                    ..Default::default()
+                }),
+                graceful_restart: Some(api::GracefulRestart {
+                    enabled: true,
+                    restart_time,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn peer_group_with_gr_restart_time(name: &str, restart_time: u32) -> api::AddPeerGroupRequest {
+        api::AddPeerGroupRequest {
+            peer_group: Some(api::PeerGroup {
+                conf: Some(api::PeerGroupConf {
+                    peer_group_name: name.to_string(),
+                    ..Default::default()
+                }),
+                graceful_restart: Some(api::GracefulRestart {
+                    enabled: true,
+                    restart_time,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_peer_gr_restart_time_4095_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_gr_restart_time(
+                "10.0.0.1", 65001, 4095
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_gr_restart_time_0_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_gr_restart_time(
+                "10.0.0.1", 65001, 0
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_gr_restart_time_4096_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_gr_restart_time(
+                "10.0.0.1", 65001, 4096
+            )))
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_gr_restart_time_4095_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_gr_restart_time(
+                "g", 4095
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_gr_restart_time_4096_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_gr_restart_time(
+                "g", 4096
+            )))
+            .await
+            .is_err()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -9863,6 +9863,106 @@ port = 3323
                 .is_err()
         );
     }
+
+    // --- RPKI/BMP port validation ---
+
+    #[tokio::test]
+    async fn add_rpki_valid_port_accepted() {
+        let svc = make_grpc_service();
+        let result = svc
+            .add_rpki(tonic::Request::new(api::AddRpkiRequest {
+                address: "10.0.0.1".to_string(),
+                port: 323,
+                ..Default::default()
+            }))
+            .await;
+        // May fail with AlreadyExists or succeed; either is not an InvalidArgument.
+        assert!(
+            result.is_ok()
+                || result
+                    .as_ref()
+                    .err()
+                    .is_some_and(|e| e.code() != tonic::Code::InvalidArgument)
+        );
+    }
+
+    #[tokio::test]
+    async fn add_rpki_port_zero_rejected() {
+        let svc = make_grpc_service();
+        let result = svc
+            .add_rpki(tonic::Request::new(api::AddRpkiRequest {
+                address: "10.0.0.1".to_string(),
+                port: 0,
+                ..Default::default()
+            }))
+            .await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn add_rpki_port_65536_rejected() {
+        let svc = make_grpc_service();
+        let result = svc
+            .add_rpki(tonic::Request::new(api::AddRpkiRequest {
+                address: "10.0.0.1".to_string(),
+                port: 65536,
+                ..Default::default()
+            }))
+            .await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn add_bmp_valid_port_accepted() {
+        let svc = make_grpc_service();
+        let result = svc
+            .add_bmp(tonic::Request::new(api::AddBmpRequest {
+                address: "10.0.0.1".to_string(),
+                port: 4789,
+                policy: api::add_bmp_request::MonitoringPolicy::Pre as i32,
+                ..Default::default()
+            }))
+            .await;
+        assert!(
+            result.is_ok()
+                || result
+                    .as_ref()
+                    .err()
+                    .is_some_and(|e| e.code() != tonic::Code::InvalidArgument)
+        );
+    }
+
+    #[tokio::test]
+    async fn add_bmp_port_zero_rejected() {
+        let svc = make_grpc_service();
+        let result = svc
+            .add_bmp(tonic::Request::new(api::AddBmpRequest {
+                address: "10.0.0.1".to_string(),
+                port: 0,
+                policy: api::add_bmp_request::MonitoringPolicy::Pre as i32,
+                ..Default::default()
+            }))
+            .await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn add_bmp_port_65536_rejected() {
+        let svc = make_grpc_service();
+        let result = svc
+            .add_bmp(tonic::Request::new(api::AddBmpRequest {
+                address: "10.0.0.1".to_string(),
+                port: 65536,
+                policy: api::add_bmp_request::MonitoringPolicy::Pre as i32,
+                ..Default::default()
+            }))
+            .await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code(), tonic::Code::InvalidArgument);
+    }
 }
 
 #[cfg(test)]

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -9963,6 +9963,73 @@ port = 3323
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().code(), tonic::Code::InvalidArgument);
     }
+
+    // --- remote_port validation ---
+
+    fn peer_with_remote_port(addr: &str, asn: u32, remote_port: u32) -> api::AddPeerRequest {
+        api::AddPeerRequest {
+            peer: Some(api::Peer {
+                conf: Some(api::PeerConf {
+                    neighbor_address: addr.to_string(),
+                    peer_asn: asn,
+                    ..Default::default()
+                }),
+                transport: Some(api::Transport {
+                    remote_port,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_peer_remote_port_zero_uses_default() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_remote_port(
+                "10.0.0.1", 65001, 0
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_remote_port_179_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_remote_port(
+                "10.0.0.1", 65001, 179
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_remote_port_65535_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_remote_port(
+                "10.0.0.1", 65001, 65535
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_remote_port_65536_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_remote_port(
+                "10.0.0.1", 65001, 65536
+            )))
+            .await
+            .is_err()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -10226,6 +10226,66 @@ port = 3323
             .is_err()
         );
     }
+
+    // --- LLGR stale_time validation ---
+
+    fn ipv4_unicast_family() -> api::Family {
+        api::Family {
+            afi: api::family::Afi::Ip as i32,
+            safi: api::family::Safi::Unicast as i32,
+        }
+    }
+
+    fn peer_with_llgr_stale_time(addr: &str, asn: u32, stale_time: u32) -> api::AddPeerRequest {
+        api::AddPeerRequest {
+            peer: Some(api::Peer {
+                conf: Some(api::PeerConf {
+                    neighbor_address: addr.to_string(),
+                    peer_asn: asn,
+                    ..Default::default()
+                }),
+                afi_safis: vec![api::AfiSafi {
+                    config: Some(api::AfiSafiConfig {
+                        family: Some(ipv4_unicast_family()),
+                        ..Default::default()
+                    }),
+                    long_lived_graceful_restart: Some(api::LongLivedGracefulRestart {
+                        config: Some(api::LongLivedGracefulRestartConfig {
+                            enabled: true,
+                            restart_time: stale_time,
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_peer_llgr_stale_time_max_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_llgr_stale_time(
+                "10.0.0.1", 65001, 0xFF_FFFF
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_llgr_stale_time_overflow_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_llgr_stale_time(
+                "10.0.0.1", 65001, 0x100_0000
+            )))
+            .await
+            .is_err()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -9618,6 +9618,108 @@ port = 3323
         svc.start_bgp(start_bgp_req(0)).await.unwrap();
         assert!(svc.start_bgp(start_bgp_req(0)).await.is_err());
     }
+
+    // --- peer group ASN=0 validation ---
+
+    #[test]
+    fn neighbor_config_peer_group_missing_peer_as_accepted() {
+        let n = config::Neighbor {
+            config: Some(config::NeighborConfig {
+                neighbor_address: Some("10.0.0.1".parse().unwrap()),
+                peer_as: None,
+                peer_group: Some("grp".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let params = PeerParams::try_from(&n).unwrap();
+        assert_eq!(params.expected_remote_asn, 0);
+    }
+
+    #[test]
+    fn neighbor_config_peer_group_zero_peer_as_accepted() {
+        let n = config::Neighbor {
+            config: Some(config::NeighborConfig {
+                neighbor_address: Some("10.0.0.1".parse().unwrap()),
+                peer_as: Some(0),
+                peer_group: Some("grp".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let params = PeerParams::try_from(&n).unwrap();
+        assert_eq!(params.expected_remote_asn, 0);
+    }
+
+    #[test]
+    fn neighbor_config_no_peer_group_missing_peer_as_rejected() {
+        let n = config::Neighbor {
+            config: Some(config::NeighborConfig {
+                neighbor_address: Some("10.0.0.1".parse().unwrap()),
+                peer_as: None,
+                peer_group: None,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(PeerParams::try_from(&n).is_err());
+    }
+
+    #[tokio::test]
+    async fn add_peer_grpc_peer_group_zero_asn_accepted() {
+        let svc = make_grpc_service();
+        svc.add_peer_group(tonic::Request::new(api::AddPeerGroupRequest {
+            peer_group: Some(api::PeerGroup {
+                conf: Some(api::PeerGroupConf {
+                    peer_group_name: "grp".to_string(),
+                    peer_asn: 65002,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        }))
+        .await
+        .unwrap();
+
+        let result = svc
+            .add_peer(tonic::Request::new(api::AddPeerRequest {
+                peer: Some(api::Peer {
+                    conf: Some(api::PeerConf {
+                        neighbor_address: "10.0.0.1".to_string(),
+                        peer_asn: 0,
+                        peer_group: "grp".to_string(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+            }))
+            .await;
+        assert!(
+            result.is_ok(),
+            "peer_asn=0 in a peer group must be accepted"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_grpc_no_peer_group_zero_asn_rejected() {
+        let svc = make_grpc_service();
+        let result = svc
+            .add_peer(tonic::Request::new(api::AddPeerRequest {
+                peer: Some(api::Peer {
+                    conf: Some(api::PeerConf {
+                        neighbor_address: "10.0.0.1".to_string(),
+                        peer_asn: 0,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+            }))
+            .await;
+        assert!(
+            result.is_err(),
+            "peer_asn=0 without a peer group must be rejected"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -10286,6 +10286,89 @@ port = 3323
             .is_err()
         );
     }
+
+    // --- auth_password length validation ---
+
+    fn peer_with_auth_password(addr: &str, asn: u32, password: &str) -> api::AddPeerRequest {
+        api::AddPeerRequest {
+            peer: Some(api::Peer {
+                conf: Some(api::PeerConf {
+                    neighbor_address: addr.to_string(),
+                    peer_asn: asn,
+                    auth_password: password.to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn peer_group_with_auth_password(name: &str, password: &str) -> api::AddPeerGroupRequest {
+        api::AddPeerGroupRequest {
+            peer_group: Some(api::PeerGroup {
+                conf: Some(api::PeerGroupConf {
+                    peer_group_name: name.to_string(),
+                    auth_password: password.to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_peer_auth_password_80_bytes_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_auth_password(
+                "10.0.0.1",
+                65001,
+                &"a".repeat(80)
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_auth_password_81_bytes_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_auth_password(
+                "10.0.0.1",
+                65001,
+                &"a".repeat(81)
+            )))
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_auth_password_80_bytes_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_auth_password(
+                "g",
+                &"a".repeat(80)
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_auth_password_81_bytes_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_auth_password(
+                "g",
+                &"a".repeat(81)
+            )))
+            .await
+            .is_err()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -9720,6 +9720,149 @@ port = 3323
             "peer_asn=0 without a peer group must be rejected"
         );
     }
+
+    // --- hold_time gRPC validation ---
+
+    fn peer_with_hold_time(addr: &str, asn: u32, hold_time: u64) -> api::AddPeerRequest {
+        api::AddPeerRequest {
+            peer: Some(api::Peer {
+                conf: Some(api::PeerConf {
+                    neighbor_address: addr.to_string(),
+                    peer_asn: asn,
+                    ..Default::default()
+                }),
+                timers: Some(api::Timers {
+                    config: Some(api::TimersConfig {
+                        hold_time,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn peer_group_with_hold_time(hold_time: u64) -> api::AddPeerGroupRequest {
+        api::AddPeerGroupRequest {
+            peer_group: Some(api::PeerGroup {
+                conf: Some(api::PeerGroupConf {
+                    peer_group_name: "grp".to_string(),
+                    ..Default::default()
+                }),
+                timers: Some(api::Timers {
+                    config: Some(api::TimersConfig {
+                        hold_time,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_peer_hold_time_zero_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_hold_time(
+                "10.0.0.1", 65001, 0
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_hold_time_90_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_hold_time(
+                "10.0.0.1", 65001, 90
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_hold_time_65535_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_hold_time(
+                "10.0.0.1", 65001, 65535
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_hold_time_1_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_hold_time(
+                "10.0.0.1", 65001, 1
+            )))
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_hold_time_2_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_hold_time(
+                "10.0.0.1", 65001, 2
+            )))
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_hold_time_65536_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_hold_time(
+                "10.0.0.1", 65001, 65536
+            )))
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_hold_time_90_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_hold_time(90)))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_hold_time_1_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_hold_time(1)))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_hold_time_65536_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_hold_time(65536)))
+                .await
+                .is_err()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/daemon/src/event/peer.rs
+++ b/daemon/src/event/peer.rs
@@ -477,7 +477,13 @@ impl TryFrom<&config::Neighbor> for PeerParams {
                 .neighbor_address
                 .as_ref()
                 .ok_or("missing neighbor address")?;
-            let asn = c.peer_as.ok_or("missing peer-as")?;
+            // peer_as may be absent when the peer belongs to a peer group;
+            // apply_peer_group() fills it in from the group's as_number.
+            let asn = if c.peer_group.is_some() {
+                c.peer_as.unwrap_or(0)
+            } else {
+                c.peer_as.ok_or("missing peer-as")?
+            };
             (addr, asn)
         };
 

--- a/daemon/src/event/peer.rs
+++ b/daemon/src/event/peer.rs
@@ -26,6 +26,12 @@ use rustybgp_packet::{self as packet, Family};
 
 use super::*;
 
+/// Maximum number of Add-Path paths to advertise per prefix (send_max).
+/// Matches the u8 upper bound used in the config file representation.
+/// RFC 7911 imposes no limit; this matches FRR's uint16 range in practice
+/// and is well above any realistic deployment need.
+pub(crate) const ADDPATH_SEND_MAX_LIMIT: usize = u8::MAX as usize;
+
 /// Static GR configuration for a single peer, set at peer creation.
 /// `None` in `PeerConfig::graceful_restart` means GR is disabled for this peer.
 /// Cloned into capability negotiation at each session open.


### PR DESCRIPTION
The send_max <= 32 cap in config/src/validate.rs came from GoBGP's implementation and has no RFC 7911 basis. BIRD imposes no limit; FRR uses uint16_t (max 65535). The config file already stores send_max as Option<u8>, so the natural ceiling is 255 without an explicit check.

Remove the validate.rs check. Add ADDPATH_SEND_MAX_LIMIT = u8::MAX (255) as the authoritative constant in peer.rs.

The gRPC TryFrom<&api::Peer> path was silently ignoring add_paths configuration in afi_safis: families were registered with mode=0 (no add-path) and send_max was always empty regardless of what the API caller sent. Fix this by parsing rx/tx mode and send_max from api::AfiSafi::add_paths for each family, and enforce the 255 ceiling via ADDPATH_SEND_MAX_LIMIT, returning InvalidArgument if exceeded.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>