### PR TITLE
daemon, table: add per-peer BGP export policy

### DIFF
--- a/daemon/src/convert.rs
+++ b/daemon/src/convert.rs
@@ -4248,6 +4248,22 @@ pub(crate) fn defined_set_kind_from_api(
     }
 }
 
+/// Extracts `(default_action, policy_names)` from a `PolicyAssignment`, ignoring
+/// its `name`/`direction` fields. Used where the direction is already implied by
+/// context (e.g. `ApplyPolicy.export_policy`) rather than carried in the message.
+pub(crate) fn disposition_and_policies_from_api(
+    req: api::PolicyAssignment,
+) -> (rustybgp_table::Disposition, Vec<String>) {
+    use rustybgp_table::Disposition;
+
+    let default_action = match api::RouteAction::try_from(req.default_action) {
+        Ok(api::RouteAction::Accept) => Disposition::Accept,
+        _ => Disposition::Reject,
+    };
+    let policy_names: Vec<String> = req.policies.into_iter().map(|p| p.name).collect();
+    (default_action, policy_names)
+}
+
 pub(crate) fn policy_assignment_from_api(
     req: api::PolicyAssignment,
 ) -> Result<
@@ -4259,7 +4275,7 @@ pub(crate) fn policy_assignment_from_api(
     ),
     rustybgp_table::TableError,
 > {
-    use rustybgp_table::{Disposition, PolicyDirection, TableError};
+    use rustybgp_table::{PolicyDirection, TableError};
 
     let direction = match api::PolicyDirection::try_from(req.direction) {
         Ok(api::PolicyDirection::Import) => PolicyDirection::Import,
@@ -4270,12 +4286,9 @@ pub(crate) fn policy_assignment_from_api(
             ));
         }
     };
-    let default_action = match api::RouteAction::try_from(req.default_action) {
-        Ok(api::RouteAction::Accept) => Disposition::Accept,
-        _ => Disposition::Reject,
-    };
-    let policy_names: Vec<String> = req.policies.into_iter().map(|p| p.name).collect();
-    Ok((req.name, direction, default_action, policy_names))
+    let name = req.name.clone();
+    let (default_action, policy_names) = disposition_and_policies_from_api(req);
+    Ok((name, direction, default_action, policy_names))
 }
 
 pub(crate) fn routing_table_state_to_api(s: rustybgp_table::TableState) -> api::GetTableResponse {

--- a/daemon/src/event/grpc.rs
+++ b/daemon/src/event/grpc.rs
@@ -411,6 +411,11 @@ impl TryFrom<&api::Peer> for PeerParams {
                 .as_ref()
                 .filter(|t| !t.bind_interface.is_empty())
                 .map(|t| t.bind_interface.clone()),
+            export_policy: p
+                .apply_policy
+                .as_ref()
+                .and_then(|ap| ap.export_policy.clone())
+                .map(convert::disposition_and_policies_from_api),
         })
     }
 }
@@ -1213,6 +1218,23 @@ impl GoBgpService for GrpcService {
         } else {
             Global::BGP_PORT
         };
+        // UpdatePeer declares the peer's full desired state (matches PeerConfig's
+        // full-replace semantics below): a request with no apply-policy.export_policy
+        // clears any existing per-peer override, reverting the peer to the global policy.
+        let export_policy = new_params
+            .export_policy
+            .take()
+            .map(|(disposition, names)| {
+                global.ptable.build_assignment(
+                    None,
+                    &peer_addr.to_string(),
+                    table::PolicyDirection::Export,
+                    disposition,
+                    names,
+                )
+            })
+            .transpose()
+            .map_err(Error::from)?;
 
         let old_password;
         {
@@ -1251,6 +1273,7 @@ impl GoBgpService for GrpcService {
                 neighbor_interface: new_params.neighbor_interface,
                 bind_interface: new_params.bind_interface,
             };
+            peer.state.export_policy.store(export_policy);
 
             if needs_teardown {
                 // Build a fresh ConnArbiter carrying the updated PeerFsm so the
@@ -2456,15 +2479,12 @@ impl GoBgpService for GrpcService {
     ) -> Result<tonic::Response<api::DeletePolicyResponse>, tonic::Status> {
         let req = request.into_inner();
         let name = req.policy.map(|p| p.name).unwrap_or_default();
-        let (import, export) = self
-            .global
-            .write()
-            .await
-            .ptable
-            .delete_policy(&name, req.preserve_statements, req.all)
-            .map_err(Error::from)?;
-        self.tables.import_policy.store(import);
-        self.tables.export_policy.store(export);
+        self.global.write().await.delete_policy(
+            self.tables.clone(),
+            &name,
+            req.preserve_statements,
+            req.all,
+        )?;
         Ok(tonic::Response::new(api::DeletePolicyResponse {}))
     }
     type ListPolicyStream = Pin<
@@ -2545,7 +2565,15 @@ impl GoBgpService for GrpcService {
             }
         }
 
-        self.global.write().await.ptable = new_ptable;
+        let mut global = self.global.write().await;
+        global.ptable = new_ptable;
+        // A full policy reload invalidates any per-peer export override built
+        // against the old table; clear all of them rather than leave a peer
+        // holding a stale Arc<PolicyAssignment> disconnected from the new table.
+        for peer in global.peers.values() {
+            peer.state.export_policy.store(None);
+        }
+        drop(global);
         self.tables.import_policy.store(new_import);
         self.tables.export_policy.store(new_export);
         Ok(tonic::Response::new(api::SetPoliciesResponse {}))
@@ -2704,20 +2732,15 @@ impl GoBgpService for GrpcService {
     ) -> Result<tonic::Response<api::DeletePolicyAssignmentResponse>, tonic::Status> {
         let req = request.into_inner();
         let assignment = req.assignment.ok_or(Error::EmptyArgument)?;
-        let (_, direction, _, policy_names) =
+        let (name, direction, _, policy_names) =
             convert::policy_assignment_from_api(assignment).map_err(Error::from)?;
-        let updated = self
-            .global
-            .write()
-            .await
-            .ptable
-            .delete_policy_assignment(direction, &policy_names, req.all)
-            .map_err(Error::from)?;
-        if direction == table::PolicyDirection::Import {
-            self.tables.import_policy.store(updated);
-        } else {
-            self.tables.export_policy.store(updated);
-        }
+        self.global.write().await.delete_policy_assignment(
+            self.tables.clone(),
+            name,
+            direction,
+            policy_names,
+            req.all,
+        )?;
         Ok(tonic::Response::new(api::DeletePolicyAssignmentResponse {}))
     }
     type ListPolicyAssignmentStream = Pin<
@@ -2733,16 +2756,42 @@ impl GoBgpService for GrpcService {
         request: tonic::Request<api::ListPolicyAssignmentRequest>,
     ) -> Result<tonic::Response<Self::ListPolicyAssignmentStream>, tonic::Status> {
         let request = request.into_inner();
-        let v: Vec<api::ListPolicyAssignmentResponse> = self
-            .global
-            .read()
-            .await
-            .ptable
-            .iter_assignments(request.direction)
-            .map(|(dir, pa)| api::ListPolicyAssignmentResponse {
-                assignment: Some(convert::policy_assignment_to_api(pa, dir)),
-            })
-            .collect();
+        let global = self.global.read().await;
+        let v: Vec<api::ListPolicyAssignmentResponse> = if Global::is_global_rib_name(&request.name)
+        {
+            global
+                .ptable
+                .iter_assignments(request.direction)
+                .map(|(dir, pa)| api::ListPolicyAssignmentResponse {
+                    assignment: Some(convert::policy_assignment_to_api(pa, dir)),
+                })
+                .collect()
+        } else {
+            let addr: IpAddr = request.name.parse().map_err(|_| {
+                Error::InvalidArgument(format!("{} is not a valid peer address", request.name))
+            })?;
+            let peer = global
+                .peers
+                .get(&addr)
+                .ok_or_else(|| Error::InvalidArgument(format!("peer {addr} isn't found")))?;
+            // Per-peer policy only supports export; an import-only request has no results.
+            if request.direction == api::PolicyDirection::Import as i32 {
+                Vec::new()
+            } else {
+                peer.state
+                    .export_policy
+                    .load_full()
+                    .map(|pa| api::ListPolicyAssignmentResponse {
+                        assignment: Some(convert::policy_assignment_to_api(
+                            &pa,
+                            api::PolicyDirection::Export as i32,
+                        )),
+                    })
+                    .into_iter()
+                    .collect()
+            }
+        };
+        drop(global);
 
         let (tx, rx) = mpsc::channel(1024);
         tokio::spawn(async move {

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -185,6 +185,11 @@ pub(super) struct PeerState {
     remote_holdtime: AtomicU16,
     remote_cap: ArcSwapOption<Vec<packet::Capability>>,
     session_addrs: ArcSwapOption<SessionAddrs>,
+    /// Per-peer export policy override; `None` means "inherit the global export
+    /// policy". Written only by gRPC handlers holding the `Global` write lock
+    /// (never by `PeerSession`); read lock-free from the export hot path via
+    /// `.load_full().or_else(|| self.tables.export_policy.load_full())`.
+    export_policy: ArcSwapOption<table::PolicyAssignment>,
 }
 
 /// Per-peer FSM coordinator.  Created once when `local_router_id` is known
@@ -464,6 +469,15 @@ impl Peer {
             gr_peer_restarting: ctx.gr_state.is_peer_restarting(),
             gr_local_restarting: is_restarting,
         }
+    }
+
+    /// True if this peer's export policy override currently references `name`.
+    /// Used by `Global::delete_policy` to refuse deleting a policy still in use.
+    fn references_policy(&self, name: &str) -> bool {
+        self.state
+            .export_policy
+            .load_full()
+            .is_some_and(|a| a.policies.iter().any(|p| p.name.as_ref() == name))
     }
 
     /// Clears session-negotiated state and connection handles so the peer is
@@ -747,6 +761,15 @@ pub(crate) struct Global {
 impl Global {
     const BGP_PORT: u16 = 179;
 
+    /// Matches GoBGP's `table.GLOBAL_RIB_NAME`: `PolicyAssignment.name` is
+    /// treated as the global assignment when it is either empty or this
+    /// literal; any other value must parse as a peer address.
+    const GLOBAL_RIB_NAME: &'static str = "global";
+
+    fn is_global_rib_name(name: &str) -> bool {
+        name.is_empty() || name == Self::GLOBAL_RIB_NAME
+    }
+
     fn new(
         kernel_event_tx: mpsc::UnboundedSender<kernel::KernelEvent>,
         bfd_event_tx: mpsc::UnboundedSender<crate::bfd::BfdEvent>,
@@ -964,8 +987,21 @@ impl Global {
         {
             params.local_asn = conf.id;
         }
-        // Extract bfd_config before params.build() consumes params.
+        // Extract bfd_config and export_policy before params.build() consumes params.
         let bfd_config = params.bfd_config.take();
+        let export_policy = params
+            .export_policy
+            .take()
+            .map(|(disposition, names)| {
+                self.ptable.build_assignment(
+                    None,
+                    &params.remote_addr.to_string(),
+                    table::PolicyDirection::Export,
+                    disposition,
+                    names,
+                )
+            })
+            .transpose()?;
         let mut peer = params.build(u32::from(self.router_id), self.asn);
         if peer.admin_down {
             peer.state
@@ -974,6 +1010,9 @@ impl Global {
         }
         if let Some(tx) = tx {
             enable_active_connect(&mut peer, tx);
+        }
+        if let Some(export_policy) = export_policy {
+            peer.state.export_policy.store(Some(export_policy));
         }
         let addr = peer.config.remote_addr;
         self.peers.insert(addr, peer);
@@ -989,6 +1028,42 @@ impl Global {
         Ok(())
     }
 
+    /// Deletes a named policy. Refuses (`TableError::StillInUse`) if any assignment
+    /// -- global (import or export) or any peer's per-peer export override --
+    /// still references it; see [[per-peer-policy]] design (a) and GoBGP's
+    /// `DeletePolicy`/`inUse()` (which this mirrors, but checks both directions
+    /// correctly rather than checking EXPORT twice).
+    ///
+    /// `all=true` wipes the entire policy table (all policies/statements/global
+    /// assignments); per-peer export overrides are cleared too so no peer is left
+    /// holding a reference into the now-empty table.
+    pub(super) fn delete_policy(
+        &mut self,
+        tables: Arc<TableManager>,
+        name: &str,
+        preserve_statements: bool,
+        all: bool,
+    ) -> Result<(), Error> {
+        if !all && self.peers.values().any(|p| p.references_policy(name)) {
+            return Err(Error::Table(table::TableError::StillInUse(
+                name.to_string(),
+            )));
+        }
+        let (import, export) = self.ptable.delete_policy(name, preserve_statements, all)?;
+        if all {
+            for peer in self.peers.values() {
+                peer.state.export_policy.store(None);
+            }
+        }
+        tables.import_policy.store(import);
+        tables.export_policy.store(export);
+        Ok(())
+    }
+
+    /// `req.name`: empty or `"global"` means the global assignment (see
+    /// `is_global_rib_name`); otherwise it must parse as a peer address
+    /// (IPv4/IPv6, matching GoBGP's convention), and the assignment applies
+    /// only to that peer's export policy (per-peer import is not supported).
     pub(super) fn add_policy_assignment(
         &mut self,
         tables: Arc<TableManager>,
@@ -996,14 +1071,82 @@ impl Global {
     ) -> Result<(), Error> {
         let (name, direction, default_action, policy_names) =
             convert::policy_assignment_from_api(req)?;
-        let (dir, assignment) =
-            self.ptable
-                .add_assignment(&name, direction, default_action, policy_names)?;
-        if dir == table::PolicyDirection::Import {
-            tables.import_policy.store(Some(Arc::clone(&assignment)));
-        } else {
-            tables.export_policy.store(Some(Arc::clone(&assignment)));
+        if Self::is_global_rib_name(&name) {
+            let (dir, assignment) =
+                self.ptable
+                    .add_assignment(&name, direction, default_action, policy_names)?;
+            if dir == table::PolicyDirection::Import {
+                tables.import_policy.store(Some(Arc::clone(&assignment)));
+            } else {
+                tables.export_policy.store(Some(Arc::clone(&assignment)));
+            }
+            return Ok(());
         }
+        if direction != table::PolicyDirection::Export {
+            return Err(Error::InvalidArgument(
+                "per-peer import policy is not supported".to_string(),
+            ));
+        }
+        let addr: IpAddr = name
+            .parse()
+            .map_err(|_| Error::InvalidArgument(format!("{name} is not a valid peer address")))?;
+        let peer = self
+            .peers
+            .get(&addr)
+            .ok_or_else(|| Error::InvalidArgument(format!("peer {addr} isn't found")))?;
+        let existing = peer.state.export_policy.load_full();
+        let assignment = self.ptable.build_assignment(
+            existing.as_deref(),
+            &name,
+            table::PolicyDirection::Export,
+            default_action,
+            policy_names,
+        )?;
+        peer.state.export_policy.store(Some(assignment));
+        Ok(())
+    }
+
+    /// See `add_policy_assignment` for the `name` convention.
+    pub(super) fn delete_policy_assignment(
+        &mut self,
+        tables: Arc<TableManager>,
+        name: String,
+        direction: table::PolicyDirection,
+        policy_names: Vec<String>,
+        all: bool,
+    ) -> Result<(), Error> {
+        if Self::is_global_rib_name(&name) {
+            let updated = self
+                .ptable
+                .delete_policy_assignment(direction, &policy_names, all)?;
+            if direction == table::PolicyDirection::Import {
+                tables.import_policy.store(updated);
+            } else {
+                tables.export_policy.store(updated);
+            }
+            return Ok(());
+        }
+        if direction != table::PolicyDirection::Export {
+            return Err(Error::InvalidArgument(
+                "per-peer import policy is not supported".to_string(),
+            ));
+        }
+        let addr: IpAddr = name
+            .parse()
+            .map_err(|_| Error::InvalidArgument(format!("{name} is not a valid peer address")))?;
+        let peer = self
+            .peers
+            .get(&addr)
+            .ok_or_else(|| Error::InvalidArgument(format!("peer {addr} isn't found")))?;
+        if all {
+            peer.state.export_policy.store(None);
+            return Ok(());
+        }
+        let existing = peer.state.export_policy.load_full();
+        let old = existing.as_deref().ok_or(table::TableError::NotFound)?;
+        peer.state
+            .export_policy
+            .store(Some(old.without_policies(&policy_names)));
         Ok(())
     }
 
@@ -1503,6 +1646,10 @@ async fn accept_connection(
                 bfd_config: None,
                 neighbor_interface: None,
                 bind_interface: None,
+                // PeerGroup does not carry policy config; dynamic peers inherit
+                // the global export policy (per-peer/peer-group policy inheritance
+                // is not yet supported).
+                export_policy: None,
             };
             let _ = g.add_peer(params, None);
             g.peers.get_mut(&remote_addr).unwrap()
@@ -2268,6 +2415,7 @@ impl PeerSession {
                 remote_holdtime: AtomicU16::new(0),
                 remote_cap: ArcSwapOption::empty(),
                 session_addrs: ArcSwapOption::empty(),
+                export_policy: ArcSwapOption::empty(),
             }),
             counter_tx: Default::default(),
             counter_rx: Default::default(),
@@ -2446,7 +2594,11 @@ impl PeerSession {
                 .iter()
                 .filter_map(|(f, max)| (*max > 1).then_some(*f)),
         );
-        let export_policy = self.tables.export_policy.load_full();
+        let export_policy = self
+            .state
+            .export_policy
+            .load_full()
+            .or_else(|| self.tables.export_policy.load_full());
         let rpki = self.tables.rpki.read().unwrap();
         let (rtc_awaiting_eor, rtc_active) = if self.codec.has_family(Family::RTC) {
             let ctx = self.context.lock().unwrap();
@@ -2566,7 +2718,11 @@ impl PeerSession {
         } else {
             None
         };
-        let export_policy = self.tables.export_policy.load_full();
+        let export_policy = self
+            .state
+            .export_policy
+            .load_full()
+            .or_else(|| self.tables.export_policy.load_full());
         let effective_max = self.effective_max(family);
         let changes = self
             .tables
@@ -3055,7 +3211,11 @@ impl PeerSession {
         let Some(pending) = self.pending.get_mut(&update.family) else {
             return;
         };
-        let export_policy = self.tables.export_policy.load_full();
+        let export_policy = self
+            .state
+            .export_policy
+            .load_full()
+            .or_else(|| self.tables.export_policy.load_full());
         let rpki = export_policy
             .as_deref()
             .filter(|p| p.needs_rpki)
@@ -3712,7 +3872,240 @@ mod tests {
             bfd_config: None,
             neighbor_interface: None,
             bind_interface: None,
+            export_policy: None,
         }
+    }
+
+    /// Adds an unconditional (no-condition) statement/policy pair named `name`
+    /// that always resolves to `disposition`.
+    fn add_simple_policy(g: &mut Global, name: &str, disposition: table::Disposition) {
+        let stmt_name = format!("{name}-stmt");
+        g.ptable
+            .add_statement(
+                &stmt_name,
+                Vec::new(),
+                Some(disposition),
+                table::Actions::default(),
+            )
+            .unwrap();
+        g.ptable.add_policy(name, vec![stmt_name]).unwrap();
+    }
+
+    #[tokio::test]
+    async fn add_peer_resolves_export_policy_from_params() {
+        let global = make_global();
+        let remote_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut g = global.write().await;
+        add_simple_policy(&mut g, "p1", table::Disposition::Reject);
+
+        let mut params = default_peer_params(remote_addr);
+        params.export_policy = Some((table::Disposition::Accept, vec!["p1".to_string()]));
+        g.add_peer(params, None).unwrap();
+
+        let peer = g.peers.get(&remote_addr).unwrap();
+        let assignment = peer.state.export_policy.load_full().unwrap();
+        assert_eq!(assignment.policies.len(), 1);
+        assert_eq!(assignment.policies[0].name.as_ref(), "p1");
+    }
+
+    #[tokio::test]
+    async fn add_peer_without_export_policy_inherits_global() {
+        let global = make_global();
+        let remote_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        let mut g = global.write().await;
+        g.add_peer(default_peer_params(remote_addr), None).unwrap();
+
+        let peer = g.peers.get(&remote_addr).unwrap();
+        assert!(peer.state.export_policy.load_full().is_none());
+    }
+
+    #[tokio::test]
+    async fn add_peer_rejects_unknown_export_policy_name() {
+        let global = make_global();
+        let remote_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+        let mut g = global.write().await;
+
+        let mut params = default_peer_params(remote_addr);
+        params.export_policy = Some((
+            table::Disposition::Accept,
+            vec!["no-such-policy".to_string()],
+        ));
+        assert!(g.add_peer(params, None).is_err());
+        // The peer must not be left half-added when policy resolution fails.
+        assert!(!g.peers.contains_key(&remote_addr));
+    }
+
+    #[tokio::test]
+    async fn add_policy_assignment_per_peer_sets_peer_state() {
+        let global = make_global();
+        let tables = make_tables();
+        let remote_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+        let mut g = global.write().await;
+        add_simple_policy(&mut g, "p1", table::Disposition::Reject);
+        g.add_peer(default_peer_params(remote_addr), None).unwrap();
+
+        g.add_policy_assignment(
+            tables.clone(),
+            api::PolicyAssignment {
+                name: remote_addr.to_string(),
+                direction: api::PolicyDirection::Export as i32,
+                policies: vec![api::Policy {
+                    name: "p1".to_string(),
+                    statements: Vec::new(),
+                }],
+                default_action: api::RouteAction::Accept as i32,
+            },
+        )
+        .unwrap();
+
+        let peer = g.peers.get(&remote_addr).unwrap();
+        let assignment = peer.state.export_policy.load_full().unwrap();
+        assert_eq!(assignment.policies[0].name.as_ref(), "p1");
+        // The global slot must stay untouched by a per-peer assignment.
+        assert!(tables.export_policy.load_full().is_none());
+    }
+
+    #[tokio::test]
+    async fn add_policy_assignment_name_global_is_treated_as_global() {
+        let global = make_global();
+        let tables = make_tables();
+        let mut g = global.write().await;
+        add_simple_policy(&mut g, "p1", table::Disposition::Reject);
+
+        // "global" must not be parsed as a peer address (GoBGP's GLOBAL_RIB_NAME).
+        g.add_policy_assignment(
+            tables.clone(),
+            api::PolicyAssignment {
+                name: "global".to_string(),
+                direction: api::PolicyDirection::Export as i32,
+                policies: vec![api::Policy {
+                    name: "p1".to_string(),
+                    statements: Vec::new(),
+                }],
+                default_action: api::RouteAction::Accept as i32,
+            },
+        )
+        .unwrap();
+
+        let assignment = tables.export_policy.load_full().unwrap();
+        assert_eq!(assignment.policies[0].name.as_ref(), "p1");
+    }
+
+    #[tokio::test]
+    async fn add_policy_assignment_rejects_per_peer_import() {
+        let global = make_global();
+        let tables = make_tables();
+        let remote_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+        let mut g = global.write().await;
+        add_simple_policy(&mut g, "p1", table::Disposition::Reject);
+        g.add_peer(default_peer_params(remote_addr), None).unwrap();
+
+        let result = g.add_policy_assignment(
+            tables,
+            api::PolicyAssignment {
+                name: remote_addr.to_string(),
+                direction: api::PolicyDirection::Import as i32,
+                policies: vec![api::Policy {
+                    name: "p1".to_string(),
+                    statements: Vec::new(),
+                }],
+                default_action: api::RouteAction::Accept as i32,
+            },
+        );
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn add_policy_assignment_rejects_unknown_peer_address() {
+        let global = make_global();
+        let tables = make_tables();
+        let mut g = global.write().await;
+        add_simple_policy(&mut g, "p1", table::Disposition::Reject);
+
+        let result = g.add_policy_assignment(
+            tables,
+            api::PolicyAssignment {
+                name: "10.0.0.9".to_string(),
+                direction: api::PolicyDirection::Export as i32,
+                policies: vec![api::Policy {
+                    name: "p1".to_string(),
+                    statements: Vec::new(),
+                }],
+                default_action: api::RouteAction::Accept as i32,
+            },
+        );
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_policy_refuses_when_referenced_by_peer() {
+        let global = make_global();
+        let tables = make_tables();
+        let remote_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 6));
+        let mut g = global.write().await;
+        add_simple_policy(&mut g, "p1", table::Disposition::Reject);
+        let mut params = default_peer_params(remote_addr);
+        params.export_policy = Some((table::Disposition::Accept, vec!["p1".to_string()]));
+        g.add_peer(params, None).unwrap();
+
+        let result = g.delete_policy(tables, "p1", false, false);
+        assert!(matches!(
+            result,
+            Err(Error::Table(table::TableError::StillInUse(_)))
+        ));
+    }
+
+    #[tokio::test]
+    async fn delete_policy_succeeds_when_unreferenced() {
+        let global = make_global();
+        let tables = make_tables();
+        let remote_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 7));
+        let mut g = global.write().await;
+        add_simple_policy(&mut g, "p1", table::Disposition::Reject);
+        g.add_peer(default_peer_params(remote_addr), None).unwrap();
+
+        g.delete_policy(tables, "p1", false, false).unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_policy_all_clears_peer_overrides() {
+        let global = make_global();
+        let tables = make_tables();
+        let remote_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8));
+        let mut g = global.write().await;
+        add_simple_policy(&mut g, "p1", table::Disposition::Reject);
+        let mut params = default_peer_params(remote_addr);
+        params.export_policy = Some((table::Disposition::Accept, vec!["p1".to_string()]));
+        g.add_peer(params, None).unwrap();
+
+        g.delete_policy(tables, "", false, true).unwrap();
+
+        let peer = g.peers.get(&remote_addr).unwrap();
+        assert!(peer.state.export_policy.load_full().is_none());
+    }
+
+    #[test]
+    fn peer_params_from_config_neighbor_extracts_export_policy() {
+        let mut n = make_minimal_neighbor_config("10.0.0.1");
+        n.apply_policy = Some(config::generate::ApplyPolicy {
+            config: Some(config::generate::ApplyPolicyConfig {
+                export_policy_list: Some(vec!["p1".to_string()]),
+                default_export_policy: Some(config::DefaultPolicyType::RejectRoute),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        let params = PeerParams::try_from(&n).unwrap();
+        let (disposition, names) = params.export_policy.unwrap();
+        assert_eq!(disposition, table::Disposition::Reject);
+        assert_eq!(names, vec!["p1".to_string()]);
+    }
+
+    #[test]
+    fn peer_params_from_config_neighbor_without_apply_policy_is_none() {
+        let n = make_minimal_neighbor_config("10.0.0.1");
+        let params = PeerParams::try_from(&n).unwrap();
+        assert!(params.export_policy.is_none());
     }
 
     /// Returns (client_stream, server_stream) connected over loopback.

--- a/daemon/src/event/peer.rs
+++ b/daemon/src/event/peer.rs
@@ -23,6 +23,7 @@ use fnv::FnvHashMap;
 use crate::config;
 use crate::convert;
 use rustybgp_packet::{self as packet, Family};
+use rustybgp_table::Disposition;
 
 use super::*;
 
@@ -142,6 +143,12 @@ pub(crate) struct PeerParams {
     pub(crate) neighbor_interface: Option<String>,
     /// Interface name for binding this peer's TCP socket (primarily a Linux VRF device); None if unused.
     pub(crate) bind_interface: Option<String>,
+    /// Per-peer export policy requested via `apply-policy`; `(default_action, policy_names)`.
+    /// `None` means no per-peer override was requested (peer inherits the global export
+    /// policy). Resolved against the policy table and applied to `PeerState.export_policy`
+    /// by `Global::add_peer`/`update_peer` after `build()`, since resolving policy names
+    /// requires `Global.ptable`, which `build()` does not have access to.
+    pub(crate) export_policy: Option<(Disposition, Vec<String>)>,
 }
 
 impl PeerParams {
@@ -341,6 +348,9 @@ impl PeerParams {
                 remote_holdtime: AtomicU16::new(0),
                 remote_cap: ArcSwapOption::empty(),
                 session_addrs: ArcSwapOption::empty(),
+                // Resolved against the policy table and stored by the caller
+                // (`Global::add_peer`) after insertion; see `PeerParams::export_policy`.
+                export_policy: ArcSwapOption::empty(),
             }),
             counter_tx: Default::default(),
             counter_rx: Default::default(),
@@ -618,6 +628,23 @@ impl TryFrom<&config::Neighbor> for PeerParams {
                 .and_then(|t| t.config.as_ref())
                 .and_then(|c| c.bind_interface.clone())
                 .filter(|s| !s.is_empty()),
+            export_policy: n
+                .apply_policy
+                .as_ref()
+                .and_then(|ap| ap.config.as_ref())
+                .and_then(|c| {
+                    if c.export_policy_list.is_none() && c.default_export_policy.is_none() {
+                        return None;
+                    }
+                    let disposition = match c.default_export_policy {
+                        Some(config::DefaultPolicyType::RejectRoute) => Disposition::Reject,
+                        _ => Disposition::Accept,
+                    };
+                    Some((
+                        disposition,
+                        c.export_policy_list.clone().unwrap_or_default(),
+                    ))
+                }),
         })
     }
 }

--- a/table/src/policy.rs
+++ b/table/src/policy.rs
@@ -1151,6 +1151,23 @@ impl PolicyAssignment {
         }
         self.disposition
     }
+
+    /// Returns a copy of this assignment with `policy_names` removed.
+    pub fn without_policies(&self, policy_names: &[String]) -> Arc<PolicyAssignment> {
+        let policies: Vec<Arc<Policy>> = self
+            .policies
+            .iter()
+            .filter(|p| !policy_names.iter().any(|n| n == p.name.as_ref()))
+            .cloned()
+            .collect();
+        let needs_rpki = Self::compute_needs_rpki(&policies);
+        Arc::new(PolicyAssignment {
+            name: self.name.clone(),
+            disposition: self.disposition,
+            policies,
+            needs_rpki,
+        })
+    }
 }
 
 /// Apply import policy to a received route.
@@ -1225,13 +1242,20 @@ impl PolicyTable {
         Default::default()
     }
 
-    pub fn add_assignment(
-        &mut self,
+    /// Resolve `policy_names` against this table and build a new `PolicyAssignment`.
+    /// When `existing` is given, its policies are appended after validating there is
+    /// no name collision (used by `AddPolicyAssignment` semantics, which accumulate
+    /// across repeated calls rather than replacing). Shared by the global-assignment
+    /// path (`add_assignment`) and the per-peer path in the daemon crate.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_assignment(
+        &self,
+        existing: Option<&PolicyAssignment>,
         name: &str,
         direction: PolicyDirection,
         default_action: Disposition,
         policy_names: Vec<String>,
-    ) -> Result<(PolicyDirection, Arc<PolicyAssignment>), TableError> {
+    ) -> Result<Arc<PolicyAssignment>, TableError> {
         let mut v = Vec::new();
         for pname in &policy_names {
             match self.policies.get(pname.as_str()) {
@@ -1258,13 +1282,7 @@ impl PolicyTable {
             }
         }
 
-        let m = match direction {
-            PolicyDirection::Import => &mut self.assignment_import,
-            PolicyDirection::Export => &mut self.assignment_export,
-        };
-
-        let name: Arc<str> = Arc::from(name);
-        if let Some(old) = m.take() {
+        if let Some(old) = existing {
             for p0 in &old.policies {
                 if let Some(p) = v.iter().find(|p1| p0.name == p1.name) {
                     return Err(TableError::InvalidArgument(format!(
@@ -1273,16 +1291,49 @@ impl PolicyTable {
                     )));
                 }
             }
-            v.append(&mut old.policies.to_owned());
+            v.extend(old.policies.iter().cloned());
         }
         let needs_rpki = PolicyAssignment::compute_needs_rpki(&v);
-        let n = Arc::new(PolicyAssignment {
-            name,
+        Ok(Arc::new(PolicyAssignment {
+            name: Arc::from(name),
             policies: v,
             disposition: default_action,
             needs_rpki,
-        });
-        m.replace(n.clone());
+        }))
+    }
+
+    /// Returns true if `name` is referenced by either global assignment (import or export).
+    pub fn policy_in_use_globally(&self, name: &str) -> bool {
+        [&self.assignment_import, &self.assignment_export]
+            .iter()
+            .any(|a| {
+                a.as_ref()
+                    .is_some_and(|a| a.policies.iter().any(|p| p.name.as_ref() == name))
+            })
+    }
+
+    pub fn add_assignment(
+        &mut self,
+        name: &str,
+        direction: PolicyDirection,
+        default_action: Disposition,
+        policy_names: Vec<String>,
+    ) -> Result<(PolicyDirection, Arc<PolicyAssignment>), TableError> {
+        let slot = match direction {
+            PolicyDirection::Import => &self.assignment_import,
+            PolicyDirection::Export => &self.assignment_export,
+        };
+        let n = self.build_assignment(
+            slot.as_deref(),
+            name,
+            direction,
+            default_action,
+            policy_names,
+        )?;
+        match direction {
+            PolicyDirection::Import => self.assignment_import = Some(n.clone()),
+            PolicyDirection::Export => self.assignment_export = Some(n.clone()),
+        }
         Ok((direction, n))
     }
 
@@ -1849,12 +1900,14 @@ impl PolicyTable {
             return Ok((None, None));
         }
 
-        let policy = self.policies.remove(name).ok_or(TableError::NotFound)?;
+        // Global (import/export) in-use check. The daemon crate checks per-peer
+        // assignments before calling this, since PolicyTable has no visibility
+        // into per-peer state. See PeerState.export_policy in the daemon crate.
+        if self.policy_in_use_globally(name) {
+            return Err(TableError::StillInUse(name.to_string()));
+        }
 
-        self.assignment_import =
-            Self::filter_policy_from_assignment(self.assignment_import.take(), name);
-        self.assignment_export =
-            Self::filter_policy_from_assignment(self.assignment_export.take(), name);
+        let policy = self.policies.remove(name).ok_or(TableError::NotFound)?;
 
         if !preserve_statements {
             for stmt in &policy.statements {
@@ -1874,26 +1927,6 @@ impl PolicyTable {
         ))
     }
 
-    fn filter_policy_from_assignment(
-        assignment: Option<Arc<PolicyAssignment>>,
-        policy_name: &str,
-    ) -> Option<Arc<PolicyAssignment>> {
-        let old = assignment?;
-        let policies: Vec<Arc<Policy>> = old
-            .policies
-            .iter()
-            .filter(|p| p.name.as_ref() != policy_name)
-            .cloned()
-            .collect();
-        let needs_rpki = PolicyAssignment::compute_needs_rpki(&policies);
-        Some(Arc::new(PolicyAssignment {
-            name: old.name.clone(),
-            disposition: old.disposition,
-            policies,
-            needs_rpki,
-        }))
-    }
-
     // Returns the updated assignment after removing policies (or None if all=true).
     pub fn delete_policy_assignment(
         &mut self,
@@ -1909,20 +1942,8 @@ impl PolicyTable {
             *field = None;
             return Ok(None);
         }
-        let old = field.take().ok_or(TableError::NotFound)?;
-        let policies: Vec<Arc<Policy>> = old
-            .policies
-            .iter()
-            .filter(|p| !policy_names.iter().any(|n| n == p.name.as_ref()))
-            .cloned()
-            .collect();
-        let needs_rpki = PolicyAssignment::compute_needs_rpki(&policies);
-        let updated = Arc::new(PolicyAssignment {
-            name: old.name.clone(),
-            disposition: old.disposition,
-            policies,
-            needs_rpki,
-        });
+        let old = field.as_ref().ok_or(TableError::NotFound)?;
+        let updated = old.without_policies(policy_names);
         *field = Some(updated.clone());
         Ok(Some(updated))
     }
@@ -1935,25 +1956,8 @@ impl PolicyTable {
         default_action: Disposition,
         policy_names: Vec<String>,
     ) -> Result<Arc<PolicyAssignment>, TableError> {
-        let mut policies = Vec::new();
-        for pname in &policy_names {
-            match self.policies.get(pname.as_str()) {
-                Some(p) => policies.push(p.clone()),
-                None => {
-                    return Err(TableError::InvalidArgument(format!(
-                        "{} policy not found",
-                        pname
-                    )));
-                }
-            }
-        }
-        let needs_rpki = PolicyAssignment::compute_needs_rpki(&policies);
-        let assignment = Arc::new(PolicyAssignment {
-            name: Arc::from(name),
-            disposition: default_action,
-            policies,
-            needs_rpki,
-        });
+        let assignment =
+            self.build_assignment(None, name, direction, default_action, policy_names)?;
         match direction {
             PolicyDirection::Import => self.assignment_import = Some(assignment.clone()),
             PolicyDirection::Export => self.assignment_export = Some(assignment.clone()),


### PR DESCRIPTION
GoBGP lets an operator assign a distinct export policy to a single peer by setting PolicyAssignment.name to that peer's address (or to "global"/"" for the shared default), but RustyBGP only had one global export policy applied to every peer. There was no way to filter routes differently for one neighbor without maintaining separate policy definitions and juggling the single global assignment by hand.

Store the per-peer override in PeerState as an ArcSwapOption that defaults to None ("inherit the global policy"); the three export call sites just try the per-peer slot first and fall back to the global one. This sidesteps the override-tracking machinery (a dirty flag, or an Arc::ptr_eq check against the live global default) that a naive design would need to keep an unmodified peer's slot in sync with global policy changes: an unset slot always reflects whatever the global policy currently is on the next read, and reverting to "inherit" is just storing None again.

Deleting a named policy now refuses (StillInUse) if it is still referenced by the global assignment or by any peer's override -- the same protection already given to statement deletion, extended to also scan per-peer state so a peer is never left holding a stale Arc<Policy> after its definition disappears. Bulk resets (delete_policy all=true, SetPolicies) clear every peer's override for the same reason, since those operations replace the whole policy table out from under any existing per-peer Arc.

Also treat the literal "global" as a synonym for "" in Add/Delete/ListPolicyAssignment, matching GoBGP's GLOBAL_RIB_NAME; without this, passing "global" was silently parsed as a peer address and failed.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>