### PR TITLE
cargo: centralise version/edition/authors in workspace.package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,10 @@
 resolver = "2"
 members = ["api", "config", "kernel", "packet", "table", "daemon"]
 
+[workspace.package]
+version = "0.2.0"
+edition = "2024"
+authors = ["FUJITA Tomonori <fujita.tomonori@gmail.com>"]
+
 [profile.release]
 lto = true

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "rustybgp-api"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
 
 [dependencies]
 tonic = "0.14"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "rustybgp-config"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
 
 [dependencies]
 regex = "1"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rustybgpd"
-version = "0.2.0"
-authors = ["FUJITA Tomonori <fujita.tomonori@gmail.com>"]
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rustybgp-kernel"
-version = "0.1.0"
-authors = ["FUJITA Tomonori <fujita.tomonori@gmail.com>"]
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
 
 [dependencies]
 rtnetlink = "0.21"

--- a/packet/Cargo.toml
+++ b/packet/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "rustybgp-packet"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
 
 [dependencies]
 byteorder = "1"

--- a/table/Cargo.toml
+++ b/table/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "rustybgp-table"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
 
 [dependencies]
 rustybgp-packet = { path = "../packet" }


### PR DESCRIPTION
All member crates previously carried their own version, edition, and authors fields, with version inconsistent across crates (daemon was already at 0.2.0 while the rest remained at 0.1.0).  Centralising these fields in [workspace.package] ensures a single source of truth: bumping the version for a release only requires editing the root Cargo.toml.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>