### PR TITLE
grpc: reject multihop_ttl values that exceed 255

### DIFF
--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -343,6 +343,7 @@ impl TryFrom<&api::Peer> for PeerParams {
             }
         };
         let ttl_security = parse_ttl_security(p.ttl_security.as_ref())?;
+        let multihop_ttl = parse_multihop_ttl(p.ebgp_multihop.as_ref())?;
 
         Ok(PeerParams {
             remote_addr,
@@ -380,13 +381,7 @@ impl TryFrom<&api::Peer> for PeerParams {
             state: SessionState::Idle,
             holdtime,
             connect_retry_time,
-            multihop_ttl: p.ebgp_multihop.as_ref().and_then(|x| {
-                if x.enabled && x.multihop_ttl != 0 {
-                    Some(x.multihop_ttl as u8)
-                } else {
-                    None
-                }
-            }),
+            multihop_ttl,
             ttl_security,
             password: if conf.auth_password.is_empty() {
                 None
@@ -668,6 +663,25 @@ pub(super) struct GrpcService {
     pub(super) global: GlobalHandle,
     pub(super) tables: TableHandle,
     path_uuid_map: tokio::sync::Mutex<FnvHashMap<uuid::Uuid, (Family, Vec<packet::PathNlri>)>>,
+}
+
+/// Validate and convert `api::EbgpMultihop` to the internal `Option<u8>`.
+/// Returns `InvalidArgument` when `multihop_ttl` does not fit in a u8 (> 255).
+/// A value of 0 with enabled=true is treated as "no multihop" (returns None).
+fn parse_multihop_ttl(mh: Option<&api::EbgpMultihop>) -> Result<Option<u8>, Error> {
+    let Some(mh) = mh else {
+        return Ok(None);
+    };
+    if !mh.enabled || mh.multihop_ttl == 0 {
+        return Ok(None);
+    }
+    if mh.multihop_ttl > u8::MAX as u32 {
+        return Err(Error::InvalidArgument(format!(
+            "multihop_ttl {} exceeds maximum of 255",
+            mh.multihop_ttl
+        )));
+    }
+    Ok(Some(mh.multihop_ttl as u8))
 }
 
 /// Validate and convert `api::TtlSecurity` to the internal `Option<u8>`.
@@ -1710,6 +1724,7 @@ impl GoBgpService for GrpcService {
         parse_ttl_security(pg.ttl_security.as_ref()).map_err(tonic::Status::from)?;
         check_gr_restart_time(pg.graceful_restart.as_ref()).map_err(tonic::Status::from)?;
         parse_llgr_api(&pg.afi_safis).map_err(tonic::Status::from)?;
+        parse_multihop_ttl(pg.ebgp_multihop.as_ref()).map_err(tonic::Status::from)?;
         if let Some(pw) = pg
             .conf
             .as_ref()
@@ -1776,6 +1791,7 @@ impl GoBgpService for GrpcService {
         parse_ttl_security(pg.ttl_security.as_ref()).map_err(tonic::Status::from)?;
         check_gr_restart_time(pg.graceful_restart.as_ref()).map_err(tonic::Status::from)?;
         parse_llgr_api(&pg.afi_safis).map_err(tonic::Status::from)?;
+        parse_multihop_ttl(pg.ebgp_multihop.as_ref()).map_err(tonic::Status::from)?;
         if let Some(pw) = pg
             .conf
             .as_ref()

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -10369,6 +10369,85 @@ port = 3323
             .is_err()
         );
     }
+
+    // --- multihop_ttl validation ---
+
+    fn peer_with_multihop_ttl(addr: &str, asn: u32, ttl: u32) -> api::AddPeerRequest {
+        api::AddPeerRequest {
+            peer: Some(api::Peer {
+                conf: Some(api::PeerConf {
+                    neighbor_address: addr.to_string(),
+                    peer_asn: asn,
+                    ..Default::default()
+                }),
+                ebgp_multihop: Some(api::EbgpMultihop {
+                    enabled: true,
+                    multihop_ttl: ttl,
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn peer_group_with_multihop_ttl(name: &str, ttl: u32) -> api::AddPeerGroupRequest {
+        api::AddPeerGroupRequest {
+            peer_group: Some(api::PeerGroup {
+                conf: Some(api::PeerGroupConf {
+                    peer_group_name: name.to_string(),
+                    ..Default::default()
+                }),
+                ebgp_multihop: Some(api::EbgpMultihop {
+                    enabled: true,
+                    multihop_ttl: ttl,
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_peer_multihop_ttl_255_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_multihop_ttl(
+                "10.0.0.1", 65001, 255
+            )))
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_multihop_ttl_256_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer(tonic::Request::new(peer_with_multihop_ttl(
+                "10.0.0.1", 65001, 256
+            )))
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_multihop_ttl_255_accepted() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_multihop_ttl("g", 255)))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn add_peer_group_multihop_ttl_256_rejected() {
+        let svc = make_grpc_service();
+        assert!(
+            svc.add_peer_group(tonic::Request::new(peer_group_with_multihop_ttl("g", 256)))
+                .await
+                .is_err()
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
api::EbgpMultihop.multihop_ttl is a uint32, but the IP TTL field is 8 bits wide, so values above 255 cannot be set on the socket.  The previous cast (multihop_ttl as u8) silently wrapped for out-of-range values.

Add parse_multihop_ttl() following the same pattern as parse_ttl_security(). Call it with ? in TryFrom<&api::Peer> and with map_err(tonic::Status::from)? in add_peer_group and update_peer_group before the infallible From<api::PeerGroup> conversion.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>