### PR TITLE
error: replace unreachable panic with Internal gRPC status

### DIFF
--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -60,7 +60,9 @@ impl From<Error> for tonic::Status {
                     tonic::Status::new(tonic::Code::FailedPrecondition, s)
                 }
             },
-            _ => panic!("unsupported error code"),
+            // No gRPC handler currently produces these variants, but handle
+            // them gracefully so a future addition cannot cause a panic.
+            e => tonic::Status::internal(e.to_string()),
         }
     }
 }


### PR DESCRIPTION
No gRPC handler currently produces Error::Packet, Error::StdIoErr, Error::Config, or Error::InvalidConfiguration, so the wildcard arm in From<Error> for tonic::Status was unreachable in practice.  Replace the panic with tonic::Status::internal() so that a future handler using one of these variants returns an error to the caller instead of crashing the daemon.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>