### PR TITLE
tests/e2e/link-state: bump Go builder image to 1.25-alpine

### DIFF
--- a/tests/e2e/link-state/tools/Dockerfile
+++ b/tests/e2e/link-state/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 RUN apk add --no-cache git ca-certificates
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
golang.org/x/net v0.55.0 requires go >= 1.25.0, and dependabot's pending bump of that dependency in tools/go.mod raises the module's `go` directive to 1.25.0 accordingly. With GOTOOLCHAIN=local, the 1.24-alpine builder cannot satisfy that requirement and `go mod tidy` fails during the BGP-LS e2e Docker build. Move the builder to 1.25-alpine ahead of merging that dependency bump so the two changes can be verified independently.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>