### PR TITLE
daemon: support Linux VRF device-scoped TCP MD5 for BGP sockets

### DIFF
--- a/daemon/src/auth.rs
+++ b/daemon/src/auth.rs
@@ -20,13 +20,17 @@ use std::os::unix::io::RawFd;
 struct TcpMd5sig {
     ss_family: u16,
     ss: [u8; 126],
-    _pad0: u16,
+    tcpm_flags: u8,
+    tcpm_prefixlen: u8,
     keylen: u16,
-    _pad1: u32,
+    tcpm_ifindex: u32,
     key: [u8; 80],
 }
+
+const TCP_MD5SIG_FLAG_IFINDEX: u8 = 2;
+
 impl TcpMd5sig {
-    fn new(addr: &IpAddr, password: String) -> TcpMd5sig {
+    fn new(addr: &IpAddr, password: String, ifindex: u32) -> TcpMd5sig {
         let mut ss = [0; 126];
         let ss_family = match addr {
             std::net::IpAddr::V4(addr) => {
@@ -42,27 +46,33 @@ impl TcpMd5sig {
         let keylen = k.len();
         let mut key = [0; 80];
         key[..std::cmp::min(keylen, 80)].clone_from_slice(&k[..std::cmp::min(keylen, 80)]);
+        let tcpm_flags = if ifindex != 0 {
+            TCP_MD5SIG_FLAG_IFINDEX
+        } else {
+            0
+        };
         TcpMd5sig {
             ss_family,
             ss,
-            _pad0: 0,
+            tcpm_flags,
+            tcpm_prefixlen: 0,
             keylen: keylen as u16,
-            _pad1: 0,
+            tcpm_ifindex: ifindex,
             key,
         }
     }
 }
 
 #[cfg(target_os = "linux")]
-pub(crate) fn set_md5sig(rawfd: RawFd, addr: &IpAddr, key: &str) {
-    let s = TcpMd5sig::new(addr, key.to_string());
+pub(crate) fn set_md5sig(rawfd: RawFd, addr: &IpAddr, key: &str, ifindex: u32) {
+    let s = TcpMd5sig::new(addr, key.to_string(), ifindex);
     unsafe {
         let ptr: *const TcpMd5sig = &s;
         let len = std::mem::size_of::<TcpMd5sig>() as u32;
         let _ = libc::setsockopt(
             rawfd,
             libc::IPPROTO_TCP,
-            libc::TCP_MD5SIG,
+            libc::TCP_MD5SIG_EXT,
             ptr as *const _,
             len,
         );
@@ -72,7 +82,16 @@ pub(crate) fn set_md5sig(rawfd: RawFd, addr: &IpAddr, key: &str) {
 // use file per target os when you add *bsd support
 // for now, let's keep things simple
 #[cfg(not(target_os = "linux"))]
-pub(crate) fn set_md5sig(_rawfd: RawFd, _addr: &IpAddr, _key: &str) {}
+pub(crate) fn set_md5sig(_rawfd: RawFd, _addr: &IpAddr, _key: &str, _ifindex: u32) {}
+
+/// Resolve a network interface name to its ifindex.
+/// Returns 0 if the interface does not exist or the name is empty.
+pub(crate) fn ifindex_of(device: &str) -> u32 {
+    if device.is_empty() {
+        return 0;
+    }
+    nix::net::if_::if_nametoindex(device).unwrap_or(0)
+}
 
 /// Set the minimum acceptable TTL for incoming packets (RFC 5082 GTSM).
 /// Packets arriving with TTL < ttl_min are dropped by the kernel.

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -406,6 +406,11 @@ impl TryFrom<&api::Peer> for PeerParams {
                 }
             }),
             neighbor_interface,
+            bind_interface: p
+                .transport
+                .as_ref()
+                .filter(|t| !t.bind_interface.is_empty())
+                .map(|t| t.bind_interface.clone()),
         })
     }
 }
@@ -921,12 +926,13 @@ impl GoBgpService for GrpcService {
             } else {
                 Some(g.bind_to_device.as_str())
             };
+            let ifindex = device.map(auth::ifindex_of).unwrap_or(0);
             global.listen_sockets.append(
                 &mut listen_addresses
                     .into_iter()
                     .map(|addr| create_listen_socket(addr, device))
                     .filter_map(|x| x.ok())
-                    .map(|x| x.as_raw_fd())
+                    .map(|x| (x.as_raw_fd(), ifindex))
                     .collect(),
             );
         }
@@ -1059,8 +1065,8 @@ impl GoBgpService for GrpcService {
             params.apply_peer_group(pg);
         }
         if let Some(password) = params.password.as_ref() {
-            for fd in &global.listen_sockets {
-                auth::set_md5sig(*fd, &params.remote_addr, password);
+            for &(fd, ifindex) in &global.listen_sockets {
+                auth::set_md5sig(fd, &params.remote_addr, password, ifindex);
             }
         }
         global.add_peer(params, Some(self.active_conn_tx.clone()))?;
@@ -1083,8 +1089,8 @@ impl GoBgpService for GrpcService {
                     );
                 }
                 if p.config.password.is_some() {
-                    for fd in &global.listen_sockets {
-                        auth::set_md5sig(*fd, &peer_addr, "");
+                    for &(fd, ifindex) in &global.listen_sockets {
+                        auth::set_md5sig(fd, &peer_addr, "", ifindex);
                     }
                 }
                 if let Some(bfd) = &global.bfd_handle {
@@ -1243,6 +1249,7 @@ impl GoBgpService for GrpcService {
                 graceful_restart: new_params.graceful_restart.clone(),
                 llgr: new_params.llgr.clone(),
                 neighbor_interface: new_params.neighbor_interface,
+                bind_interface: new_params.bind_interface,
             };
 
             if needs_teardown {
@@ -1275,13 +1282,13 @@ impl GoBgpService for GrpcService {
         // Update TCP MD5 socket option after releasing the peer borrow.
         if old_password != new_params.password {
             if old_password.is_some() {
-                for fd in &listen_sockets {
-                    auth::set_md5sig(*fd, &peer_addr, "");
+                for &(fd, ifindex) in &listen_sockets {
+                    auth::set_md5sig(fd, &peer_addr, "", ifindex);
                 }
             }
             if let Some(pw) = &new_params.password {
-                for fd in &listen_sockets {
-                    auth::set_md5sig(*fd, &peer_addr, pw);
+                for &(fd, ifindex) in &listen_sockets {
+                    auth::set_md5sig(fd, &peer_addr, pw, ifindex);
                 }
             }
         }

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -627,6 +627,8 @@ pub(super) fn enable_active_connect(peer: &mut Peer, ch: mpsc::UnboundedSender<T
     };
     let retry_time = peer.config.connect_retry_time;
     let password = peer.config.password.as_ref().map(|x| x.to_string());
+    let bind_interface = peer.config.bind_interface.clone();
+    let peer_ifindex = bind_interface.as_deref().map(auth::ifindex_of).unwrap_or(0);
     let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel::<()>();
     let join_handle = tokio::spawn(async move {
         loop {
@@ -634,8 +636,11 @@ pub(super) fn enable_active_connect(peer: &mut Peer, ch: mpsc::UnboundedSender<T
                 IpAddr::V4(_) => tokio::net::TcpSocket::new_v4().unwrap(),
                 IpAddr::V6(_) => tokio::net::TcpSocket::new_v6().unwrap(),
             };
+            if let Some(dev) = bind_interface.as_deref() {
+                let _ = socket.bind_device(Some(dev.as_bytes()));
+            }
             if let Some(key) = password.as_ref() {
-                auth::set_md5sig(socket.as_raw_fd(), &peer_addr, key);
+                auth::set_md5sig(socket.as_raw_fd(), &peer_addr, key, peer_ifindex);
             }
             tokio::select! {
                 result = tokio::time::timeout(
@@ -705,7 +710,7 @@ pub(crate) struct Global {
     pub(crate) asn: u32,
     pub(crate) router_id: Ipv4Addr,
     listen_port: Option<u16>,
-    listen_sockets: Vec<RawFd>,
+    listen_sockets: Vec<(RawFd, u32)>,
     pub(crate) peers: FnvHashMap<IpAddr, Peer>,
     peer_group: FnvHashMap<String, PeerGroup>,
 
@@ -1292,7 +1297,9 @@ impl Global {
 
         loop {
             notify.notified().await;
-            let listen_sockets = if let Some(listen_port) = global.read().await.listen_port {
+            let (listen_sockets, listen_ifindex) = if let Some(listen_port) =
+                global.read().await.listen_port
+            {
                 let global_config = bgp
                     .as_ref()
                     .and_then(|x| x.global.as_ref())
@@ -1311,26 +1318,28 @@ impl Global {
                 let device = global_config
                     .and_then(|c| c.bind_to_device.as_deref())
                     .filter(|s| !s.is_empty());
-
-                addrs
+                let ifindex = device.map(auth::ifindex_of).unwrap_or(0);
+                let sockets = addrs
                     .into_iter()
                     .map(|addr| create_listen_socket(addr, device))
                     .filter_map(|x| x.ok())
-                    .collect()
+                    .collect::<Vec<_>>();
+                (sockets, ifindex)
             } else {
-                Vec::new()
+                (Vec::new(), 0)
             };
 
-            global
-                .write()
-                .await
-                .listen_sockets
-                .append(&mut listen_sockets.iter().map(|x| x.as_raw_fd()).collect());
+            global.write().await.listen_sockets.append(
+                &mut listen_sockets
+                    .iter()
+                    .map(|x| (x.as_raw_fd(), listen_ifindex))
+                    .collect(),
+            );
 
             for (addr, peer) in &global.read().await.peers {
                 if let Some(password) = &peer.config.password {
                     for l in &listen_sockets {
-                        auth::set_md5sig(l.as_raw_fd(), addr, password);
+                        auth::set_md5sig(l.as_raw_fd(), addr, password, listen_ifindex);
                     }
                 }
             }
@@ -1493,6 +1502,7 @@ async fn accept_connection(
                 llgr: group.llgr.clone(),
                 bfd_config: None,
                 neighbor_interface: None,
+                bind_interface: None,
             };
             let _ = g.add_peer(params, None);
             g.peers.get_mut(&remote_addr).unwrap()
@@ -3701,6 +3711,7 @@ mod tests {
             llgr: None,
             bfd_config: None,
             neighbor_interface: None,
+            bind_interface: None,
         }
     }
 

--- a/daemon/src/event/peer.rs
+++ b/daemon/src/event/peer.rs
@@ -103,6 +103,11 @@ pub(crate) struct PeerConfig {
     /// When set, the TCP connection uses the link-local address discovered via
     /// NDP at peer-add time, with the interface index as the socket scope ID.
     pub(crate) neighbor_interface: Option<String>,
+    /// Interface name for binding this peer's TCP socket; corresponds to GoBGP's
+    /// Transport.BindInterface.  The primary use case is a Linux VRF device: when
+    /// set, the outgoing socket is bound to that Linux VRF device and TCP MD5 is
+    /// scoped to its ifindex so the key applies only within that Linux VRF device.
+    pub(crate) bind_interface: Option<String>,
 }
 
 /// Plain-struct replacement for the old PeerBuilder.
@@ -135,6 +140,8 @@ pub(crate) struct PeerParams {
     pub(crate) bfd_config: Option<crate::bfd::BfdPeerConfig>,
     /// Interface name for unnumbered BGP (RFC 7938); None for normal peers.
     pub(crate) neighbor_interface: Option<String>,
+    /// Interface name for binding this peer's TCP socket (primarily a Linux VRF device); None if unused.
+    pub(crate) bind_interface: Option<String>,
 }
 
 impl PeerParams {
@@ -322,6 +329,7 @@ impl PeerParams {
                 graceful_restart: self.graceful_restart,
                 llgr: self.llgr,
                 neighbor_interface: self.neighbor_interface,
+                bind_interface: self.bind_interface,
             },
             admin_down: self.admin_down,
             state: Arc::new(PeerState {
@@ -604,6 +612,12 @@ impl TryFrom<&config::Neighbor> for PeerParams {
                     }
                 }),
             neighbor_interface,
+            bind_interface: n
+                .transport
+                .as_ref()
+                .and_then(|t| t.config.as_ref())
+                .and_then(|c| c.bind_interface.clone())
+                .filter(|s| !s.is_empty()),
         })
     }
 }


### PR DESCRIPTION
TCP MD5 keys set on a Linux VRF device-bound socket must be scoped to the device's ifindex so the kernel applies them only within that Linux VRF device.  Without this, a key set on a global socket would match connections from any Linux VRF device, and a key set on a Linux VRF device-bound socket would be silently ignored.

Switch from TCP_MD5SIG to TCP_MD5SIG_EXT throughout.  TCP_MD5SIG_EXT is a strict superset (available since Linux 4.13) and is required to pass TCP_MD5SIG_FLAG_IFINDEX.  When ifindex is 0 the flags field stays clear, so behaviour for non-Linux-VRF-device peers is unchanged.

For listen sockets: derive ifindex from the global bind-to-device name at socket creation time and store it alongside the raw FD in Global::listen_sockets (changed from Vec<RawFd> to Vec<(RawFd, u32)>). Pass the ifindex to every set_md5sig call on those FDs.

For outgoing peer connections: add bind_interface: Option<String> to PeerConfig and PeerParams.  The field corresponds to GoBGP's Transport.BindInterface; the primary use case is a Linux VRF device. Read it from Transport.bind_interface in the gRPC (api::Peer) path and from transport.config.bind-interface in the config-file (config::Neighbor) path.  In enable_active_connect, bind_device the socket to that interface before connect, and derive the ifindex for the MD5 setsockopt call.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>