### PR TITLE
daemon, table: replace SystemTime with u32 for per-path timestamps

### DIFF
--- a/daemon/src/bmp.rs
+++ b/daemon/src/bmp.rs
@@ -113,11 +113,7 @@ fn flush_peer_snapshot(
                     Ipv4Addr::from(change.source.router_id),
                     0,
                     change.source.remote_addr,
-                    change
-                        .timestamp
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs() as u32,
+                    change.timestamp,
                 ),
                 update,
                 addpath: change.addpath,
@@ -435,10 +431,7 @@ impl BmpClient {
                         net: change.net.clone(),
                         attr: best.map(|p| p.attr.clone()),
                         nexthop: best.and_then(|p| p.nexthop),
-                        timestamp: std::time::SystemTime::now()
-                            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs() as u32,
+                        timestamp: crate::proto::unix_secs(),
                     };
                     let msg = loc_rib_to_bmp(&lrc, local_id, local_asn);
                     if lines.send(&msg).await.is_err() {
@@ -495,10 +488,7 @@ impl BmpClient {
                                         Ipv4Addr::from(change.source.router_id),
                                         0,
                                         change.source.remote_addr,
-                                        change.timestamp
-                                            .duration_since(SystemTime::UNIX_EPOCH)
-                                            .unwrap_or_default()
-                                            .as_secs() as u32,
+                                        change.timestamp,
                                     ),
                                     update,
                                     addpath: change.addpath,
@@ -522,10 +512,7 @@ impl BmpClient {
                                         Ipv4Addr::from(change.source.router_id),
                                         0,
                                         change.source.remote_addr,
-                                        change.timestamp
-                                            .duration_since(SystemTime::UNIX_EPOCH)
-                                            .unwrap_or_default()
-                                            .as_secs() as u32,
+                                        change.timestamp,
                                     ),
                                     update,
                                     addpath: change.addpath,
@@ -549,11 +536,7 @@ impl BmpClient {
                                         Ipv4Addr::from(change.peer_id),
                                         0,
                                         change.peer_addr,
-                                        change
-                                            .timestamp
-                                            .duration_since(SystemTime::UNIX_EPOCH)
-                                            .unwrap_or_default()
-                                            .as_secs() as u32,
+                                        change.timestamp,
                                     ),
                                     update,
                                     addpath: change.addpath,
@@ -578,11 +561,7 @@ impl BmpClient {
                                         Ipv4Addr::from(change.peer_id),
                                         0,
                                         change.peer_addr,
-                                        change
-                                            .timestamp
-                                            .duration_since(SystemTime::UNIX_EPOCH)
-                                            .unwrap_or_default()
-                                            .as_secs() as u32,
+                                        change.timestamp,
                                     ),
                                     update,
                                     addpath: change.addpath,
@@ -747,7 +726,7 @@ mod tests {
             nlris,
             attrs: Some(Arc::new(Vec::new())),
             nexthop: None,
-            timestamp: SystemTime::UNIX_EPOCH,
+            timestamp: 0u32,
         }
     }
 
@@ -763,7 +742,7 @@ mod tests {
             nlris,
             attrs: None,
             nexthop: None,
-            timestamp: SystemTime::UNIX_EPOCH,
+            timestamp: 0u32,
         }
     }
 

--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -4301,7 +4301,6 @@ pub(crate) fn destination_to_api(
     family: Family,
     binary: &PathBinaryFlags,
 ) -> api::Destination {
-    use crate::proto::ToApi;
     api::Destination {
         prefix: d.net.to_string(),
         paths: d
@@ -4315,7 +4314,10 @@ pub(crate) fn destination_to_api(
                 },
                 family: Some(family_to_api(family)),
                 identifier: p.remote_path_id,
-                age: Some(p.timestamp.to_api()),
+                age: Some(prost_types::Timestamp {
+                    seconds: p.timestamp as i64,
+                    nanos: 0,
+                }),
                 pattrs: if binary.only_binary {
                     vec![]
                 } else {

--- a/daemon/src/event/export.rs
+++ b/daemon/src/event/export.rs
@@ -15,7 +15,6 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
-use std::time::SystemTime;
 
 use fnv::{FnvHashMap, FnvHashSet};
 use tokio::sync::mpsc;
@@ -37,7 +36,7 @@ pub(super) struct BmpAdjOut {
     peer_asn: u32,
     peer_id: u32,
     addpath: bool,
-    timestamp: SystemTime,
+    timestamp: u32,
 }
 
 impl BmpAdjOut {
@@ -54,7 +53,7 @@ impl BmpAdjOut {
             peer_asn,
             peer_id,
             addpath,
-            timestamp: SystemTime::now(),
+            timestamp: crate::proto::unix_secs(),
         }
     }
 
@@ -449,7 +448,7 @@ impl NlriSink for AdjOutSink {
         let entry = table::PathEntry {
             source: Arc::clone(source),
             remote_path_id: 0,
-            timestamp: std::time::SystemTime::UNIX_EPOCH,
+            timestamp: 0u32,
             attr,
             validation: None,
             stale: source.is_stale(),

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -1989,7 +1989,7 @@ impl GoBgpService for GrpcService {
             insert_attrs = vpn_attrs;
         }
         let map_nets = insert_nets.clone();
-        let timestamp = std::time::SystemTime::now();
+        let timestamp = crate::proto::unix_secs();
         let source = table::Source::local();
         if let Some(attrs) = insert_attrs {
             for net in insert_nets {
@@ -2032,7 +2032,7 @@ impl GoBgpService for GrpcService {
             .await
             .remove(&id)
             .ok_or_else(|| tonic::Status::new(tonic::Code::NotFound, "uuid not found"))?;
-        let timestamp = std::time::SystemTime::now();
+        let timestamp = crate::proto::unix_secs();
         let source = table::Source::local();
         for net in nets {
             self.tables
@@ -2277,7 +2277,7 @@ impl GoBgpService for GrpcService {
                 if let Ok((family, nets, attrs, nexthop)) = self.local_path(path)
                     && let Some(attrs) = attrs
                 {
-                    let timestamp = std::time::SystemTime::now();
+                    let timestamp = crate::proto::unix_secs();
                     for net in nets {
                         self.tables.insert_route(
                             source.clone(),
@@ -2349,7 +2349,7 @@ impl GoBgpService for GrpcService {
         self.tables
             .add_vrf(name, rd, import_rt, export_rt, vrf.id)
             .map_err(Error::Table)?;
-        let now = std::time::SystemTime::now();
+        let now = crate::proto::unix_secs();
         for nlri in nlris.into_iter() {
             self.tables.insert_route(
                 table::Source::local(),
@@ -2390,7 +2390,7 @@ impl GoBgpService for GrpcService {
                 }),
             })
             .collect::<Vec<_>>();
-        let now = std::time::SystemTime::now();
+        let now = crate::proto::unix_secs();
         for nlri in nlris.into_iter() {
             self.tables
                 .remove_route(table::Source::local(), Family::RTC, nlri, None, now);

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -2935,7 +2935,7 @@ impl PeerSession {
         reach: Option<bgp::ReachNlri>,
         unreach: Option<packet::UnreachNlri>,
         attr: Arc<Vec<packet::Attribute>>,
-        timestamp: std::time::SystemTime,
+        timestamp: u32,
     ) -> bool {
         // RFC 4456 §8 loop detection: discard UPDATE if ORIGINATOR_ID equals
         // local router-id, or if CLUSTER_LIST already contains local cluster-id.
@@ -3141,7 +3141,7 @@ impl PeerSession {
 
         // For UPDATE Routes: if FSM didn't reject (no SessionDown), process routes.
         if let Some((reach, unreach, attr)) = route_fields {
-            let rx_timestamp = std::time::SystemTime::now();
+            let rx_timestamp = crate::proto::unix_secs();
             if self.rx_update(reach, unreach, attr, rx_timestamp).await {
                 let cease = bgp::Message::Notification(
                     rustybgp_packet::Notification::CeaseMaxPrefixReached,
@@ -5254,7 +5254,7 @@ mod tests {
                 packet::Attribute::new_with_value(packet::Attribute::ORIGIN, 0u32).unwrap(),
             ]),
             None,
-            std::time::SystemTime::UNIX_EPOCH,
+            0u32,
         );
     }
 
@@ -5436,7 +5436,7 @@ mod tests {
                 packet::Attribute::new_with_value(packet::Attribute::ORIGIN, 0u32).unwrap(),
             ]),
             None,
-            std::time::SystemTime::UNIX_EPOCH,
+            0u32,
         );
         let dest_id = tables
             .collect_loc_rib_paths_limited(Family::IPV4_VPN, 1)
@@ -5932,7 +5932,7 @@ mod tests {
                 false,
                 false,
                 None,
-                std::time::SystemTime::UNIX_EPOCH,
+                0u32,
             );
             let _ = t.rtable.insert(
                 source.clone(),
@@ -5945,7 +5945,7 @@ mod tests {
                 false,
                 false,
                 None,
-                std::time::SystemTime::UNIX_EPOCH,
+                0u32,
             );
         }
 
@@ -5999,7 +5999,7 @@ mod tests {
                 false,
                 false,
                 None,
-                std::time::SystemTime::UNIX_EPOCH,
+                0u32,
             );
         }
         assert_eq!(
@@ -9121,12 +9121,7 @@ port = 3323
         ]);
 
         let exceeded = session
-            .rx_update(
-                reach_set("10.0.0.0/24"),
-                None,
-                attrs,
-                std::time::SystemTime::now(),
-            )
+            .rx_update(reach_set("10.0.0.0/24"), None, attrs, 0u32)
             .await;
 
         assert!(!exceeded, "loop detection must not trigger CEASE");
@@ -9148,12 +9143,7 @@ port = 3323
         ]);
 
         let exceeded = session
-            .rx_update(
-                reach_set("10.0.0.0/24"),
-                None,
-                attrs,
-                std::time::SystemTime::now(),
-            )
+            .rx_update(reach_set("10.0.0.0/24"), None, attrs, 0u32)
             .await;
 
         assert!(!exceeded, "loop detection must not trigger CEASE");
@@ -9180,12 +9170,7 @@ port = 3323
         ]);
 
         let exceeded = session
-            .rx_update(
-                reach_set("10.0.0.0/24"),
-                None,
-                attrs,
-                std::time::SystemTime::now(),
-            )
+            .rx_update(reach_set("10.0.0.0/24"), None, attrs, 0u32)
             .await;
 
         assert!(!exceeded, "loop detection must not trigger CEASE");

--- a/daemon/src/proto.rs
+++ b/daemon/src/proto.rs
@@ -13,18 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::SystemTime;
-
-pub(crate) trait ToApi<T: prost::Message> {
-    fn to_api(&self) -> T;
-}
-
-impl ToApi<prost_types::Timestamp> for SystemTime {
-    fn to_api(&self) -> prost_types::Timestamp {
-        let unix = self.duration_since(SystemTime::UNIX_EPOCH).unwrap();
-        prost_types::Timestamp {
-            seconds: unix.as_secs() as i64,
-            nanos: unix.subsec_nanos() as i32,
-        }
-    }
+/// Return the current time as seconds since the Unix epoch (truncated to u32).
+pub(crate) fn unix_secs() -> u32 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as u32
 }

--- a/daemon/src/rtc.rs
+++ b/daemon/src/rtc.rs
@@ -555,7 +555,6 @@ mod tests {
     use rustybgp_packet::bgp::Attribute;
     use rustybgp_table::SoftResetPath;
     use std::sync::Arc;
-    use std::time::SystemTime;
 
     fn make_rtc_path(match_type: MatchType) -> SoftResetPath {
         let nlri = Nlri::Rtc(rustybgp_packet::rtc::RtcNlri { match_type });
@@ -566,7 +565,7 @@ mod tests {
             None,
             rustybgp_table::Source::local(),
             Arc::new(vec![]),
-            SystemTime::UNIX_EPOCH,
+            0u32,
         )
     }
 
@@ -653,15 +652,7 @@ mod tests {
             rustybgp_table::PeerRole::Ebgp,
         ));
         src.mark_stale();
-        (
-            Family::RTC,
-            nlri,
-            0,
-            None,
-            src,
-            Arc::new(vec![]),
-            SystemTime::UNIX_EPOCH,
-        )
+        (Family::RTC, nlri, 0, None, src, Arc::new(vec![]), 0u32)
     }
 
     #[test]

--- a/daemon/src/table_manager.rs
+++ b/daemon/src/table_manager.rs
@@ -39,7 +39,7 @@ pub(crate) struct AdjRibInChange {
     pub(crate) nlris: Vec<packet::PathNlri>,
     pub(crate) attrs: Option<Arc<Vec<packet::Attribute>>>,
     pub(crate) nexthop: Option<bgp::Nexthop>,
-    pub(crate) timestamp: std::time::SystemTime,
+    pub(crate) timestamp: u32,
 }
 
 #[derive(Clone)]
@@ -88,7 +88,7 @@ pub(crate) struct AdjRibOutChange {
     pub(crate) nlri: packet::PathNlri,
     pub(crate) attrs: Option<Arc<Vec<packet::Attribute>>>,
     pub(crate) nexthop: Option<bgp::Nexthop>,
-    pub(crate) timestamp: std::time::SystemTime,
+    pub(crate) timestamp: u32,
 }
 
 /// EOR (End-of-RIB) marker received from a peer (RFC 4724 §2).
@@ -308,7 +308,7 @@ impl TableManager {
         nexthop: Option<bgp::Nexthop>,
         attr: Arc<Vec<packet::Attribute>>,
         prefix_limit: Option<(u32, Arc<std::sync::atomic::AtomicU64>)>,
-        timestamp: std::time::SystemTime,
+        timestamp: u32,
     ) -> bool {
         let import_policy = self.import_policy.load_full();
         let kernel_handle = self.kernel_handle.load_full();
@@ -390,7 +390,7 @@ impl TableManager {
         family: Family,
         net: packet::PathNlri,
         prefix_counter: Option<Arc<std::sync::atomic::AtomicU64>>,
-        timestamp: std::time::SystemTime,
+        timestamp: u32,
     ) {
         let kernel_handle = self.kernel_handle.load_full();
         let idx = self.dealer(&net.nlri);
@@ -917,7 +917,7 @@ impl TableManager {
             Some(nexthop),
             attr,
             None,
-            std::time::SystemTime::now(),
+            crate::proto::unix_secs(),
         );
     }
 
@@ -930,7 +930,7 @@ impl TableManager {
             family,
             packet::PathNlri { nlri, path_id: 0 },
             None,
-            std::time::SystemTime::now(),
+            crate::proto::unix_secs(),
         );
     }
 
@@ -1132,7 +1132,7 @@ impl TableShard {
         nets: &[packet::PathNlri],
         attrs: Option<&Arc<Vec<packet::Attribute>>>,
         nexthop: Option<bgp::Nexthop>,
-        timestamp: std::time::SystemTime,
+        timestamp: u32,
     ) {
         let addpath = self.has_addpath(&source.remote_addr, &family);
         for (_, tx) in subs {
@@ -1157,7 +1157,7 @@ impl TableShard {
         nets: &[packet::PathNlri],
         attrs: Option<&Arc<Vec<packet::Attribute>>>,
         nexthop: Option<bgp::Nexthop>,
-        timestamp: std::time::SystemTime,
+        timestamp: u32,
     ) {
         let addpath = self.has_addpath(&source.remote_addr, &family);
         for (_, tx) in subs {
@@ -1244,10 +1244,7 @@ impl TableShard {
                 net: update.net.clone(),
                 attr: best.map(|p| p.attr.clone()),
                 nexthop: best.and_then(|p| p.nexthop),
-                timestamp: std::time::SystemTime::now()
-                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs() as u32,
+                timestamp: crate::proto::unix_secs(),
             };
             for (_, tx) in subs {
                 let _ = tx.send(BgpEvent::LocRib(change.clone()));
@@ -1576,7 +1573,7 @@ mod tests {
             Some(packet::bgp::Nexthop::V4(nh)),
             Arc::new(vec![]),
             None,
-            std::time::SystemTime::UNIX_EPOCH,
+            0u32,
         );
     }
 
@@ -1710,7 +1707,7 @@ mod tests {
                 Some(bgp::Nexthop::V4(Ipv4Addr::new(1, 1, 1, 1))),
                 attr.clone(),
                 None,
-                std::time::SystemTime::UNIX_EPOCH,
+                0u32,
             );
         }
 

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -22,7 +22,6 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::ops::AddAssign;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock};
-use std::time::SystemTime;
 
 use rustybgp_packet::{self as packet, Attribute, Family, bgp};
 
@@ -181,7 +180,7 @@ pub struct PathEntry {
     /// AddPath path identifier received from the peer (0 when AddPath is not in use).
     /// AddPath path identifier received from the peer (0 when AddPath is not in use).
     pub remote_path_id: u32,
-    pub timestamp: SystemTime,
+    pub timestamp: u32,
     pub attr: Arc<Vec<packet::Attribute>>,
     pub validation: Option<RpkiValidation>,
     /// True when this path is marked stale during Graceful Restart (RFC 4724).
@@ -282,7 +281,7 @@ struct RibEntry {
     /// increment.
     original_attr: Arc<Vec<packet::Attribute>>,
     remote_path_id: u32,
-    timestamp: SystemTime,
+    timestamp: u32,
     flags: u8,
 }
 
@@ -582,7 +581,7 @@ pub struct Reach {
     pub net: packet::PathNlri,
     pub attr: Arc<Vec<packet::Attribute>>,
     pub nexthop: Option<bgp::Nexthop>,
-    pub timestamp: SystemTime,
+    pub timestamp: u32,
 }
 
 impl From<Reach> for bgp::Message {
@@ -626,7 +625,7 @@ pub type SoftResetPath = (
     Option<bgp::Nexthop>,
     Arc<Source>,
     Arc<Vec<packet::Attribute>>,
-    SystemTime,
+    u32,
 );
 
 /// Result of a single `Table::insert()` or `Table::remove()` operation.
@@ -1196,7 +1195,7 @@ impl Table {
         filtered: bool,
         nexthop_invalid: bool,
         prefix_limit: Option<(u32, &Arc<AtomicU64>)>,
-        timestamp: SystemTime,
+        timestamp: u32,
     ) -> InsertResult {
         let flags = if filtered { RibEntry::FLAG_FILTERED } else { 0 }
             | if nexthop_invalid {
@@ -2362,7 +2361,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             s2,
@@ -2375,7 +2374,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             s1.clone(),
@@ -2388,7 +2387,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             s1.clone(),
@@ -2401,7 +2400,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         assert_eq!(rt.ribs.get(&family).unwrap().destinations.len(), 3);
@@ -2447,7 +2446,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().any_changed);
         assert!(update.as_changed().unwrap().best_changed);
@@ -2469,7 +2468,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // Insert with router_id=2 (higher, won't become best)
         let update = rt.insert(
@@ -2483,7 +2482,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // Best did not change; second path entered current_paths at index 1
         assert!(!update.as_changed().unwrap().best_changed);
@@ -2508,7 +2507,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         let update = rt.insert(
             source(2, 65002, 65000, 2),
@@ -2521,7 +2520,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // Higher local_pref wins → best changes to source 2
         assert!(update.as_changed().unwrap().best_changed);
@@ -2547,7 +2546,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         let update = rt.insert(
             source(2, 65002, 65000, 2),
@@ -2560,7 +2559,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // Shorter AS path wins
         assert!(update.as_changed().unwrap().best_changed);
@@ -2587,7 +2586,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // Insert with ORIGIN=IGP(0), router_id=2
         let update = rt.insert(
@@ -2601,7 +2600,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // IGP (lower origin value) wins
         assert!(update.as_changed().unwrap().best_changed);
@@ -2628,7 +2627,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // eBGP peer (remote_asn != local_asn), router_id=2 (higher)
         let update = rt.insert(
@@ -2642,7 +2641,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // eBGP wins even though router_id is higher
         assert!(update.as_changed().unwrap().best_changed);
@@ -2669,7 +2668,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // router_id=5 (lower wins)
         let update = rt.insert(
@@ -2683,7 +2682,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         let best = update.as_changed().unwrap().new_best().unwrap();
@@ -2717,7 +2716,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // One hop in CLUSTER_LIST — shorter wins
         let update = rt.insert(
@@ -2731,7 +2730,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         let best = update.as_changed().unwrap().new_best().unwrap();
@@ -2757,7 +2756,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // No CLUSTER_LIST (length 0) — wins
         let update = rt.insert(
@@ -2771,7 +2770,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         let best = update.as_changed().unwrap().new_best().unwrap();
@@ -2807,7 +2806,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // Same CLUSTER_LIST length (1), lower ORIGINATOR_ID — wins
         let update = rt.insert(
@@ -2831,7 +2830,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         let best = update.as_changed().unwrap().new_best().unwrap();
@@ -2860,7 +2859,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             s2.clone(),
@@ -2873,7 +2872,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // Remove best (router_id=1) → s2 promoted to best
         let (update, _) = rt.remove(s1, Family::IPV4, net, 0, None);
@@ -2902,7 +2901,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             s2.clone(),
@@ -2915,7 +2914,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // Remove non-best (router_id=2) → best unchanged, s1 still best
         let (update, _) = rt.remove(s2, Family::IPV4, net, 0, None);
@@ -2944,7 +2943,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         let (update, _) = rt.remove(s1, Family::IPV4, net, 0, None);
         // Withdrawal: best gone
@@ -2970,7 +2969,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(
             update.as_changed().is_none(),
@@ -2990,7 +2989,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         let best = update.as_changed().unwrap().new_best().unwrap();
@@ -3014,7 +3013,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered best (router_id=2)
         let s2 = source(2, 65002, 65000, 2);
@@ -3029,7 +3028,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         let best = update.as_changed().unwrap().new_best().unwrap();
@@ -3046,7 +3045,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(!update.as_changed().unwrap().best_changed);
         assert!(update.as_changed().unwrap().any_changed);
@@ -3071,7 +3070,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered best
         rt.insert(
@@ -3085,7 +3084,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // replace the filtered head with updated attrs (still filtered) → no best change, no any_changed
         let update = rt.insert(
@@ -3099,7 +3098,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(
             update.as_changed().is_none(),
@@ -3125,7 +3124,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered best (router_id=1)
         rt.insert(
@@ -3139,7 +3138,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // another unfiltered (router_id=2)
         let s2 = source(2, 65002, 65000, 2);
@@ -3154,7 +3153,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // replace s1 as filtered → s2 becomes unfiltered best
         let update = rt.insert(
@@ -3168,7 +3167,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         let best = update.as_changed().unwrap().new_best().unwrap();
@@ -3195,7 +3194,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             s2.clone(),
@@ -3208,7 +3207,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         // Replace s1 with worse attrs (local_pref=50) → s2 (local_pref=100) becomes best.
@@ -3223,7 +3222,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         let update = update
@@ -3254,7 +3253,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered best (router_id=1)
         let s1 = source(1, 65001, 65000, 1);
@@ -3269,7 +3268,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered non-best (router_id=2)
         let s2 = source(2, 65002, 65000, 2);
@@ -3284,7 +3283,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // replace s2 with different attrs → still non-best
         let update = rt.insert(
@@ -3298,7 +3297,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(!update.as_changed().unwrap().best_changed);
         assert!(update.as_changed().unwrap().any_changed);
@@ -3323,7 +3322,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // filtered path: received=1, accepted=0
         let stats: Vec<_> = rt.peer_stats(&s1.remote_addr).unwrap().collect();
@@ -3353,7 +3352,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // Second path (path_id=2): same prefix, additional Add-Path path.
         // received must NOT increment again.
@@ -3368,7 +3367,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         let stats: Vec<_> = rt.peer_stats(&src.remote_addr).unwrap().collect();
@@ -3402,7 +3401,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             src.clone(),
@@ -3415,7 +3414,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         // Remove path_id=1: path_id=2 still exists -> received must stay 1
@@ -3456,7 +3455,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             s1.clone(),
@@ -3469,7 +3468,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             s1.clone(),
@@ -3482,7 +3481,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert_eq!(flat_best(&rt, &Family::IPV4).len(), 3);
     }
@@ -3825,7 +3824,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // s2: local_pref=50, router_id=1 (better router_id, worse local_pref)
         let s2 = source(2, 65002, 65000, 1);
@@ -3840,7 +3839,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // s1 must remain best (higher local_pref wins over lower router_id)
         // s2 enters as a new current path, best unchanged
@@ -3867,7 +3866,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         // Replace with filtered → no unfiltered best remains → best_changed, new_best=None
@@ -3882,7 +3881,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         assert!(update.as_changed().unwrap().new_best().is_none());
@@ -3906,7 +3905,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // s2 inserts a filtered path
         let s2 = source(2, 65002, 65000, 2);
@@ -3921,7 +3920,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // s1 gets replaced as filtered → all filtered → withdrawal
         let update = rt.insert(
@@ -3935,7 +3934,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         assert!(update.as_changed().unwrap().new_best().is_none());
@@ -3959,7 +3958,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered path
         let s2 = source(2, 65002, 65000, 2);
@@ -3974,7 +3973,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         let bests = flat_best(&rt, &Family::IPV4);
         assert_eq!(bests.len(), 1);
@@ -3996,7 +3995,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(rt.collect_loc_rib_paths(&Family::IPV4).is_empty());
     }
@@ -4020,7 +4019,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered best (router_id=2)
         let s2 = source(2, 65002, 65000, 2);
@@ -4035,7 +4034,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered non-best (router_id=3)
         let s3 = source(3, 65003, 65000, 3);
@@ -4050,7 +4049,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // remove s2 (best) → s3 becomes new best
         let (update, _) = rt.remove(s2, Family::IPV4, net, 0, None);
@@ -4075,7 +4074,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // only unfiltered path
         let s2 = source(2, 65002, 65000, 2);
@@ -4090,7 +4089,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // remove s2 → all filtered → withdrawal (best_changed=true, new_best=None)
         let (update, _) = rt.remove(s2, Family::IPV4, net, 0, None);
@@ -4117,7 +4116,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered best
         let s2 = source(2, 65002, 65000, 2);
@@ -4132,7 +4131,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered non-best
         let s3 = source(3, 65003, 65000, 3);
@@ -4147,7 +4146,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // drop s2 → s3 becomes new best
         let (changes, _) = rt.drop(s2.remote_addr, Family::IPV4);
@@ -4174,7 +4173,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // unfiltered best from s2
         let s2 = source(2, 65002, 65000, 2);
@@ -4189,7 +4188,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // drop s1 (filtered) → no best change
         let (changes, _) = rt.drop(s1.remote_addr, Family::IPV4);
@@ -4214,7 +4213,7 @@ mod tests {
             true,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // 1 unfiltered path
         rt.insert(
@@ -4228,7 +4227,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         let s = rt.state(Family::IPV4);
         assert_eq!(s.num_destination, 1);
@@ -4258,7 +4257,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         let best = update.as_changed().unwrap().new_best().unwrap();
@@ -4276,7 +4275,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(update.as_changed().unwrap().best_changed);
         assert_eq!(update.as_changed().unwrap().current_paths.len(), 2);
@@ -4323,7 +4322,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         let original_id = update
             .as_changed()
@@ -4344,7 +4343,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         // Same path_id preserved, replaced_path_id indicates what was replaced
         assert_eq!(
@@ -4374,7 +4373,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         let s1_id = u1.as_changed().unwrap().new_best().unwrap().local_path_id;
         rt.insert(
@@ -4388,7 +4387,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         // Remove s1 → s2 becomes new best; s1_id was the old best
@@ -4426,7 +4425,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             s2.clone(),
@@ -4439,7 +4438,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         let best = flat_best(&rt, &Family::IPV4);
@@ -4476,7 +4475,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         s.mark_stale();
@@ -4507,7 +4506,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         // Mark stale before the fresh route arrives (as GR does after session drop)
@@ -4524,7 +4523,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         let best = flat_best(&rt, &Family::IPV4);
@@ -4552,7 +4551,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         s.mark_stale();
@@ -4584,7 +4583,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             fresh_src.clone(),
@@ -4597,7 +4596,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         stale_src.mark_stale();
@@ -4630,7 +4629,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         s.mark_stale();
@@ -4655,7 +4654,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         let (changes, _) = rt.drop_stale(s.remote_addr, Family::IPV4, None);
@@ -4685,7 +4684,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             fresh_src.clone(),
@@ -4698,7 +4697,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         // Without stale, stale_src wins (lower router_id).
@@ -4750,7 +4749,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         s1.mark_stale();
 
@@ -4780,7 +4779,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         // The stale path from session 1 must be replaced, not accumulated.
@@ -4828,7 +4827,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         s1.mark_stale();
 
@@ -4873,7 +4872,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         rt.insert(
             s1.clone(),
@@ -4886,7 +4885,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         s1.mark_stale();
         assert_eq!(flat_best(&rt, &Family::IPV4).len(), 2);
@@ -4904,7 +4903,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         // id=1 replaced (now fresh), id=2 still stale.
@@ -4935,7 +4934,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         let changes = rt.restale(src.remote_addr, Family::IPV4);
@@ -4974,7 +4973,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(
             update.as_changed().is_none(),
@@ -5012,7 +5011,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(
             update.as_changed().unwrap().best_changed || update.as_changed().unwrap().any_changed,
@@ -5043,7 +5042,7 @@ mod tests {
                 false,
                 false,
                 None,
-                SystemTime::UNIX_EPOCH,
+                0u32,
             );
             assert!(u.as_changed().is_none());
         }
@@ -5059,7 +5058,7 @@ mod tests {
                 false,
                 false,
                 None,
-                SystemTime::UNIX_EPOCH,
+                0u32,
             );
             assert!(u.as_changed().is_none());
         }
@@ -5105,7 +5104,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(
             update.as_changed().unwrap().best_changed || update.as_changed().unwrap().any_changed,
@@ -5136,7 +5135,7 @@ mod tests {
             false,
             false,
             pl,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(
             matches!(result, InsertResult::PrefixLimitExceeded),
@@ -5170,7 +5169,7 @@ mod tests {
             false,
             false,
             Some((max, &counter)),
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert_eq!(counter.load(Ordering::Relaxed), 1);
 
@@ -5186,7 +5185,7 @@ mod tests {
             false,
             false,
             Some((max, &counter)),
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(
             !matches!(result, InsertResult::PrefixLimitExceeded),
@@ -5223,7 +5222,7 @@ mod tests {
                 false,
                 false,
                 Some((max, &counter)),
-                SystemTime::UNIX_EPOCH,
+                0u32,
             );
             assert!(
                 !matches!(result, InsertResult::PrefixLimitExceeded),
@@ -5246,7 +5245,7 @@ mod tests {
             false,
             false,
             Some((max, &counter)),
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
         assert!(matches!(result, InsertResult::PrefixLimitExceeded));
         assert_eq!(counter.load(Ordering::Relaxed), 3);
@@ -5267,7 +5266,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
     }
 
@@ -5449,7 +5448,7 @@ mod tests {
             true, // filtered = true
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
     }
 
@@ -5513,7 +5512,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         let peer = s1.remote_addr;
@@ -5552,7 +5551,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         let peer = s1.remote_addr;
@@ -5588,7 +5587,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         let reaches: Vec<_> = rt.iter_reach(Family::IPV4).collect();
@@ -5795,7 +5794,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
 
         let peer1_addr = peer1.remote_addr;
@@ -5924,7 +5923,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
     }
 
@@ -6014,7 +6013,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
     }
 
@@ -6113,7 +6112,7 @@ mod tests {
             false,
             false,
             None,
-            SystemTime::UNIX_EPOCH,
+            0u32,
         );
     }
 


### PR DESCRIPTION
std::time::SystemTime occupies 16 bytes on Linux (struct timespec: tv_sec + tv_nsec, both i64).  Path timestamps are used only in three places: BMP per-peer headers, MRT table dumps, and the gRPC ListPath age field.  All three ultimately express the value as seconds since the Unix epoch.  BMP (RFC 7854 section 4.2) encodes the timestamp as a 32-bit seconds field followed by a 32-bit microseconds field; RustyBGP already hard-coded the microseconds to zero.  MRT generates its own snapshot timestamp independently.  The gRPC Timestamp nanos field is now set to zero, which is acceptable given that sub-second precision is not meaningful for BGP path age reporting.

Storing the timestamp as u32 (Unix seconds) saves 12 bytes per RibEntry, PathEntry, Reach, AdjRibInChange, AdjRibOutChange, and BmpAdjOut instance.  The conversion boilerplate in bmp.rs (.duration_since(UNIX_EPOCH).as_secs() as u32) is eliminated since the stored value is already in wire format.

Add proto::unix_secs() as the single call site for obtaining the current time as a u32, replacing scattered SystemTime::now() + duration_since() chains throughout daemon.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>