### PR TITLE
policy: honour NexthopAction::Unchanged for pre-policy nexthop default

### DIFF
--- a/daemon/src/event/export.rs
+++ b/daemon/src/event/export.rs
@@ -253,28 +253,43 @@ impl PeerExportContext {
         bgp::PeerCodec::new()
     }
 
-    /// Clear a received MED before export policy runs, for eBGP peers only.
+    /// Apply pre-policy defaults for export, run before `apply_export()`.
     ///
-    /// RFC 4271 §5.1.4: MED "must not ... propagate to other neighboring
-    /// ASes". This has to run *before* export policy (not folded into the
-    /// post-policy `export_attrs`) so that a `set-med` export policy action
-    /// can still set MED for the direct eBGP peer -- that use case is exactly
-    /// what MED is for. FRR does the same thing in the same order:
+    /// Clears a received MED for eBGP peers (RFC 4271 §5.1.4: MED "must not
+    /// ... propagate to other neighboring ASes") and defaults the nexthop
+    /// (see `export_nexthop`: self-nexthop for eBGP/ConfedEbgp; local
+    /// address when no nexthop is stored, e.g. a locally-originated route).
+    /// Both must run *before* export policy -- not folded into the
+    /// post-policy `export_attrs` -- so that `set-med` / `set-nexthop`
+    /// export policy actions are not silently discarded by a later,
+    /// unconditional rewrite. FRR does the same for MED in the same order:
     /// `subgroup_announce_check()` zeroes MED for eBGP peers before applying
-    /// the outbound route-map, so a route-map `set metric` still lands on the
-    /// wire. ConfedEbgp / iBGP / RS client keep MED as-is (confederation
-    /// members are treated as internal per RFC 5065).
-    pub(super) fn clear_received_med(&self, attr: &mut Arc<Vec<packet::Attribute>>) {
-        if self.role != PeerRole::Ebgp {
-            return;
-        }
-        if !attr
-            .iter()
-            .any(|a| a.code() == packet::Attribute::MULTI_EXIT_DESC)
+    /// the outbound route-map, so a route-map `set metric` still lands on
+    /// the wire. GoBGP does the same for nexthop: `prePolicyFilterpath` runs
+    /// `UpdatePathAttrs` (which forces self-nexthop) before `ApplyPolicy`.
+    ///
+    /// `nexthop` must hold the genuine, as-received value on entry: this
+    /// call overwrites it with the default, so callers must snapshot the
+    /// route's original nexthop beforehand and pass that snapshot into
+    /// `apply_export()` as `original_nexthop`, used only by
+    /// `NexthopAction::Unchanged` to restore the genuine original instead of
+    /// confirming the default just applied here (mirrors GoBGP's
+    /// `options.OldNextHop`, captured before `UpdatePathAttrs` runs).
+    pub(super) fn pre_policy_defaults(
+        &self,
+        attr: &mut Arc<Vec<packet::Attribute>>,
+        nexthop: &mut Option<bgp::Nexthop>,
+        family: Family,
+    ) {
+        if self.role == PeerRole::Ebgp
+            && attr
+                .iter()
+                .any(|a| a.code() == packet::Attribute::MULTI_EXIT_DESC)
         {
-            return;
+            Arc::make_mut(attr).retain(|a| a.code() != packet::Attribute::MULTI_EXIT_DESC);
         }
-        Arc::make_mut(attr).retain(|a| a.code() != packet::Attribute::MULTI_EXIT_DESC);
+
+        self.export_nexthop(nexthop, family);
     }
 
     /// Apply per-peer attribute transformation to outgoing route attributes.
@@ -287,11 +302,12 @@ impl PeerExportContext {
     /// all UPDATE messages to internal peers).
     /// RS client: pass through unchanged.
     ///
-    /// MED is intentionally not handled here: unlike LOCAL_PREF, an eBGP
-    /// export policy may legitimately set MED for the direct peer (RFC 4271
-    /// §5.1.4), so clearing a *received* MED must happen before export
-    /// policy runs -- see `clear_received_med`, called earlier in the export
-    /// pipeline -- rather than here, after policy has already run.
+    /// MED and nexthop are intentionally not handled here: unlike LOCAL_PREF,
+    /// an eBGP export policy may legitimately set them for the direct peer
+    /// (RFC 4271 §5.1.4, and third-party nexthop respectively), so their
+    /// defaults must be applied before export policy runs -- see
+    /// `pre_policy_defaults`, called earlier in the export pipeline --
+    /// rather than here, after policy has already run.
     pub(super) fn export_attrs(
         &self,
         attrs: &Arc<Vec<bgp::Attribute>>,
@@ -379,16 +395,18 @@ impl PeerExportContext {
         )
     }
 
-    /// Apply per-peer nexthop transformation to an outgoing route nexthop.
+    /// Compute the default per-peer nexthop for an outgoing route.
     ///
-    /// eBGP: replace with local_addr (with link-local for IPv6 when available).
-    /// iBGP / iBGP-RR-client / RS client: pass through unchanged (next-hop
-    /// unchanged).
-    pub(super) fn export_nexthop(
-        &self,
-        nexthop: Option<bgp::Nexthop>,
-        family: Family,
-    ) -> Option<bgp::Nexthop> {
+    /// eBGP / ConfedEbgp: self-nexthop (local_addr, with link-local for IPv6
+    /// when available). iBGP / iBGP-RR-client / RS client: pass through
+    /// unchanged. No stored nexthop (e.g. a locally-originated route):
+    /// self-nexthop for any role, except Flowspec (RFC 8955 §4 carries no
+    /// nexthop).
+    ///
+    /// Called only from `pre_policy_defaults`, i.e. before export policy
+    /// runs, so that a `set-nexthop` export policy action can override this
+    /// default rather than being clobbered by it afterward.
+    fn export_nexthop(&self, nexthop: &mut Option<bgp::Nexthop>, family: Family) {
         let local = || match self.local_addr {
             IpAddr::V4(v4) => bgp::Nexthop::V4(v4),
             IpAddr::V6(v6) => {
@@ -406,7 +424,7 @@ impl PeerExportContext {
                 | Family::IPV4_FLOWSPEC_VPN
                 | Family::IPV6_FLOWSPEC_VPN
         );
-        match (self.role, nexthop) {
+        *nexthop = match (self.role, *nexthop) {
             // Flowspec carries no nexthop (RFC 8955 §4): preserve None.
             (_, None) if is_flowspec => None,
             // No stored nexthop for non-Flowspec (e.g. locally originated RTC):
@@ -414,7 +432,7 @@ impl PeerExportContext {
             (_, None) => Some(local()),
             (PeerRole::RsClient | PeerRole::Ibgp | PeerRole::IbgpRrClient, Some(nh)) => Some(nh),
             (PeerRole::ConfedEbgp | PeerRole::Ebgp, Some(_)) => Some(local()),
-        }
+        };
     }
 }
 
@@ -619,9 +637,10 @@ pub(super) fn process_nlri_change<S: NlriSink>(
             if rtc_filter.is_some_and(|f| !f.allows(&best.attr)) {
                 return None;
             }
+            let original_nexthop = best.nexthop;
             let mut nexthop = best.nexthop;
             let mut attr = Arc::clone(&best.attr);
-            export_ctx.clear_received_med(&mut attr);
+            export_ctx.pre_policy_defaults(&mut attr, &mut nexthop, update.family);
             if export_policy.is_some_and(|policy| {
                 table::apply_export(
                     policy,
@@ -630,6 +649,7 @@ pub(super) fn process_nlri_change<S: NlriSink>(
                     &update.net,
                     &mut attr,
                     &mut nexthop,
+                    original_nexthop,
                     export_ctx.local_addr,
                     remote_addr,
                 ) == table::Disposition::Reject
@@ -664,7 +684,6 @@ pub(super) fn process_nlri_change<S: NlriSink>(
                     attr
                 };
                 let attr = export_ctx.export_attrs(&attr);
-                let nexthop = export_ctx.export_nexthop(nexthop, update.family);
                 // BMP post-policy Reach: use the fully-rewritten attr/nexthop.
                 if let Some(bmp) = bmp {
                     bmp.post(
@@ -691,7 +710,7 @@ pub(super) fn process_nlri_change<S: NlriSink>(
         }
         // Build the effective top-N after echo prevention, split horizon, and
         // export policy.  Store post-policy (attr, nexthop) so that
-        // export_attrs/export_nexthop can be applied in one step below.
+        // export_attrs can be applied in one step below.
         let current_top_n: Vec<(
             u32,
             Arc<Vec<packet::Attribute>>,
@@ -708,9 +727,10 @@ pub(super) fn process_nlri_change<S: NlriSink>(
                 if rtc_filter.is_some_and(|f| !f.allows(&path.attr)) {
                     return None;
                 }
+                let original_nexthop = path.nexthop;
                 let mut nexthop = path.nexthop;
                 let mut attr = Arc::clone(&path.attr);
-                export_ctx.clear_received_med(&mut attr);
+                export_ctx.pre_policy_defaults(&mut attr, &mut nexthop, update.family);
                 if export_policy.is_some_and(|policy| {
                     table::apply_export(
                         policy,
@@ -719,6 +739,7 @@ pub(super) fn process_nlri_change<S: NlriSink>(
                         &update.net,
                         &mut attr,
                         &mut nexthop,
+                        original_nexthop,
                         export_ctx.local_addr,
                         remote_addr,
                     ) == table::Disposition::Reject
@@ -758,7 +779,7 @@ pub(super) fn process_nlri_change<S: NlriSink>(
             if !already_sent || was_replaced {
                 export_map.mark_sent(update.family, update.dest_id, *pid);
                 let attr = export_ctx.export_attrs(attr);
-                let nexthop = export_ctx.export_nexthop(*nexthop, update.family);
+                let nexthop = *nexthop;
                 if let Some(bmp) = bmp {
                     bmp.post(
                         update.family,

--- a/daemon/src/event/export.rs
+++ b/daemon/src/event/export.rs
@@ -280,6 +280,7 @@ impl PeerExportContext {
         attr: &mut Arc<Vec<packet::Attribute>>,
         nexthop: &mut Option<bgp::Nexthop>,
         family: Family,
+        is_local: bool,
     ) {
         if self.role == PeerRole::Ebgp
             && attr
@@ -289,7 +290,7 @@ impl PeerExportContext {
             Arc::make_mut(attr).retain(|a| a.code() != packet::Attribute::MULTI_EXIT_DESC);
         }
 
-        self.export_nexthop(nexthop, family);
+        self.export_nexthop(nexthop, family, is_local);
     }
 
     /// Apply per-peer attribute transformation to outgoing route attributes.
@@ -403,10 +404,20 @@ impl PeerExportContext {
     /// self-nexthop for any role, except Flowspec (RFC 8955 §4 carries no
     /// nexthop).
     ///
+    /// `is_local` (`Source::is_local()`): for a locally-injected route (e.g.
+    /// via the `AddPath` gRPC API) with an explicit, non-unspecified nexthop,
+    /// that value is honored for *any* role instead of being forced to self
+    /// -- an unspecified nexthop (`0.0.0.0`/`::`, a common "let the router
+    /// fill this in" sentinel) still gets the self-nexthop default. Mirrors
+    /// GoBGP's `UpdatePathAttrs`: `!path.IsLocal() || nexthop.IsUnspecified()`
+    /// for eBGP and `path.IsLocal() && nexthop.IsUnspecified()` for iBGP --
+    /// both reduce to the same "local + unspecified -> self, local + explicit
+    /// -> keep" rule, which is what this function implements directly.
+    ///
     /// Called only from `pre_policy_defaults`, i.e. before export policy
     /// runs, so that a `set-nexthop` export policy action can override this
     /// default rather than being clobbered by it afterward.
-    fn export_nexthop(&self, nexthop: &mut Option<bgp::Nexthop>, family: Family) {
+    fn export_nexthop(&self, nexthop: &mut Option<bgp::Nexthop>, family: Family, is_local: bool) {
         let local = || match self.local_addr {
             IpAddr::V4(v4) => bgp::Nexthop::V4(v4),
             IpAddr::V6(v6) => {
@@ -430,6 +441,12 @@ impl PeerExportContext {
             // No stored nexthop for non-Flowspec (e.g. locally originated RTC):
             // use per-peer local address.
             (_, None) => Some(local()),
+            // Locally-injected route with an explicit nexthop: honor it,
+            // regardless of peer role.
+            (_, Some(nh)) if is_local && !nh.addr().is_unspecified() => Some(nh),
+            // Locally-injected route with an unspecified (0.0.0.0/::) nexthop:
+            // fill in self, regardless of peer role.
+            (_, Some(_)) if is_local => Some(local()),
             (PeerRole::RsClient | PeerRole::Ibgp | PeerRole::IbgpRrClient, Some(nh)) => Some(nh),
             (PeerRole::ConfedEbgp | PeerRole::Ebgp, Some(_)) => Some(local()),
         };
@@ -640,7 +657,12 @@ pub(super) fn process_nlri_change<S: NlriSink>(
             let original_nexthop = best.nexthop;
             let mut nexthop = best.nexthop;
             let mut attr = Arc::clone(&best.attr);
-            export_ctx.pre_policy_defaults(&mut attr, &mut nexthop, update.family);
+            export_ctx.pre_policy_defaults(
+                &mut attr,
+                &mut nexthop,
+                update.family,
+                best.source.is_local(),
+            );
             if export_policy.is_some_and(|policy| {
                 table::apply_export(
                     policy,
@@ -731,7 +753,12 @@ pub(super) fn process_nlri_change<S: NlriSink>(
                 let original_nexthop = path.nexthop;
                 let mut nexthop = path.nexthop;
                 let mut attr = Arc::clone(&path.attr);
-                export_ctx.pre_policy_defaults(&mut attr, &mut nexthop, update.family);
+                export_ctx.pre_policy_defaults(
+                    &mut attr,
+                    &mut nexthop,
+                    update.family,
+                    path.source.is_local(),
+                );
                 if export_policy.is_some_and(|policy| {
                     table::apply_export(
                         policy,

--- a/daemon/src/event/export.rs
+++ b/daemon/src/event/export.rs
@@ -650,6 +650,7 @@ pub(super) fn process_nlri_change<S: NlriSink>(
                     &mut attr,
                     &mut nexthop,
                     original_nexthop,
+                    export_ctx.role == PeerRole::ConfedEbgp,
                     export_ctx.local_addr,
                     remote_addr,
                 ) == table::Disposition::Reject
@@ -740,6 +741,7 @@ pub(super) fn process_nlri_change<S: NlriSink>(
                         &mut attr,
                         &mut nexthop,
                         original_nexthop,
+                        export_ctx.role == PeerRole::ConfedEbgp,
                         export_ctx.local_addr,
                         remote_addr,
                     ) == table::Disposition::Reject

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -536,8 +536,8 @@ impl Peer {
 
     /// Build a `PeerExportContext` for adj-out display (no live session needed).
     ///
-    /// Uses the router-id as `local_addr` fallback; `export_nexthop` is not
-    /// called for display so the exact local address does not matter.
+    /// Uses the router-id as `local_addr` fallback; `pre_policy_defaults` is
+    /// not called for display so the exact local address does not matter.
     fn adj_out_export_ctx(&self, global: &Global) -> PeerExportContext {
         PeerExportContext {
             role: self.peer_role(global),
@@ -7131,6 +7131,16 @@ mod tests {
             out
         }
 
+        /// Extract the nexthop carried by each reach UPDATE message.
+        fn reach_nexthops(msgs: &[bgp::Message]) -> Vec<Option<bgp::Nexthop>> {
+            msgs.iter()
+                .filter_map(|msg| match msg {
+                    bgp::Message::Update(bgp::Update::Reach { nexthop, .. }) => Some(*nexthop),
+                    _ => None,
+                })
+                .collect()
+        }
+
         const SELF: &str = "10.0.0.1";
         const PEER: &str = "10.0.0.2";
 
@@ -7244,6 +7254,97 @@ mod tests {
 
             assert!(pending.is_empty());
             assert!(!em.was_sent(Family::IPV4, 1));
+        }
+
+        // ---- export policy: NexthopAction::Unchanged vs pre-policy default ----
+
+        fn nexthop_export_policy(action: table::NexthopAction) -> Arc<table::PolicyAssignment> {
+            let mut ptable = table::PolicyTable::new();
+            ptable
+                .add_statement(
+                    "st1",
+                    vec![],
+                    Some(table::Disposition::Accept),
+                    table::Actions {
+                        nexthop: Some(action),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            ptable.add_policy("pol1", vec!["st1".to_string()]).unwrap();
+            let (_, assignment) = ptable
+                .add_assignment(
+                    "peer",
+                    table::PolicyDirection::Export,
+                    table::Disposition::Accept,
+                    vec!["pol1".to_string()],
+                )
+                .unwrap();
+            assignment
+        }
+
+        #[test]
+        fn ebgp_export_policy_nexthop_unchanged_preserves_third_party_nexthop() {
+            let mut em = ExportMap::default();
+            let mut pending = crate::peer_tx::PendingTx::new(false);
+            let net = nlri("10.0.0.0/24");
+            let mut p = path(1, source(PEER));
+            // Third-party nexthop: neither this router's local_addr nor the peer's address.
+            p.nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(192, 168, 100, 1)));
+            let update = change(&net, true, true, None, vec![p]);
+            let policy = nexthop_export_policy(table::NexthopAction::Unchanged);
+
+            process_nlri_change(
+                &update,
+                1,
+                SELF.parse().unwrap(),
+                &mut em,
+                &mut pending,
+                &ebgp_ctx(),
+                Some(&policy),
+                None,
+                None,
+                None,
+                None,
+            );
+
+            let msgs = pending.drain_messages(Family::IPV4);
+            assert_eq!(
+                reach_nexthops(&msgs),
+                vec![Some(bgp::Nexthop::V4(Ipv4Addr::new(192, 168, 100, 1)))],
+                "NexthopAction::Unchanged must preserve the third-party nexthop, not force self"
+            );
+        }
+
+        #[test]
+        fn ebgp_export_without_policy_forces_self_nexthop() {
+            let mut em = ExportMap::default();
+            let mut pending = crate::peer_tx::PendingTx::new(false);
+            let net = nlri("10.0.0.0/24");
+            let mut p = path(1, source(PEER));
+            p.nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(192, 168, 100, 1)));
+            let update = change(&net, true, true, None, vec![p]);
+
+            process_nlri_change(
+                &update,
+                1,
+                SELF.parse().unwrap(),
+                &mut em,
+                &mut pending,
+                &ebgp_ctx(), // local_addr = 127.0.0.1
+                None,
+                None,
+                None,
+                None,
+                None,
+            );
+
+            let msgs = pending.drain_messages(Family::IPV4);
+            assert_eq!(
+                reach_nexthops(&msgs),
+                vec![Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1)))],
+                "without a set-nexthop policy, eBGP export must force self-nexthop"
+            );
         }
 
         #[test]
@@ -7768,7 +7869,7 @@ mod tests {
             assert_eq!(reach[0].1, 2);
         }
 
-        // ---- export_attrs / export_nexthop per-role correctness ----
+        // ---- export_attrs / pre_policy_defaults per-role correctness ----
 
         fn attr_with_local_pref() -> Arc<Vec<packet::Attribute>> {
             Arc::new(vec![
@@ -7858,9 +7959,9 @@ mod tests {
 
         #[test]
         fn ebgp_export_attrs_does_not_touch_med() {
-            // MED stripping for eBGP happens in clear_received_med(), called
+            // MED stripping for eBGP happens in pre_policy_defaults(), called
             // *before* export policy runs, not in export_attrs() (which runs
-            // after policy). See clear_received_med_* tests below.
+            // after policy). See pre_policy_defaults_*_med_* tests below.
             let ctx = ebgp_ctx();
             let exported = ctx.export_attrs(&attr_with_med());
             assert!(
@@ -7872,10 +7973,11 @@ mod tests {
         }
 
         #[test]
-        fn clear_received_med_strips_for_ebgp() {
+        fn pre_policy_defaults_strips_med_for_ebgp() {
             let ctx = ebgp_ctx();
             let mut attr = attr_with_med();
-            ctx.clear_received_med(&mut attr);
+            let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1)));
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
             assert!(
                 attr.iter()
                     .all(|a| a.code() != packet::Attribute::MULTI_EXIT_DESC),
@@ -7884,10 +7986,11 @@ mod tests {
         }
 
         #[test]
-        fn clear_received_med_keeps_for_ibgp() {
+        fn pre_policy_defaults_keeps_med_for_ibgp() {
             let ctx = ibgp_ctx();
             let mut attr = attr_with_med();
-            ctx.clear_received_med(&mut attr);
+            let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1)));
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
             assert!(
                 attr.iter().any(
                     |a| a.code() == packet::Attribute::MULTI_EXIT_DESC && a.value() == Some(50)
@@ -7897,10 +8000,11 @@ mod tests {
         }
 
         #[test]
-        fn clear_received_med_keeps_for_confed_ebgp() {
+        fn pre_policy_defaults_keeps_med_for_confed_ebgp() {
             let ctx = confed_ebgp_ctx();
             let mut attr = attr_with_med();
-            ctx.clear_received_med(&mut attr);
+            let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1)));
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
             assert!(
                 attr.iter().any(
                     |a| a.code() == packet::Attribute::MULTI_EXIT_DESC && a.value() == Some(50)
@@ -8101,26 +8205,30 @@ mod tests {
         }
 
         #[test]
-        fn ebgp_export_rewrites_nexthop() {
+        fn pre_policy_defaults_rewrites_nexthop_for_ebgp() {
             let ctx = ebgp_ctx(); // local_addr = 127.0.0.1
+            let mut attr = Arc::new(vec![]);
             let original = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
-            let exported = ctx.export_nexthop(Some(original), Family::IPV4);
+            let mut nexthop = Some(original);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
             assert_eq!(
-                exported,
+                nexthop,
                 Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1))),
                 "eBGP nexthop must be rewritten to local_addr"
             );
         }
 
         #[test]
-        fn ibgp_export_keeps_nexthop() {
+        fn pre_policy_defaults_keeps_nexthop_for_ibgp() {
             let ctx = ibgp_ctx();
+            let mut attr = Arc::new(vec![]);
             let original = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
-            let exported = ctx.export_nexthop(Some(original), Family::IPV4);
-            assert_eq!(exported, Some(original), "iBGP nexthop must be unchanged");
+            let mut nexthop = Some(original);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
+            assert_eq!(nexthop, Some(original), "iBGP nexthop must be unchanged");
         }
 
-        // ---- Confederation: export_attrs / export_nexthop ----
+        // ---- Confederation: export_attrs / pre_policy_defaults ----
 
         fn confed_ebgp_ctx() -> PeerExportContext {
             PeerExportContext {
@@ -8225,12 +8333,14 @@ mod tests {
         }
 
         #[test]
-        fn confed_ebgp_export_nexthop_rewrites_to_local() {
+        fn confed_ebgp_pre_policy_defaults_rewrites_nexthop_to_local() {
             let ctx = confed_ebgp_ctx(); // local_addr = 127.0.0.1
+            let mut attr = Arc::new(vec![]);
             let original = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
-            let exported = ctx.export_nexthop(Some(original), Family::IPV4);
+            let mut nexthop = Some(original);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
             assert_eq!(
-                exported,
+                nexthop,
                 Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1))),
                 "ConfedEbgp nexthop must be rewritten to local_addr"
             );

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -7347,6 +7347,79 @@ mod tests {
             );
         }
 
+        // ---- export policy: as-prepend confed-awareness ----
+
+        fn as_prepend_export_policy(asn: u32, repeat: u32) -> Arc<table::PolicyAssignment> {
+            let mut ptable = table::PolicyTable::new();
+            ptable
+                .add_statement(
+                    "st1",
+                    vec![],
+                    Some(table::Disposition::Accept),
+                    table::Actions {
+                        as_prepend: Some(table::AsPrependAction {
+                            asn,
+                            repeat,
+                            use_left_most: false,
+                        }),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            ptable.add_policy("pol1", vec!["st1".to_string()]).unwrap();
+            let (_, assignment) = ptable
+                .add_assignment(
+                    "peer",
+                    table::PolicyDirection::Export,
+                    table::Disposition::Accept,
+                    vec!["pol1".to_string()],
+                )
+                .unwrap();
+            assignment
+        }
+
+        #[test]
+        fn confed_ebgp_export_policy_as_prepend_uses_confed_sequence() {
+            let mut em = ExportMap::default();
+            let mut pending = crate::peer_tx::PendingTx::new(false);
+            let net = nlri("10.0.0.0/24");
+            let p = path(1, source(PEER));
+            let update = change(&net, true, true, None, vec![p]);
+            let policy = as_prepend_export_policy(65100, 1);
+
+            process_nlri_change(
+                &update,
+                1,
+                SELF.parse().unwrap(),
+                &mut em,
+                &mut pending,
+                &confed_ebgp_ctx(), // local_asn = 65001
+                Some(&policy),
+                None,
+                None,
+                None,
+                None,
+            );
+
+            let msgs = pending.drain_messages(Family::IPV4);
+            let attr = reach_attrs(&msgs).expect("reach message must be present");
+            let aspath = attr
+                .iter()
+                .find(|a| a.code() == packet::Attribute::AS_PATH)
+                .expect("AS_PATH must be present");
+            let buf = aspath.binary().unwrap();
+            assert_eq!(
+                buf[0],
+                packet::Attribute::AS_PATH_TYPE_CONFED_SEQ,
+                "policy as-prepend for a ConfedEbgp peer must land in AS_CONFED_SEQUENCE"
+            );
+            assert_eq!(
+                bgp::AsPathIter::new(aspath).flatten().collect::<Vec<u32>>(),
+                vec![65001, 65100],
+                "own Member-AS stays outermost; policy prepend follows inside the same segment"
+            );
+        }
+
         #[test]
         fn nonaddpath_echo_prevention() {
             let mut em = ExportMap::default();

--- a/daemon/src/event/mod.rs
+++ b/daemon/src/event/mod.rs
@@ -7347,6 +7347,74 @@ mod tests {
             );
         }
 
+        #[test]
+        fn ebgp_export_honors_addpath_explicit_nexthop() {
+            // A route injected via the AddPath gRPC API (table::Source::local())
+            // with an explicit nexthop must reach an eBGP peer unchanged, even
+            // with no export policy configured (GoBGP parity).
+            let mut em = ExportMap::default();
+            let mut pending = crate::peer_tx::PendingTx::new(false);
+            let net = nlri("10.0.0.0/24");
+            let mut p = path(1, table::Source::local());
+            p.nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(192, 168, 100, 1)));
+            let update = change(&net, true, true, None, vec![p]);
+
+            process_nlri_change(
+                &update,
+                1,
+                SELF.parse().unwrap(),
+                &mut em,
+                &mut pending,
+                &ebgp_ctx(), // local_addr = 127.0.0.1
+                None,
+                None,
+                None,
+                None,
+                None,
+            );
+
+            let msgs = pending.drain_messages(Family::IPV4);
+            assert_eq!(
+                reach_nexthops(&msgs),
+                vec![Some(bgp::Nexthop::V4(Ipv4Addr::new(192, 168, 100, 1)))],
+                "AddPath-injected explicit nexthop must be honored for eBGP export"
+            );
+        }
+
+        #[test]
+        fn ebgp_export_fills_self_for_addpath_unspecified_nexthop() {
+            // A route injected via AddPath with nexthop=0.0.0.0 (the common
+            // "let the router fill this in" convention) must still get
+            // self-nexthop, matching GoBGP's IsUnspecified() check.
+            let mut em = ExportMap::default();
+            let mut pending = crate::peer_tx::PendingTx::new(false);
+            let net = nlri("10.0.0.0/24");
+            let mut p = path(1, table::Source::local());
+            p.nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::UNSPECIFIED));
+            let update = change(&net, true, true, None, vec![p]);
+
+            process_nlri_change(
+                &update,
+                1,
+                SELF.parse().unwrap(),
+                &mut em,
+                &mut pending,
+                &ebgp_ctx(), // local_addr = 127.0.0.1
+                None,
+                None,
+                None,
+                None,
+                None,
+            );
+
+            let msgs = pending.drain_messages(Family::IPV4);
+            assert_eq!(
+                reach_nexthops(&msgs),
+                vec![Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1)))],
+                "AddPath nexthop=0.0.0.0 must still be filled with self-nexthop"
+            );
+        }
+
         // ---- export policy: as-prepend confed-awareness ----
 
         fn as_prepend_export_policy(asn: u32, repeat: u32) -> Arc<table::PolicyAssignment> {
@@ -8050,7 +8118,7 @@ mod tests {
             let ctx = ebgp_ctx();
             let mut attr = attr_with_med();
             let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1)));
-            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, false);
             assert!(
                 attr.iter()
                     .all(|a| a.code() != packet::Attribute::MULTI_EXIT_DESC),
@@ -8063,7 +8131,7 @@ mod tests {
             let ctx = ibgp_ctx();
             let mut attr = attr_with_med();
             let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1)));
-            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, false);
             assert!(
                 attr.iter().any(
                     |a| a.code() == packet::Attribute::MULTI_EXIT_DESC && a.value() == Some(50)
@@ -8077,7 +8145,7 @@ mod tests {
             let ctx = confed_ebgp_ctx();
             let mut attr = attr_with_med();
             let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1)));
-            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, false);
             assert!(
                 attr.iter().any(
                     |a| a.code() == packet::Attribute::MULTI_EXIT_DESC && a.value() == Some(50)
@@ -8283,7 +8351,7 @@ mod tests {
             let mut attr = Arc::new(vec![]);
             let original = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
             let mut nexthop = Some(original);
-            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, false);
             assert_eq!(
                 nexthop,
                 Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1))),
@@ -8297,8 +8365,80 @@ mod tests {
             let mut attr = Arc::new(vec![]);
             let original = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
             let mut nexthop = Some(original);
-            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, false);
             assert_eq!(nexthop, Some(original), "iBGP nexthop must be unchanged");
+        }
+
+        // ---- pre_policy_defaults: locally-injected explicit nexthop (GoBGP parity) ----
+
+        #[test]
+        fn pre_policy_defaults_honors_explicit_local_nexthop_for_ebgp() {
+            let ctx = ebgp_ctx(); // local_addr = 127.0.0.1
+            let mut attr = Arc::new(vec![]);
+            let explicit = bgp::Nexthop::V4(Ipv4Addr::new(192, 168, 1, 1));
+            let mut nexthop = Some(explicit);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, true);
+            assert_eq!(
+                nexthop,
+                Some(explicit),
+                "a locally-injected route's explicit nexthop must be honored for eBGP"
+            );
+        }
+
+        #[test]
+        fn pre_policy_defaults_fills_self_for_local_unspecified_nexthop_ebgp() {
+            let ctx = ebgp_ctx(); // local_addr = 127.0.0.1
+            let mut attr = Arc::new(vec![]);
+            let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::UNSPECIFIED));
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, true);
+            assert_eq!(
+                nexthop,
+                Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1))),
+                "0.0.0.0 on a locally-injected route is a sentinel for self-nexthop"
+            );
+        }
+
+        #[test]
+        fn pre_policy_defaults_honors_explicit_local_nexthop_for_ibgp() {
+            let ctx = ibgp_ctx();
+            let mut attr = Arc::new(vec![]);
+            let explicit = bgp::Nexthop::V4(Ipv4Addr::new(192, 168, 1, 1));
+            let mut nexthop = Some(explicit);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, true);
+            assert_eq!(
+                nexthop,
+                Some(explicit),
+                "a locally-injected route's explicit nexthop must be honored for iBGP too"
+            );
+        }
+
+        #[test]
+        fn pre_policy_defaults_fills_self_for_local_unspecified_nexthop_ibgp() {
+            let ctx = ibgp_ctx(); // local_addr = 127.0.0.1
+            let mut attr = Arc::new(vec![]);
+            let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::UNSPECIFIED));
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, true);
+            assert_eq!(
+                nexthop,
+                Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1))),
+                "0.0.0.0 on a locally-injected route must be filled with self for iBGP too"
+            );
+        }
+
+        #[test]
+        fn pre_policy_defaults_ignores_is_local_for_peer_received_ebgp() {
+            // A peer-received route (is_local=false) must still be forced to
+            // self-nexthop for eBGP regardless of the nexthop value -- is_local
+            // only changes behavior for locally-injected routes.
+            let ctx = ebgp_ctx();
+            let mut attr = Arc::new(vec![]);
+            let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(192, 168, 1, 1)));
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, false);
+            assert_eq!(
+                nexthop,
+                Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1))),
+                "peer-received nexthop must still be forced to self for eBGP"
+            );
         }
 
         // ---- Confederation: export_attrs / pre_policy_defaults ----
@@ -8411,7 +8551,7 @@ mod tests {
             let mut attr = Arc::new(vec![]);
             let original = bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1));
             let mut nexthop = Some(original);
-            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4);
+            ctx.pre_policy_defaults(&mut attr, &mut nexthop, Family::IPV4, false);
             assert_eq!(
                 nexthop,
                 Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1))),

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -2010,8 +2010,18 @@ impl Table {
         local_addr: IpAddr,
         peer_addr: IpAddr,
         rpki: Option<&RpkiTable>,
+        original_nexthop: Option<bgp::Nexthop>,
     ) -> Disposition {
-        assignment.apply(source, net, attr, nexthop, local_addr, peer_addr, rpki)
+        assignment.apply(
+            source,
+            net,
+            attr,
+            nexthop,
+            original_nexthop,
+            local_addr,
+            peer_addr,
+            rpki,
+        )
     }
 }
 
@@ -3535,6 +3545,7 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(result, Disposition::Reject);
     }
@@ -3586,6 +3597,7 @@ mod tests {
             &mut nh(),
             IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(result, Disposition::Accept);
@@ -3643,6 +3655,7 @@ mod tests {
             &mut nexthop,
             IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(result, Disposition::Accept);
@@ -3703,6 +3716,7 @@ mod tests {
             &mut nexthop,
             local_addr,
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(result, Disposition::Accept);
@@ -3766,6 +3780,7 @@ mod tests {
             &mut nexthop,
             IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(nexthop, original);

--- a/table/src/lib.rs
+++ b/table/src/lib.rs
@@ -2011,6 +2011,7 @@ impl Table {
         peer_addr: IpAddr,
         rpki: Option<&RpkiTable>,
         original_nexthop: Option<bgp::Nexthop>,
+        is_confed: bool,
     ) -> Disposition {
         assignment.apply(
             source,
@@ -2018,6 +2019,7 @@ impl Table {
             attr,
             nexthop,
             original_nexthop,
+            is_confed,
             local_addr,
             peer_addr,
             rpki,
@@ -3546,6 +3548,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(result, Disposition::Reject);
     }
@@ -3599,6 +3602,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(result, Disposition::Accept);
     }
@@ -3657,6 +3661,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(result, Disposition::Accept);
         assert_eq!(
@@ -3718,6 +3723,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(result, Disposition::Accept);
         assert_eq!(
@@ -3782,6 +3788,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(nexthop, original);
     }

--- a/table/src/policy.rs
+++ b/table/src/policy.rs
@@ -819,6 +819,7 @@ impl Statement {
         attr: &mut Arc<Vec<packet::Attribute>>,
         nexthop: &mut Option<bgp::Nexthop>,
         original_nexthop: Option<bgp::Nexthop>,
+        is_confed: bool,
         local_addr: IpAddr,
         peer_addr: IpAddr,
         rpki: Option<&RpkiTable>,
@@ -934,7 +935,11 @@ impl Statement {
             };
             let mut new_as_path = existing;
             for _ in 0..action.repeat {
-                new_as_path = new_as_path.as_path_prepend(asn);
+                new_as_path = if is_confed {
+                    new_as_path.as_path_prepend_confed(asn)
+                } else {
+                    new_as_path.as_path_prepend(asn)
+                };
             }
             attrs.retain(|a| a.code() != packet::Attribute::AS_PATH);
             attrs.push(new_as_path);
@@ -1136,6 +1141,7 @@ impl Policy {
         attr: &mut Arc<Vec<packet::Attribute>>,
         nexthop: &mut Option<bgp::Nexthop>,
         original_nexthop: Option<bgp::Nexthop>,
+        is_confed: bool,
         local_addr: IpAddr,
         peer_addr: IpAddr,
         rpki: Option<&RpkiTable>,
@@ -1147,6 +1153,7 @@ impl Policy {
                 attr,
                 nexthop,
                 original_nexthop,
+                is_confed,
                 local_addr,
                 peer_addr,
                 rpki,
@@ -1185,6 +1192,7 @@ impl PolicyAssignment {
         attr: &mut Arc<Vec<packet::Attribute>>,
         nexthop: &mut Option<bgp::Nexthop>,
         original_nexthop: Option<bgp::Nexthop>,
+        is_confed: bool,
         local_addr: IpAddr,
         peer_addr: IpAddr,
         rpki: Option<&RpkiTable>,
@@ -1196,6 +1204,7 @@ impl PolicyAssignment {
                 attr,
                 nexthop,
                 original_nexthop,
+                is_confed,
                 local_addr,
                 peer_addr,
                 rpki,
@@ -1245,12 +1254,15 @@ pub fn apply_import(
     // PolicyTable::build_assignment() also rejects nexthop actions in import
     // policies at load time, so this is never actually exercised.
     let original_nexthop = *nexthop;
+    // Import is never "towards a confederation member" in the export sense,
+    // so a policy's as-prepend action (if any) always uses AS_SEQUENCE.
     let filtered = policy.apply(
         source,
         net,
         &mut attr,
         nexthop,
         original_nexthop,
+        false,
         source.local_addr,
         source.remote_addr,
         rpki,
@@ -1265,6 +1277,11 @@ pub fn apply_import(
 /// `NexthopAction::Unchanged` to restore the genuine original instead of
 /// confirming the just-applied default.
 ///
+/// `is_confed` marks the destination peer as a confederation member: a
+/// policy's as-prepend action then adds AS_CONFED_SEQUENCE instead of
+/// AS_SEQUENCE, matching GoBGP's `AsPathPrependAction.Apply`, which passes
+/// `confed := option.Info.Confederation` into the shared `PrependAsn`.
+///
 /// Returns the `Disposition` from the policy chain.
 /// Pass `rpki: None` to skip RPKI validation (e.g. in tests or when no RTR session is active).
 #[allow(clippy::too_many_arguments)]
@@ -1276,6 +1293,7 @@ pub fn apply_export(
     attr: &mut Arc<Vec<packet::Attribute>>,
     nexthop: &mut Option<bgp::Nexthop>,
     original_nexthop: Option<bgp::Nexthop>,
+    is_confed: bool,
     local_addr: IpAddr,
     peer_addr: IpAddr,
 ) -> Disposition {
@@ -1285,6 +1303,7 @@ pub fn apply_export(
         attr,
         nexthop,
         original_nexthop,
+        is_confed,
         local_addr,
         peer_addr,
         rpki,
@@ -2649,6 +2668,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
 
         let result = get_communities(&attr);
@@ -2680,6 +2700,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
 
         let result = get_communities(&attr);
@@ -2707,6 +2728,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
 
         let result = get_communities(&attr);
@@ -2735,6 +2757,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
 
         assert!(
@@ -2766,6 +2789,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
 
         let result = get_communities(&attr);
@@ -2824,6 +2848,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
 
         assert_eq!(get_local_pref(&attr), Some(200));
@@ -2854,6 +2879,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
 
         assert_eq!(get_local_pref(&attr), Some(150));
@@ -2914,6 +2940,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_med(&attr), Some(300));
     }
@@ -2935,6 +2962,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_med(&attr), Some(100));
     }
@@ -2956,6 +2984,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_med(&attr), Some(250));
     }
@@ -2977,6 +3006,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_med(&attr), Some(150));
     }
@@ -2998,6 +3028,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_med(&attr), Some(0));
     }
@@ -3068,6 +3099,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_as_path(&attr), vec![65100, 65001, 65002]);
     }
@@ -3089,6 +3121,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_as_path(&attr), vec![65100, 65100, 65100, 65001]);
     }
@@ -3110,6 +3143,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_as_path(&attr), vec![65001, 65001, 65002]);
     }
@@ -3131,8 +3165,44 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_as_path(&attr), vec![65100, 65100]);
+    }
+
+    #[test]
+    fn as_prepend_confed_uses_as_confed_sequence() {
+        // A policy's as-prepend action targeting a confederation member must
+        // land in AS_CONFED_SEQUENCE, not AS_SEQUENCE, or the AS_PATH would
+        // look like it left the confederation when it didn't.
+        let assignment = make_as_prepend_assignment(65100, 1, false);
+        let s = source();
+        let net = nlri();
+        let mut attr = Arc::new(vec![as_path_attr(&[65001, 65002])]);
+        let mut nexthop = nh();
+        Table::apply_policy(
+            &assignment,
+            &s,
+            &net,
+            &mut attr,
+            &mut nexthop,
+            local_addr(),
+            s.remote_addr,
+            None,
+            None,
+            true,
+        );
+        let aspath = attr
+            .iter()
+            .find(|a| a.code() == packet::Attribute::AS_PATH)
+            .expect("AS_PATH must be present");
+        let buf = aspath.binary().unwrap();
+        assert_eq!(
+            buf[0],
+            packet::Attribute::AS_PATH_TYPE_CONFED_SEQ,
+            "prepended segment must be AS_CONFED_SEQUENCE for a confed peer"
+        );
+        assert_eq!(get_as_path(&attr), vec![65100, 65001, 65002]);
     }
 
     fn make_ext_community_assignment(action: ExtCommunityAction) -> Arc<PolicyAssignment> {
@@ -3201,6 +3271,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         let result = get_ext_communities(&attr);
         assert!(result.contains(&SOO_65002_100), "original preserved");
@@ -3227,6 +3298,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         let result = get_ext_communities(&attr);
         assert!(!result.contains(&RT_65001_100), "removed");
@@ -3253,6 +3325,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         let result = get_ext_communities(&attr);
         assert_eq!(result, vec![RT_65001_100]);
@@ -3319,6 +3392,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         let result = get_large_communities(&attr);
         assert!(result.contains(&(65000, 1, 200)), "original preserved");
@@ -3345,6 +3419,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         let result = get_large_communities(&attr);
         assert!(!result.contains(&(65000, 1, 100)), "removed");
@@ -3371,6 +3446,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_large_communities(&attr), vec![(65001, 2, 50)]);
     }
@@ -3427,6 +3503,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_origin(&attr), Some(0));
     }
@@ -3450,6 +3527,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(get_origin(&attr), Some(2));
         assert_eq!(
@@ -3502,6 +3580,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3525,6 +3604,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3548,6 +3628,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3571,6 +3652,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3595,6 +3677,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3619,6 +3702,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3641,6 +3725,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3663,6 +3748,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3686,6 +3772,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3708,6 +3795,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3730,6 +3818,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3752,6 +3841,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3774,6 +3864,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3796,6 +3887,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3826,6 +3918,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3906,6 +3999,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3931,6 +4025,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -4005,6 +4100,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -4030,6 +4126,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -4074,6 +4171,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -4096,6 +4194,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -4120,6 +4219,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -4225,6 +4325,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(
             nexthop,
@@ -4256,6 +4357,7 @@ mod tests {
             s.remote_addr,
             None,
             original_nexthop,
+            false,
         );
         assert_eq!(
             nexthop, original_nexthop,
@@ -4283,6 +4385,7 @@ mod tests {
             s.remote_addr,
             None,
             None,
+            false,
         );
         assert_eq!(
             nexthop,

--- a/table/src/policy.rs
+++ b/table/src/policy.rs
@@ -818,6 +818,7 @@ impl Statement {
         net: &packet::Nlri,
         attr: &mut Arc<Vec<packet::Attribute>>,
         nexthop: &mut Option<bgp::Nexthop>,
+        original_nexthop: Option<bgp::Nexthop>,
         local_addr: IpAddr,
         peer_addr: IpAddr,
         rpki: Option<&RpkiTable>,
@@ -850,7 +851,15 @@ impl Statement {
                         IpAddr::V6(v6) => bgp::Nexthop::V6(v6),
                     });
                 }
-                NexthopAction::Unchanged => {}
+                // Restore the genuine pre-default nexthop. When there is none
+                // (e.g. a locally-originated route with no stored nexthop),
+                // leave the caller-supplied default in place rather than
+                // clearing it: a non-Flowspec UPDATE cannot omit NEXT_HOP.
+                NexthopAction::Unchanged => {
+                    if let Some(orig) = original_nexthop {
+                        *nexthop = Some(orig);
+                    }
+                }
             }
         }
 
@@ -1126,12 +1135,22 @@ impl Policy {
         net: &packet::Nlri,
         attr: &mut Arc<Vec<packet::Attribute>>,
         nexthop: &mut Option<bgp::Nexthop>,
+        original_nexthop: Option<bgp::Nexthop>,
         local_addr: IpAddr,
         peer_addr: IpAddr,
         rpki: Option<&RpkiTable>,
     ) -> Disposition {
         for statement in &self.statements {
-            let d = statement.apply(source, net, attr, nexthop, local_addr, peer_addr, rpki);
+            let d = statement.apply(
+                source,
+                net,
+                attr,
+                nexthop,
+                original_nexthop,
+                local_addr,
+                peer_addr,
+                rpki,
+            );
             if d != Disposition::Pass {
                 return d;
             }
@@ -1165,12 +1184,22 @@ impl PolicyAssignment {
         net: &packet::Nlri,
         attr: &mut Arc<Vec<packet::Attribute>>,
         nexthop: &mut Option<bgp::Nexthop>,
+        original_nexthop: Option<bgp::Nexthop>,
         local_addr: IpAddr,
         peer_addr: IpAddr,
         rpki: Option<&RpkiTable>,
     ) -> Disposition {
         for policy in &self.policies {
-            let d = policy.apply(source, net, attr, nexthop, local_addr, peer_addr, rpki);
+            let d = policy.apply(
+                source,
+                net,
+                attr,
+                nexthop,
+                original_nexthop,
+                local_addr,
+                peer_addr,
+                rpki,
+            );
             if d != Disposition::Pass {
                 return d;
             }
@@ -1211,11 +1240,17 @@ pub fn apply_import(
     nexthop: &mut Option<bgp::Nexthop>,
 ) -> (bool, Arc<Vec<packet::Attribute>>) {
     let mut attr = Arc::clone(attrs);
+    // Import has no pre-policy nexthop defaulting step, so the "original" is
+    // just the current value -- NexthopAction::Unchanged is a no-op here.
+    // PolicyTable::build_assignment() also rejects nexthop actions in import
+    // policies at load time, so this is never actually exercised.
+    let original_nexthop = *nexthop;
     let filtered = policy.apply(
         source,
         net,
         &mut attr,
         nexthop,
+        original_nexthop,
         source.local_addr,
         source.remote_addr,
         rpki,
@@ -1224,6 +1259,11 @@ pub fn apply_import(
 }
 
 /// Apply export policy to a route being advertised to a peer.
+///
+/// `original_nexthop` is the nexthop as received, before any pre-policy
+/// defaulting (e.g. eBGP self-nexthop) was applied to `nexthop` -- used by
+/// `NexthopAction::Unchanged` to restore the genuine original instead of
+/// confirming the just-applied default.
 ///
 /// Returns the `Disposition` from the policy chain.
 /// Pass `rpki: None` to skip RPKI validation (e.g. in tests or when no RTR session is active).
@@ -1235,10 +1275,20 @@ pub fn apply_export(
     net: &packet::Nlri,
     attr: &mut Arc<Vec<packet::Attribute>>,
     nexthop: &mut Option<bgp::Nexthop>,
+    original_nexthop: Option<bgp::Nexthop>,
     local_addr: IpAddr,
     peer_addr: IpAddr,
 ) -> Disposition {
-    policy.apply(source, net, attr, nexthop, local_addr, peer_addr, rpki)
+    policy.apply(
+        source,
+        net,
+        attr,
+        nexthop,
+        original_nexthop,
+        local_addr,
+        peer_addr,
+        rpki,
+    )
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -2598,6 +2648,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
 
         let result = get_communities(&attr);
@@ -2628,6 +2679,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
 
         let result = get_communities(&attr);
@@ -2653,6 +2705,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
 
@@ -2680,6 +2733,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
 
@@ -2710,6 +2764,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
 
@@ -2768,6 +2823,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
 
         assert_eq!(get_local_pref(&attr), Some(200));
@@ -2796,6 +2852,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
 
@@ -2856,6 +2913,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(get_med(&attr), Some(300));
     }
@@ -2875,6 +2933,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(get_med(&attr), Some(100));
@@ -2896,6 +2955,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(get_med(&attr), Some(250));
     }
@@ -2916,6 +2976,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(get_med(&attr), Some(150));
     }
@@ -2935,6 +2996,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(get_med(&attr), Some(0));
@@ -3005,6 +3067,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(get_as_path(&attr), vec![65100, 65001, 65002]);
     }
@@ -3024,6 +3087,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(get_as_path(&attr), vec![65100, 65100, 65100, 65001]);
@@ -3045,6 +3109,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(get_as_path(&attr), vec![65001, 65001, 65002]);
     }
@@ -3064,6 +3129,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(get_as_path(&attr), vec![65100, 65100]);
@@ -3134,6 +3200,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         let result = get_ext_communities(&attr);
         assert!(result.contains(&SOO_65002_100), "original preserved");
@@ -3159,6 +3226,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         let result = get_ext_communities(&attr);
         assert!(!result.contains(&RT_65001_100), "removed");
@@ -3183,6 +3251,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         let result = get_ext_communities(&attr);
@@ -3249,6 +3318,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         let result = get_large_communities(&attr);
         assert!(result.contains(&(65000, 1, 200)), "original preserved");
@@ -3274,6 +3344,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         let result = get_large_communities(&attr);
         assert!(!result.contains(&(65000, 1, 100)), "removed");
@@ -3298,6 +3369,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(get_large_communities(&attr), vec![(65001, 2, 50)]);
@@ -3354,6 +3426,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(get_origin(&attr), Some(0));
     }
@@ -3375,6 +3448,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(get_origin(&attr), Some(2));
@@ -3427,6 +3501,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3448,6 +3523,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Accept);
@@ -3471,6 +3547,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3492,6 +3569,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Accept);
@@ -3516,6 +3594,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3539,6 +3618,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3560,6 +3640,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3580,6 +3661,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Accept);
@@ -3603,6 +3685,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3623,6 +3706,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Reject);
@@ -3645,6 +3729,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -3665,6 +3750,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Reject);
@@ -3687,6 +3773,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3707,6 +3794,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Accept);
@@ -3736,6 +3824,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Reject);
@@ -3816,6 +3905,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3839,6 +3929,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Accept);
@@ -3913,6 +4004,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Reject);
     }
@@ -3936,6 +4028,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Accept);
@@ -3980,6 +4073,7 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(d, Disposition::Accept);
     }
@@ -4000,6 +4094,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Reject);
@@ -4023,6 +4118,7 @@ mod tests {
             &mut nexthop,
             local_addr(),
             s.remote_addr,
+            None,
             None,
         );
         assert_eq!(d, Disposition::Accept);
@@ -4128,11 +4224,70 @@ mod tests {
             local_addr(),
             s.remote_addr,
             None,
+            None,
         );
         assert_eq!(
             nexthop,
             Some(bgp::Nexthop::V4(Ipv4Addr::new(192, 168, 1, 1))),
             "nexthop should be set to peer address"
+        );
+    }
+
+    #[test]
+    fn nexthop_unchanged_action_restores_original() {
+        // `nexthop` simulates the value already overwritten by a pre-policy
+        // default (e.g. eBGP self-nexthop); `original_nexthop` is the
+        // genuine value received before that default was applied.
+        // NexthopAction::Unchanged must restore the latter, not confirm the
+        // former -- otherwise "unchanged" would always mean "self".
+        let assignment = make_nexthop_assignment(NexthopAction::Unchanged);
+        let s = source();
+        let net = nlri();
+        let mut attr = Arc::new(vec![]);
+        let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1)));
+        let original_nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        Table::apply_policy(
+            &assignment,
+            &s,
+            &net,
+            &mut attr,
+            &mut nexthop,
+            local_addr(),
+            s.remote_addr,
+            None,
+            original_nexthop,
+        );
+        assert_eq!(
+            nexthop, original_nexthop,
+            "unchanged should restore the genuine original nexthop, not keep the pre-policy default"
+        );
+    }
+
+    #[test]
+    fn nexthop_unchanged_action_keeps_default_when_no_original() {
+        // When there was no genuine original (e.g. a locally-originated
+        // route with no stored nexthop), Unchanged must not clear nexthop
+        // back to None -- a non-Flowspec UPDATE cannot omit NEXT_HOP.
+        let assignment = make_nexthop_assignment(NexthopAction::Unchanged);
+        let s = source();
+        let net = nlri();
+        let mut attr = Arc::new(vec![]);
+        let mut nexthop = Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1)));
+        Table::apply_policy(
+            &assignment,
+            &s,
+            &net,
+            &mut attr,
+            &mut nexthop,
+            local_addr(),
+            s.remote_addr,
+            None,
+            None,
+        );
+        assert_eq!(
+            nexthop,
+            Some(bgp::Nexthop::V4(Ipv4Addr::new(127, 0, 0, 1))),
+            "with no original, the pre-policy default must be left in place"
         );
     }
 


### PR DESCRIPTION
Export previously forced self-nexthop for eBGP/ConfedEbgp after export policy ran, silently discarding any NexthopAction the policy set (same bug class as the earlier set-med issue). Fixing the ordering alone would just move the bug: with the default now applied before policy, Unchanged would confirm the just-applied self-nexthop instead of restoring the genuine received value, making "unchanged" always mean "self". Thread the pre-default nexthop through as original_nexthop so Unchanged can restore it, mirroring GoBGP's options.OldNextHop pattern.

clear_received_med and the nexthop defaulting are merged into a single pre_policy_defaults, since both are pre-policy steps invoked from the same two call sites in process_nlri_change.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>